### PR TITLE
Adds 'secure' property to 'token' cookie

### DIFF
--- a/include/webutil.js
+++ b/include/webutil.js
@@ -1,6 +1,7 @@
 /*
  * noVNC: HTML5 VNC client
  * Copyright (C) 2012 Joel Martin
+ * Copyright (C) 2013 NTT corp.
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.
@@ -94,16 +95,20 @@ WebUtil.getQueryVar = function(name, defVal) {
 
 // No days means only for this browser session
 WebUtil.createCookie = function(name,value,days) {
-    var date, expires;
+    var date, expires, secure;
     if (days) {
         date = new Date();
         date.setTime(date.getTime()+(days*24*60*60*1000));
         expires = "; expires="+date.toGMTString();
-    }
-    else {
+    } else {
         expires = "";
     }
-    document.cookie = name+"="+value+expires+"; path=/";
+    if (document.location.protocol === "https:") {
+        secure = "; secure";
+    } else {
+        secure = "";
+    }
+    document.cookie = name+"="+value+expires+"; path=/"+secure;
 };
 
 WebUtil.readCookie = function(name, defaultValue) {


### PR DESCRIPTION
This patch adds 'secure' property to 'token' cookie if the protocol
is https. The 'secure' property is left empty for http connections.
