### PR TITLE
Remove old flagfile support

### DIFF
--- a/utils/nova-novncproxy
+++ b/utils/nova-novncproxy
@@ -132,7 +132,7 @@ if __name__ == '__main__':
         parser.error("SSL only and %s not found" % FLAGS.cert)
 
     # Setup flags
-    utils.default_flagfile()
+    utils.default_cfgfile()
     FLAGS(sys.argv)
 
     # Create and start the NovaWebSockets proxy


### PR DESCRIPTION
default_flagfile has been removed from the nova trunk in favour of .ini files (https://github.com/openstack/nova/commit/7e3e9b8e9cea4f1bf78d127ffb915b79c854fdbe)
