### PR TITLE
Register onmouseup events if they occur outside canvas

### DIFF
--- a/include/input.js
+++ b/include/input.js
@@ -609,12 +609,13 @@ that.grab = function() {
 
     if ('ontouchstart' in document.documentElement) {
         Util.addEvent(c, 'touchstart', onMouseDown);
-        Util.addEvent(c, 'touchend', onMouseUp);
+        Util.addEvent(window, 'touchend', onMouseUp);
         Util.addEvent(c, 'touchmove', onMouseMove);
     } else {
         Util.addEvent(c, 'mousedown', onMouseDown);
-        Util.addEvent(c, 'mouseup', onMouseUp);
+        Util.addEvent(window, 'mouseup', onMouseUp);
         Util.addEvent(c, 'mousemove', onMouseMove);
+        Util.addEvent(c, 'mouseout', onMouseMove);
         Util.addEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
                 onMouseWheel);
     }
@@ -632,12 +633,13 @@ that.ungrab = function() {
 
     if ('ontouchstart' in document.documentElement) {
         Util.removeEvent(c, 'touchstart', onMouseDown);
-        Util.removeEvent(c, 'touchend', onMouseUp);
+        Util.removeEvent(window, 'touchend', onMouseUp);
         Util.removeEvent(c, 'touchmove', onMouseMove);
     } else {
         Util.removeEvent(c, 'mousedown', onMouseDown);
-        Util.removeEvent(c, 'mouseup', onMouseUp);
+        Util.removeEvent(window, 'mouseup', onMouseUp);
         Util.removeEvent(c, 'mousemove', onMouseMove);
+        Util.removeEvent(c, 'mouseout', onMouseUp);
         Util.removeEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
                 onMouseWheel);
     }


### PR DESCRIPTION
If you press a mouse button, move the mouse outside the noVNC canvas, and then release the mouse button, no `onmouseup` event is ever seen by noVNC.

This is a minimal fix, which just always processes `onmouseup` events (figuring they're harmless if there was no prior `onmousedown` event triggered.)

To ensure the mouse is at the edge of the canvas when the `onmouseup` is triggered, I also registered a handler for the `onmouseout` event.

More complex handling could be implemented, to, for example:
- only handle `onmouseup` if one or more buttons were pressed while the mouse was on the canvas
- handle `onmousemove` as well (and clamp the coordinates to fit within the target canvas, probably)
- handle mouse wheel scrolling while outside the canvas(?)

but I'm not sure which of these behaviors would be desirable, so here's the minimal version to begin with.
