### PR TITLE
Collect zombie child processes within server loop

### DIFF
--- a/utils/websocket.py
+++ b/utils/websocket.py
@@ -853,7 +853,8 @@ Sec-WebSocket-Accept: %s\r
                     pid = err = 0
                     child_count = 0
 
-                    if multiprocessing and self.idle_timeout:
+                    if multiprocessing:
+                        # Collect zombie child processes
                         child_count = len(multiprocessing.active_children())
 
                     time_elapsed = time.time() - self.launch_time


### PR DESCRIPTION
Related to OpenStack Nova bug 1048703 (https://bugs.launchpad.net/nova/+bug/1048703).  Numerous zombie child processes have been witnessed by end users of Nova.  Instead of only cleaning up zombie processes when a new client connects, noVNC should periodically attempt to cleanup any zombie processes.
