### PR TITLE
Errors in Firefox and Chrome with 'base64' protocols parameter

### DIFF
--- a/include/websock.js
+++ b/include/websock.js
@@ -253,7 +253,7 @@ function init() {
 function open(uri) {
     init();
 
-    websocket = new WebSocket(uri, 'base64');
+    websocket = new WebSocket(uri);
     // TODO: future native binary support
     //websocket = new WebSocket(uri, ['binary', 'base64']);
 


### PR DESCRIPTION
Receiving an error in both Firefox and Chrome when trying to connect.  I tracked it down to line 256 in include/websock.py where WebSocket objects are created.  This line was changed in d890e8640f adding the 2nd parameter, "base64". 

``` javascript
    new WebSocket(uri, 'base64')
```

 Not sure if this is required for other browsers, but reverting that line fixes connections for both Firefox and Chrome.
