### PR TITLE
Set FBU.bytes to 1 in encHandlers.COPYRECT

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -1126,6 +1126,7 @@ encHandlers.COPYRECT = function display_copy_rect() {
 
     var old_x, old_y;
 
+    FBU.bytes = 1;
     if (ws.rQwait("COPYRECT", 4)) { return false; }
     display.renderQ_push({
             'type': 'copy',


### PR DESCRIPTION
FBU.bytes must be set before return false to indicate that the FBU
header has been read. If not set then "if (FBU.bytes == 0) { ..}"
in framebufferUpdate will be entered and the copyrect header will
be interpreted as a new FBU leading to a "unsupported encoding"
disconnect error.
