### PR TITLE
Yet another workaround: IE9 leaves "ReferenceError: RFB is not defined"

### DIFF
--- a/include/start.js
+++ b/include/start.js
@@ -1,1 +1,1 @@
-window.onload = UI.load;
+NoVnc.onload = UI.load;

--- a/include/websock.js
+++ b/include/websock.js
@@ -35,23 +35,14 @@ if (window.WebSocket && !window.WEB_SOCKET_FORCE_FLASH) {
 
     Websock_native = false;
     (function () {
-        function get_INCLUDE_URI() {
-            return (typeof INCLUDE_URI !== "undefined") ?
-                INCLUDE_URI : "include/";
-        }
-
-        var start = "<script src='" + get_INCLUDE_URI(),
-            end = "'><\/script>", extra = "";
-
         window.WEB_SOCKET_SWF_LOCATION = get_INCLUDE_URI() +
                     "web-socket-js/WebSocketMain.swf";
         if (Util.Engine.trident) {
             Util.Debug("Forcing uncached load of WebSocketMain.swf");
             window.WEB_SOCKET_SWF_LOCATION += "?" + Math.random();
         }
-        extra += start + "web-socket-js/swfobject.js" + end;
-        extra += start + "web-socket-js/web_socket.js" + end;
-        document.write(extra);
+        load_scripts(get_INCLUDE_URI() + "web-socket-js/",
+                ["swfobject.js", "web_socket.js"]);
     }());
 }
 

--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -84,7 +84,7 @@
             }
         }
 
-        window.onload = function () {
+        NoVnc.onload = function () {
             var host, port, password, path, token;
 
             $D('sendCtrlAltDelButton').style.display = "inline";


### PR DESCRIPTION
This patch gives yet another workaround for https://github.com/kanaka/noVNC/issues/199 and https://github.com/kanaka/noVNC/issues/194 .

This patch is simpler than the previous one https://github.com/kanaka/noVNC/pull/201 . But it works a bit slower though. While the current noVNC loads scripts asynchronously at the same time, this patch makes noVNC load them one by one in register order.
