### PR TITLE
websockify: use threading instead of multiprocessing on Windows

### DIFF
--- a/utils/websocket.py
+++ b/utils/websocket.py
@@ -904,6 +904,17 @@ Sec-WebSocket-Accept: %s\r
                             self.msg('%s: exiting due to --run-once'
                                     % address[0])
                             break
+                    elif sys.platform == 'win32':
+                        import threading
+                        self.vmsg('%s: new handler Thread' % address[0])
+                        import pickle
+                        selfcopy = pickle.loads(pickle.dumps(self))
+                        p = threading.Thread(
+                                target=selfcopy.top_new_client,
+                                args=(startsock, address))
+                        p.daemon = True
+                        p.start()
+                        startsock = None
                     elif multiprocessing:
                         self.vmsg('%s: new handler Process' % address[0])
                         p = multiprocessing.Process(


### PR DESCRIPTION
multiprocessing isn't able to copy the socket on Windows: "AttributeError: 'module' object has no attribute 'fromfd'"

With kanaka:master: 

```
C:\Users\meta\Documents\noVNC\utils>\python27\python .\websockify   1111 192.168.56.102:5900  --verbose
Traceback (most recent call last):
  File ".\websockify", line 1, in <module>
    websockify
NameError: name 'websockify' is not defined
```

After `cp websockify websockify.py`:

```
C:\Users\meta\Documents\noVNC\utils>\python27\python .\websockify   1111 192.168.56.102:5900  --verbose
WARNING: no 'numpy' module, HyBi protocol is slower or disabled
WARNING: no 'resource' module, daemonizing is slower or disabled
WebSocket server settings:
  - Listen on :1111
  - Flash security policy server
  - No SSL/TLS support (no cert file)
  - proxying from :1111 to 192.168.56.102:5900

  1: 127.0.0.1: new handler Process
WARNING: no 'numpy' module, HyBi protocol is slower or disabled
WARNING: no 'resource' module, daemonizing is slower or disabled
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "C:\python27\lib\multiprocessing\forking.py", line 381, in main
    self = load(from_parent)
  File "C:\python27\lib\pickle.py", line 1378, in load
    return Unpickler(file).load()
  File "C:\python27\lib\pickle.py", line 858, in load
    dispatch[key](self)
  File "C:\python27\lib\pickle.py", line 1133, in load_reduce
    value = func(*args)
  File "C:\python27\lib\multiprocessing\reduction.py", line 193, in rebuild_socket
    _sock = fromfd(fd, family, type_, proto)
  File "C:\python27\lib\multiprocessing\reduction.py", line 182, in fromfd
    s = socket.fromfd(fd, family, type_, proto)
AttributeError: 'module' object has no attribute 'fromfd'
```

threading seems to work fine with two concurrent connections.
