### PR TITLE
Fixes the onscreen keyboard in Chrome on Android

### DIFF
--- a/vnc.html
+++ b/vnc.html
@@ -67,7 +67,7 @@
                     id="showKeyboard" class="noVNC_status_button"
                     value="Keyboard" title="Show Keyboard"/>
                 <input type="email" autocapitalize="off" autocorrect="off"
-                    id="keyboardinput" class=""/>
+                    id="keyboardinput" class="" value="&nbsp;"/>
             </div>
         </div>
 


### PR DESCRIPTION
Fixes Issue #275.

As seen in #275, using the onscreen Android keyboard in noVNC in Chrome does not work as of now in noVNC. This is because keyPress events does not get sent in Chrome on Android. As seen in this [thread](https://code.google.com/p/chromium/issues/detail?id=118639) it seems like the Chromium developers do not consider this behavior a bug and they recommend using input events instead.

This patch allows noVNC to catch input events from the hidden keyboardinput field which was used to give focus in order to bring up the onscreen keyboard. Input events instead of keyPress events brings a few pros and a few cons.. some keys that does not generate any input will require special handling but on the upside you automatically support the input of more than one character at a time, from for example gesture typing or "swipe" as well as auto-complete.

In cases where keyboard input works without this patch the code will not be invoked since the keyPress events prevents input from being entered into the input field. We will therefore never get input events at the same time as keyPress events.

Below follows a list of what I have tested and which events each case will trigger:

**Android 4.3, Nexus 7:**
Chrome 29 - input events
Firefox 23 - keypress events

**iOS 6.1, iPad Mini:**
Safari 6 - keypress events
Chrome 29 - keypress events

This patch is only affecting Chrome on Android as far as I can see. Unfortunately I do not have access to any windows touch device to test on.

And by the way, issues #126 and #251 should also be closed since the problem has been fixed in newer Firefox versions.
