### PR TITLE
Ctrl+'-' won't work on a US keyboad with the latest Firefox.

### DIFF
--- a/include/input.js
+++ b/include/input.js
@@ -110,6 +110,10 @@ function getKeysymSpecial(evt) {
                 if (Util.Engine.gecko || Util.Engine.presto) {
                             keysym = 45; }
                                         break;
+            case 173       :                     // -  (Mozilla)
+                if (Util.Engine.gecko) {
+                            keysym = 45; }
+                                        break;
             case 189       : keysym = 45; break; // -  (IE)
             case 190       : keysym = 46; break; // .  (Mozilla, IE)
             case 191       : keysym = 47; break; // /  (Mozilla, IE)


### PR DESCRIPTION
Firefox 17 generates 173 as the keycode for the minus key.
It seems like older versions generate 109 instead of 173 though.
