### PR TITLE
Allow higher frame rates by using a new approach for framebufferUpdate requests

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -595,7 +595,6 @@ mouseButton = function(x, y, down, bmask) {
             return;
         } else {
             viewportDragging = false;
-            ws.send(fbUpdateRequests()); // Force immediate redraw
         }
     }
 
@@ -873,7 +872,7 @@ init_msg = function() {
 
         response = pixelFormat();
         response = response.concat(clientEncodings());
-        response = response.concat(fbUpdateRequests());
+        response = response.concat(fbUpdateRequests()); // initial fbu-request
         timing.fbu_rt_start = (new Date()).getTime();
         timing.pixels = 0;
         ws.send(response);
@@ -907,6 +906,7 @@ normal_msg = function() {
     case 0:  // FramebufferUpdate
         ret = framebufferUpdate(); // false means need more data
         if (ret) {
+            // only allow one outstanding fbu-request at a time
             ws.send(fbUpdateRequests());
         }
         break;
@@ -1571,8 +1571,6 @@ encHandlers.DesktopSize = function set_desktopsize() {
     conf.onFBResize(that, fb_width, fb_height);
     display.resize(fb_width, fb_height);
     timing.fbu_rt_start = (new Date()).getTime();
-    // Send a new non-incremental request
-    ws.send(fbUpdateRequests());
 
     FBU.bytes = 0;
     FBU.rects -= 1;
@@ -1798,7 +1796,6 @@ that.sendCtrlAltDel = function() {
     arr = arr.concat(keyEvent(0xFFFF, 0)); // Delete
     arr = arr.concat(keyEvent(0xFFE9, 0)); // Alt
     arr = arr.concat(keyEvent(0xFFE3, 0)); // Control
-    arr = arr.concat(fbUpdateRequests());
     ws.send(arr);
 };
 
@@ -1815,7 +1812,6 @@ that.sendKey = function(code, down) {
         arr = arr.concat(keyEvent(code, 1));
         arr = arr.concat(keyEvent(code, 0));
     }
-    arr = arr.concat(fbUpdateRequests());
     ws.send(arr);
 };
 


### PR DESCRIPTION
Instead of incorrectly using timers and sending new fbu-requests continiously when the mouse moved or when a key was pressed, this fix makes noVNC follow the RFB protocol and keep only one outstanding request at a time. A framebufferUpdate request will only be sent after a full framebufferUpdate has been recieved.

The screen area will be updated as fast as network allows. For administrative tasks when there are less updates, the framebufferUpdate request will simply block until there's new data, and the bandwidth will go down. Same principle goes for CPU usage.

Fixes issue #221.
