### PR TITLE
Import cfg from oslo in nova-novncproxy

### DIFF
--- a/utils/nova-novncproxy
+++ b/utils/nova-novncproxy
@@ -23,6 +23,7 @@ Leverages wsproxy.py by Joel Martin
 '''
 
 import Cookie
+from oslo.config import cfg
 import socket
 import sys
 
@@ -31,7 +32,6 @@ import wsproxy
 from nova import config
 from nova import context
 from nova import utils
-from nova.openstack.common import cfg
 from nova.openstack.common import rpc
 
 


### PR DESCRIPTION
Upstram OpenStack Nova package has moved the config engine into a
separate package. Mirror that change in the novnc script.
