### PR TITLE
Fix grep pattern when matching netstat output

### DIFF
--- a/utils/launch.sh
+++ b/utils/launch.sh
@@ -60,7 +60,7 @@ done
 which netstat >/dev/null 2>&1 \
     || die "Must have netstat installed"
 
-netstat -ltn | grep -qs "${PORT}.*LISTEN" \
+netstat -ltn | grep -qs "${PORT} .*LISTEN" \
     && die "Port ${PORT} in use. Try --listen PORT"
 
 trap "cleanup" TERM QUIT INT EXIT


### PR DESCRIPTION
The current grep pattern matches also port numbers that match only
partially the given $PORT number; e.g., if $PORT is 6080, 60800 will
match as well.

While TCP listening sockets in the 60000-65535 range are rare, they
need to be handled as well. The problem is also present if the user
selects a shorter PORT value with the --listen command line argument.

By adding a space, the pattern is fixed.
