### PR TITLE
make utils/ more compatible across OSes

### DIFF
--- a/utils/img2js.py
+++ b/utils/img2js.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 #
 # Convert image to Javascript compatible base64 Data URI

--- a/utils/launch.sh
+++ b/utils/launch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
     if [ "$*" ]; then

--- a/utils/web.py
+++ b/utils/web.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 '''
 A super simple HTTP/HTTPS webserver for python. Automatically detect
 

--- a/utils/websocket.py
+++ b/utils/websocket.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 '''
 Python WebSocket library with support for "wss://" encryption.

--- a/utils/websockify
+++ b/utils/websockify
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 '''
 A WebSocket to TCP socket proxy with support for "wss://" encryption.


### PR DESCRIPTION
Hi,

Just a very minor change to the shebang on the util scripts.  This makes things a little bit more cross-compatible with different OSes (on FreeBSD, most of the executables are located under /usr/local/bin).

Using /usr/bin/env will try to use the correct executable for that OS by looking in the user's PATH.
