### PR TITLE
support ALTGR key event

### DIFF
--- a/include/input.js
+++ b/include/input.js
@@ -69,6 +69,7 @@ function getKeysymSpecial(evt) {
             case 17        : keysym = 0xFFE3; break; // CONTROL
             //case 18        : keysym = 0xFFE7; break; // Left Meta (Mac Option)
             case 18        : keysym = 0xFFE9; break; // Left ALT (Mac Command)
+            case 225       : keysym = 0xFFEA; break; // ALTGR
 
             case 112       : keysym = 0xFFBE; break; // F1
             case 113       : keysym = 0xFFBF; break; // F2


### PR DESCRIPTION
FireFox 15 for Linux now generates a ALTGR key event against a ALTGR key.  This patch will make those using European keyboards happy.

This doesn't work with FireFox 15 for Windows, FireFox 14 or earlier or other browsers since they generate CTRL + ALT key events against a ALTGR key. I am also working on this and I will post the code later.
