### PR TITLE
Grab CONF from the correct place (again)

### DIFF
--- a/utils/nova-novncproxy
+++ b/utils/nova-novncproxy
@@ -64,7 +64,7 @@ opts = [
                default=6080,
                help='Port on which to listen for incoming requests'),
     ]
-CONF = config.CONF
+CONF = cfg.CONF
 CONF.register_cli_opts(opts)
 
 # As of nova commit 0b11668e64450039dc071a4a123abd02206f865f we must


### PR DESCRIPTION
A recent change to Nova broke this again. This fixes the issue.
