### PR TITLE
Fix rpc initialization issue

### DIFF
--- a/utils/nova-novncproxy
+++ b/utils/nova-novncproxy
@@ -69,10 +69,8 @@ FLAGS.register_cli_opts(opts)
 
 # As of nova commit 0b11668e64450039dc071a4a123abd02206f865f we must
 # manually register the rpc library
-try:
+if hasattr(rpc, 'register_opts'):
     rpc.register_opts(FLAGS)
-except:
-    pass
 
 
 class NovaWebSocketProxy(wsproxy.WebSocketProxy):


### PR DESCRIPTION
- As of nova commit https://github.com/openstack/nova/commit/8972e9544dead61c198037f24eecf0f04558a914 we must manually register flags for the rpc library
- Wrapping with try/catch for backwards compatibility
