### PR TITLE
Improved websocket binary support detection

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -296,17 +296,13 @@ function connect() {
     var uri;
     
     if (typeof UsingSocketIO !== "undefined") {
-        uri = "http://" + rfb_host + ":" + rfb_port + "/" + rfb_path;
+        uri = "http";
     } else {
-        if (conf.encrypt) {
-            uri = "wss://";
-        } else {
-            uri = "ws://";
-        }
-        uri += rfb_host + ":" + rfb_port + "/" + rfb_path;
+        uri = conf.encrypt ? "wss" : "ws";
     }
+    uri += "://" + rfb_host + ":" + rfb_port + "/" + rfb_path;
     Util.Info("connecting to " + uri);
-    // TODO: make protocols a configurable
+
     ws.open(uri, conf.wsProtocols);
 
     Util.Debug("<< RFB.connect");

--- a/include/websock.js
+++ b/include/websock.js
@@ -262,7 +262,7 @@ function on(evt, handler) {
     eventHandlers[evt] = handler;
 }
 
-function init(protocols) {
+function init(protocols, ws_schema) {
     rQ         = [];
     rQi        = 0;
     sQ         = [];
@@ -278,11 +278,14 @@ function init(protocols) {
         bt = true;
     }
 
-    // Check for full binary type support in WebSockets
-    // TODO: this sucks, the property should exist on the prototype
-    // but it does not.
+    // Check for full binary type support in WebSocket
+    // Inspired by:
+    // https://github.com/Modernizr/Modernizr/issues/370
+    // https://github.com/Modernizr/Modernizr/blob/master/feature-detects/websockets/binary.js
     try {
-        if (bt && ('binaryType' in (new WebSocket("wss://localhost:17523")))) {
+        if (bt &&
+            ('binaryType' in WebSocket.prototype ||
+            !!(new WebSocket(ws_schema + '://.').binaryType))) {
             Util.Info("Detected binaryType support in WebSockets");
             wsbt = true;
         }
@@ -325,7 +328,8 @@ function init(protocols) {
 }
 
 function open(uri, protocols) {
-    protocols = init(protocols);
+    var ws_schema = uri.match(/^([a-z]+):\/\//)[1];
+    protocols = init(protocols, ws_schema);
 
     if (test_mode) {
         websocket = {};


### PR DESCRIPTION
A facke connection to 'wss://localhost:17523' (randomly chosen) to detect
the WebSocket binary support is not the best solution.
First of all, check of prototype has the property 'binaryType'. If not,
perform a dummy connection to 'wss://.' instead of 'wss://localhost:17523'.

This patch was inspired by the discussion and implementation of Modernizr:
https://github.com/Modernizr/Modernizr/issues/370
https://github.com/Modernizr/Modernizr/blob/master/feature-detects/websockets/binary.js
