### PR TITLE
Use wss when creating localhost connection to detect binary support

### DIFF
--- a/include/websock.js
+++ b/include/websock.js
@@ -282,7 +282,7 @@ function init(protocols) {
     // TODO: this sucks, the property should exist on the prototype
     // but it does not.
     try {
-        if (bt && ('binaryType' in (new WebSocket("ws://localhost:17523")))) {
+        if (bt && ('binaryType' in (new WebSocket("wss://localhost:17523")))) {
             Util.Info("Detected binaryType support in WebSockets");
             wsbt = true;
         }


### PR DESCRIPTION
Some browsers (Firefox) reject unencrypted ws connections if the hosting
page uses https by throwing an exception when you create the websocket
object.

NoVNC interprets this as binary being unsupported, and falls back to
base64.

If we instead connect to wss://localhost, the websocket object can be
created regardless of whether the hosting page is on http or https.
