### PR TITLE
Keyboard altgr

### DIFF
--- a/include/input.js
+++ b/include/input.js
@@ -84,6 +84,9 @@ function getKeysymSpecial(evt) {
             case 123       : keysym = 0xFFC9; break; // F12
 
             case 225       : keysym = 0xFE03; break; // AltGr
+            case 91       : keysym = 0xFFEC; break; // Super_R (Win Key)
+            case 93       : keysym = 0xFF67; break; // Menu (Win Menu)
+
             default        :                  break;
         }
     }


### PR DESCRIPTION
This patch adds more support for some special keys:
- AltGr Key (since firefox 15)
- R_Super key (Usually found as the Windows key)
- Menu key (Usually found as Windows Contextual Menu key)
