### PR TITLE
Add declaration of token in vnc_auto.html.

### DIFF
--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -89,7 +89,7 @@
         }
 
         window.onload = function () {
-            var host, port, password;
+            var host, port, password, token;
 
             $D('sendCtrlAltDelButton').onclick = sendCtrlAltDel;
 


### PR DESCRIPTION
Without this Google Chrome 12 raises error and VNC window halts in loading state.
