### PR TITLE
Fixes nova rpc package.

### DIFF
--- a/utils/nova-novncproxy
+++ b/utils/nova-novncproxy
@@ -30,9 +30,9 @@ import wsproxy
 
 from nova import context
 from nova import flags
-from nova import rpc
 from nova import utils
 from nova.openstack.common import cfg
+from nova.openstack.common import rpc
 
 
 opts = [


### PR DESCRIPTION
Nova rpc package is moved to nova.openstack.common

For more info:
https://github.com/openstack/nova/commit/ba3754e3ff672a877d90c78486c7f4d5fd4bf7b0
