### PR TITLE
Tiny fix for cases when 'alt' or 'ctl' is stuck at 'keyDown' when the window loses focus.

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -1617,6 +1617,16 @@ that.sendKey = function(code, down) {
     ws.send(arr);
 };
 
+// Sending UP keys for all control keys, used because of the keypress and hold effect issues VNC.
+that.resetKeyboard = function(code, down) {
+	that.sendKey(0xffe9, 0); // alt ( left )
+	that.sendKey(0xffea, 0); // alt ( right )
+	that.sendKey(0xffe3, 0); // ctrl( left )
+	that.sendKey(0xffe4, 0); // ctrl ( right )
+	that.sendKey(0xffe2, 0); // shift ( right )
+	that.sendKey(0xffe1, 0); // shift ( right )
+};
+
 that.clipboardPasteFrom = function(text) {
     if (rfb_state !== "normal") { return; }
     //Util.Debug(">> clipboardPasteFrom: " + text.substr(0,40) + "...");

--- a/vnc.html
+++ b/vnc.html
@@ -193,6 +193,9 @@
 
     <script>
         window.onload = UI.load;
+		window.onblur = function() {
+			rfb.resetKeyboard();
+		};
     </script>
  </body>
 </html>

--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -60,6 +60,9 @@
             rfb.sendCtrlAltDel();
             return false;
         }
+		window.onblur = function() {
+			rfb.resetKeyboard();
+		}
         function updateState(rfb, state, oldstate, msg) {
             var s, sb, cad, level;
             s = $D('noVNC_status');


### PR DESCRIPTION
http://www.fifi.org/doc/vnc-common/faq.html
Check question: 'The keyboard doesn't work / keys do strange things!'
