### PR TITLE
Fix: IE9 leaves "ReferenceError: RFB is not defined"

### DIFF
--- a/include/start.js
+++ b/include/start.js
@@ -1,1 +1,1 @@
-window.onload = UI.load;
+NoVnc.onload = UI.load;

--- a/include/vnc.js
+++ b/include/vnc.js
@@ -9,6 +9,12 @@
 /*jslint evil: true */
 /*global window, document, INCLUDE_URI */
 
+var NoVnc = {};
+NoVnc.onload = null;
+NoVnc.init_scripts = [];
+NoVnc.loading = 0;
+
+
 /*
  * Load supporting scripts
  */
@@ -21,11 +27,48 @@ function get_INCLUDE_URI() {
  */
 function load_scripts(base, files) {
     var head = document.getElementsByTagName('head')[0];
+
+    function onloadhook () {
+        if (this.initState)  //Already initialized
+            return;
+        this.initState = true;
+        NoVnc.loading--;
+        initscripts();
+        if (NoVnc.loading === 0 && !!NoVnc.onload) {
+            NoVnc.onload();
+            NoVnc.onload = null;
+        }
+    }
+    function initscripts() {
+        // Call the initialization routines in register order when all
+        // the scripts have been loaded.
+        // Notice: These routines may also call load_scripts to start
+        //         loading other scripts.
+        while (NoVnc.loading === 0 && NoVnc.init_scripts.length > 0) {
+            var script = NoVnc.init_scripts[0];
+            NoVnc.init_scripts.splice(0, 1);
+            // It is assumed that ABC.js should have _init_ABC() to
+            // initialize itself.
+            var f = script.src.split("/");
+            f = "_init_" + f[f.length -1].split(".")[0].replace(/[\-\+]/,"_");
+            eval("if (typeof " + f + " !== 'undefined') " + f + "()");
+        }
+    }
+
     for (var i=0; i<files.length; i++) {
         var script = document.createElement('script');
         script.type = 'text/javascript';
+        NoVnc.loading++;
+        script.onload = onloadhook;
+        script.onreadystatechange = function () {
+            if (this.readyState == 'complete' || this.readyState == 'loaded')
+                this.onload();
+        }
+        script.initState = false;
         script.src = base + files[i];
         head.appendChild(script);
+        NoVnc.init_scripts = NoVnc.init_scripts.concat([script]);
+
     }
 }
 

--- a/include/web-socket-js/web_socket.js
+++ b/include/web-socket-js/web_socket.js
@@ -3,7 +3,7 @@
 // Reference: http://dev.w3.org/html5/websockets/
 // Reference: http://tools.ietf.org/html/rfc6455
 
-(function() {
+function _init_web_socket() {
   
   if (window.WEB_SOCKET_FORCE_FLASH) {
     // Keeps going.
@@ -388,4 +388,4 @@
     });
   }
   
-})();
+}

--- a/include/websock.js
+++ b/include/websock.js
@@ -25,34 +25,27 @@
 // To enable WebSocket emulator debug:
 //window.WEB_SOCKET_DEBUG=1;
 
-if (window.WebSocket && !window.WEB_SOCKET_FORCE_FLASH) {
-    Websock_native = true;
-} else if (window.MozWebSocket && !window.WEB_SOCKET_FORCE_FLASH) {
-    Websock_native = true;
-    window.WebSocket = window.MozWebSocket;
-} else {
-    /* no builtin WebSocket so load web_socket.js */
+function _init_websock() {
+    if (window.WebSocket && !window.WEB_SOCKET_FORCE_FLASH) {
+        Websock_native = true;
+    } else if (window.MozWebSocket && !window.WEB_SOCKET_FORCE_FLASH) {
+        Websock_native = true;
+        window.WebSocket = window.MozWebSocket;
+    } else {
+        /* no builtin WebSocket so load web_socket.js */
 
-    Websock_native = false;
-    (function () {
-        function get_INCLUDE_URI() {
-            return (typeof INCLUDE_URI !== "undefined") ?
-                INCLUDE_URI : "include/";
-        }
-
-        var start = "<script src='" + get_INCLUDE_URI(),
-            end = "'><\/script>", extra = "";
-
-        window.WEB_SOCKET_SWF_LOCATION = get_INCLUDE_URI() +
-                    "web-socket-js/WebSocketMain.swf";
-        if (Util.Engine.trident) {
-            Util.Debug("Forcing uncached load of WebSocketMain.swf");
-            window.WEB_SOCKET_SWF_LOCATION += "?" + Math.random();
-        }
-        extra += start + "web-socket-js/swfobject.js" + end;
-        extra += start + "web-socket-js/web_socket.js" + end;
-        document.write(extra);
-    }());
+        Websock_native = false;
+        (function () {
+            window.WEB_SOCKET_SWF_LOCATION = get_INCLUDE_URI() +
+                        "web-socket-js/WebSocketMain.swf";
+            if (Util.Engine.trident) {
+                Util.Debug("Forcing uncached load of WebSocketMain.swf");
+                window.WEB_SOCKET_SWF_LOCATION += "?" + Math.random();
+            }
+            load_scripts(get_INCLUDE_URI() + "web-socket-js/",
+                    ["swfobject.js", "web_socket.js"]);
+        }());
+    }
 }
 
 

--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -84,7 +84,7 @@
             }
         }
 
-        window.onload = function () {
+        NoVnc.onload = function () {
             var host, port, password, path, token;
 
             $D('sendCtrlAltDelButton').style.display = "inline";


### PR DESCRIPTION
This patch gives a workaround for  https://github.com/kanaka/noVNC/issues/199 and https://github.com/kanaka/noVNC/issues/194 .

noVNC also runs well on IE9 with the patch:
- it is guaranteed that scripts are Initialized in register order.
- noVNC starts its service when catching a NoVnc.onload event, which is fired when all scripts are loaded and initialized.

This patch makes all script objects catch its onload event to track the status of loading scripts. When it detects the completion of loading all of them, it starts to call the initialization routines of the scripts in register order. If there is a script named ABC.js and it depends on objects defined in other scripts to initialize itself, you should move this part into a initialization routine named _init_ABC(). This function is guaranteed to be called after the scripts it depends has been initialized.

There is a chance some scripts happen to require loading other scripts from their initialization routines. In this case, noVNC will wait for the completion of loading these scripts again and restart invoking initialization routines.

Once it detects all scripts are initialized, it fires a NoVnc.onload event.
