### PR TITLE
Display the desktop name in the document title

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -1,6 +1,7 @@
 /*
  * noVNC: HTML5 VNC client
  * Copyright (C) 2012 Joel Martin
+ * Copyright (C) 2013 Samuel Mannehed for Cendio AB
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.
@@ -165,6 +166,8 @@ Util.conf_defaults(conf, that, defaults, [
         'onFBUComplete(rfb, fbu): RFB FBU received and processed '],
     ['onFBResize',         'rw', 'func', function() { },
         'onFBResize(rfb, width, height): frame buffer resized'],
+    ['onDesktopName',      'rw', 'func', function() { },
+        'onDesktopName(rfb, name): desktop name received'],
 
     // These callback names are deprecated
     ['updateState',        'rw', 'func', function() { },
@@ -873,6 +876,7 @@ init_msg = function() {
         /* Connection name/title */
         name_length   = ws.rQshift32();
         fb_name = ws.rQshiftStr(name_length);
+        conf.onDesktopName(that, fb_name);
         
         if (conf.true_color && fb_name === "Intel(r) AMT KVM")
         {

--- a/include/ui.js
+++ b/include/ui.js
@@ -1,6 +1,7 @@
 /*
  * noVNC: HTML5 VNC client
  * Copyright (C) 2012 Joel Martin
+ * Copyright (C) 2013 Samuel Mannehed for Cendio AB
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.
@@ -82,7 +83,8 @@ start: function(callback) {
 
     UI.rfb = RFB({'target': $D('noVNC_canvas'),
                   'onUpdateState': UI.updateState,
-                  'onClipboard': UI.clipReceive});
+                  'onClipboard': UI.clipReceive,
+                  'onDesktopName': UI.updateDocumentTitle});
     UI.updateVisualState();
 
     // Unfocus clipboard when over the VNC area
@@ -527,6 +529,12 @@ updateVisualState: function() {
     }
 
     //Util.Debug("<< updateVisualState");
+},
+
+
+// Display the desktop name in the document title
+updateDocumentTitle: function(rfb, name) {
+    document.title = name + " - noVNC";
 },
 
 


### PR DESCRIPTION
To make it easier to identify the session if for example the user has multiple sessions active in different tabs of the browser.
