### PR TITLE
Fix issue #326: correct handling of shift key

### DIFF
--- a/include/keyboard.js
+++ b/include/keyboard.js
@@ -31,7 +31,7 @@ var kbdUtil = (function() {
     function hasShortcutModifier(charModifier, currentModifiers) {
         var mods = {};
         for (var key in currentModifiers) {
-            if (key !== 0xffe1) {
+            if (parseInt(key) !== 0xffe1) {
                 mods[key] = currentModifiers[key];
             }
         }

--- a/tests/test.helper.js
+++ b/tests/test.helper.js
@@ -248,5 +248,13 @@ describe('Helpers', function() {
                 })).to.be.deep.equal([{keysym: keysyms.lookup(0xffe9), type: 'keydown'}]);
             });
         });
+        describe('do not treat shift as a modifier key', function() {
+            it('should not treat shift as a shortcut modifier', function() {
+                expect(kbdUtil.hasShortcutModifier([], {0xffe1 : true})).to.be.false;
+            });
+            it('should not treat shift as a char modifier', function() {
+                expect(kbdUtil.hasCharModifier([], {0xffe1 : true})).to.be.false;
+            });
+        });
     });
 });


### PR DESCRIPTION
When shortcut modifiers (modifier keys such as CTRL, which do not participate in
composing character input) are pressed, we try to suppress the keypress
event, as browsers do not reliably generate it. This means that
subsequent key events are decoded only based on the keydown event.

Due to a type error (comparing a string to a number), shift was
mistakenly treated as a shortcut modifier, preventing text input which
relied on shift, such as _ and %, from being generated.
