### PR TITLE
Better support of IPv6 in websockify

### DIFF
--- a/utils/websocket.py
+++ b/utils/websocket.py
@@ -109,6 +109,7 @@ Sec-WebSocket-Accept: %s\r
         self.verbose        = verbose
         self.listen_host    = listen_host
         self.listen_port    = listen_port
+        self.prefer_ipv6    = source_is_ipv6
         self.ssl_only       = ssl_only
         self.daemon         = daemon
         self.run_once       = run_once
@@ -801,7 +802,7 @@ Sec-WebSocket-Accept: %s\r
         is a WebSockets client then call new_client() method (which must
         be overridden) for each new client connection.
         """
-        lsock = self.socket(self.listen_host, self.listen_port)
+        lsock = self.socket(self.listen_host, self.listen_port, False, self.prefer_ipv6)
 
         if self.daemon:
             self.daemonize(keepfd=lsock.fileno(), chdir=self.web)

--- a/utils/websockify
+++ b/utils/websockify
@@ -242,6 +242,9 @@ def websockify_init():
             choices=["exit", "ignore", "respawn"],
             help="action to take when the wrapped program exits "
             "or daemonizes: exit (default), ignore, respawn")
+    parser.add_option("--prefer-ipv6", "-6",
+            action="store_true", dest="source_is_ipv6",
+            help="prefer IPv6 when resolving source_addr")
     (opts, args) = parser.parse_args()
 
     # Sanity checks


### PR DESCRIPTION
This patch adds support for square brackets notation of IPv6 in websockify since it avoids confusion between IP members and port number. It also adds an option that set preference of IPv6 over IPv4 when resolving host_addr.
