### PR TITLE
Allow to use by default current pathname for path, if path is not specified

### DIFF
--- a/include/ui.js
+++ b/include/ui.js
@@ -53,7 +53,7 @@ load: function() {
     UI.initSetting('cursor', false);
     UI.initSetting('shared', true);
     UI.initSetting('connectTimeout', 2);
-    UI.initSetting('path', '');
+    UI.initSetting('path', UI.getCurrentPath());
 
     UI.rfb = RFB({'target': $D('noVNC_canvas'),
                   'onUpdateState': UI.updateState,
@@ -620,6 +620,11 @@ setBarPosition: function() {
 
     var vncwidth = $D('noVNC_screen').style.offsetWidth;
     $D('noVNC-control-bar').style.width = vncwidth + 'px';
+},
+
+getCurrentPath: function() {
+  var pathname = window.location.pathname;
+  return pathname.substring(1, pathname.lastIndexOf('/'));
 }
 
 };


### PR DESCRIPTION
If no path parameter is specified, it will use current pathname, i.e
my/no/vnc for http://www.mydomain.com/my/no/vnc/vnc.html.

It is useful for url based proxy when the path determines what backend to use.

I don't know if it is acceptable for all use cases thought (i.e when static files are not in the same location than the websockify server).
