### PR TITLE
Fix to onMouseDisable

### DIFF
--- a/include/input.js
+++ b/include/input.js
@@ -611,9 +611,9 @@ function onMouseDisable(e) {
     evt = (e ? e : window.event);
     pos = Util.getEventPosition(e, conf.target, conf.scale);
     /* Stop propagation if inside canvas area */
-    if ((pos.x >= 0) && (pos.y >= 0) &&
-        (pos.x < conf.target.offsetWidth) &&
-        (pos.y < conf.target.offsetHeight)) {
+    if ((pos.realx >= 0) && (pos.realy >= 0) &&
+        (pos.realx < conf.target.offsetWidth) &&
+        (pos.realy < conf.target.offsetHeight)) {
         //Util.Debug("mouse event disabled");
         Util.stopEvent(e);
         return false;

--- a/include/util.js
+++ b/include/util.js
@@ -298,9 +298,11 @@ Util.getEventPosition = function (e, obj, scale) {
     if (typeof scale === "undefined") {
         scale = 1;
     }
-    var x = Math.max(Math.min(docX - pos.x, obj.width-1), 0);
-	var y = Math.max(Math.min(docY - pos.y, obj.height-1), 0);
-    return {'x': x / scale, 'y': y / scale};
+    var realx = docX - pos.x;
+    var realy = docY - pos.y;
+    var x = Math.max(Math.min(realx, obj.width-1), 0);
+    var y = Math.max(Math.min(realy, obj.height-1), 0);
+    return {'x': x / scale, 'y': y / scale, 'realx': realx / scale, 'realy': realy / scale};
 };
 
 


### PR DESCRIPTION
Hi Joel

As requested a pull request for my tidied fix to onMouseDisable which was preventing clicks outside the canvas area from being propagated due to Util.getEventPosition returning coordinates which are always constrained to the canvas area.
