### PR TITLE
Tweak order/whitespace/style to match vnc.html more closely. 

### DIFF
--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <html>
+<head>
+
     <!-- 
     noVNC example: simple example using default UI
     Copyright (C) 2012 Joel Martin
@@ -9,19 +11,25 @@
     Connect parameters are provided in query string:
         http://example.com/?host=HOST&port=PORT&encrypt=1&true_color=1
     -->
-    <head>
-        <title>noVNC</title>
-        <meta http-equiv="X-UA-Compatible" content="chrome=1">
-        <link rel="stylesheet" href="include/base.css" title="plain">
-        <!--
-        <script type='text/javascript' 
-            src='http://getfirebug.com/releases/lite/1.2/firebug-lite-compressed.js'></script>
-        -->
-        <script src="include/util.js"></script>
-    </head>
+    <title>noVNC</title>
 
-    <body style="margin: 0px;">
-        <div id="noVNC_screen">
+    <!-- Always force latest IE rendering engine (even in intranet) & Chrome Frame
+                Remove this if you use the .htaccess -->
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+
+
+    <!-- Stylesheets -->
+    <link rel="stylesheet" href="include/base.css" title="plain">
+
+     <!--
+    <script type='text/javascript'
+        src='http://getfirebug.com/releases/lite/1.2/firebug-lite-compressed.js'></script>
+    -->
+        <script src="include/util.js"></script>
+</head>
+
+<body style="margin: 0px;">
+    <div id="noVNC_screen">
             <div id="noVNC_status_bar" class="noVNC_status_bar" style="margin-top: 0px;">
                 <table border=0 width="100%"><tr>
                     <td><div id="noVNC_status">Loading</div></td>


### PR DESCRIPTION
There's a lot of common code in vnc.html and vnc_auto.html. Unfortunately, due to order/whitespace/style, it is difficult to "diff" them, to tell what's really different. This commit tweaks vnc_auto.html to more closely match vnc.html. No functional changes. 
