### PR TITLE
websockify: KeyError in wsproxy.py

### DIFF
--- a/utils/websockify
+++ b/utils/websockify
@@ -45,9 +45,9 @@ Traffic Legend:
         self.target_port    = kwargs.pop('target_port')
         self.wrap_cmd       = kwargs.pop('wrap_cmd')
         self.wrap_mode      = kwargs.pop('wrap_mode')
-        self.unix_target    = kwargs.pop('unix_target')
-        self.ssl_target     = kwargs.pop('ssl_target')
-        self.target_cfg     = kwargs.pop('target_cfg')
+        self.unix_target    = kwargs.pop('unix_target', None)
+        self.ssl_target     = kwargs.pop('ssl_target', None)
+        self.target_cfg     = kwargs.pop('target_cfg', None)
         # Last 3 timestamps command was run
         self.wrap_times    = [0, 0, 0]
 


### PR DESCRIPTION
The following exception is caused by 204675c85d08733d66c2dddb58ac6d5dcfedc11f
unbreak it by adding default value None.

> # ./utils/nova-novncproxy --config-file /etc/nova/nova.conf --web .
> 
> Traceback (most recent call last):
>   File "./utils/nova-novncproxy", line 151, in <module>
>     wrap_cmd=None)
>   File "./utils/nova-novncproxy", line 78, in **init**
>     wsproxy.WebSocketProxy.**init**(self, _args, *_kwargs)
>   File "/opt/stack/noVNC/utils/wsproxy.py", line 48, in **init**
>     self.unix_target    = kwargs.pop('unix_target')
> KeyError: 'unix_target'

Signed-off-by: Isaku Yamahata yamahata@valinux.co.jp
