### PR TITLE
Support for AltGr key

### DIFF
--- a/include/input.js
+++ b/include/input.js
@@ -53,7 +53,7 @@ function getKeysymSpecial(evt) {
     if (evt.type === 'keydown') {
         switch ( evt.keyCode ) {
             // AltGR on French keyboard support:
-            case 0         : keysym = 0xFFEA; break; // Left ALT
+            case 0         : keysym = 0xFFEA; break; // Right ALT
                 
             case 27        : keysym = 0xFF1B; break; // ESCAPE
             case 46        : keysym = 0xFFFF; break; // DELETE


### PR DESCRIPTION
Hello,
Here a small fix for supporting the AltGr key on French keyboard.
The altGr key return keyCode=0 and which=0.
Sending this key as Right Alt to VNC, makes it works correctly
This brings some important keys for the french keyboard : ~#{[|^@]}
