### PR TITLE
Fix problem in touchable device

### DIFF
--- a/include/input.js
+++ b/include/input.js
@@ -355,14 +355,14 @@ that.grab = function() {
         Util.addEvent(window, 'touchend', onMouseUp);
         Util.addEvent(c, 'touchend', onMouseUp);
         Util.addEvent(c, 'touchmove', onMouseMove);
-    } else {
+    }
         Util.addEvent(c, 'mousedown', onMouseDown);
         Util.addEvent(window, 'mouseup', onMouseUp);
         Util.addEvent(c, 'mouseup', onMouseUp);
         Util.addEvent(c, 'mousemove', onMouseMove);
         Util.addEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
                 onMouseWheel);
-    }
+    
 
     /* Work around right and middle click browser behaviors */
     Util.addEvent(document, 'click', onMouseDisable);
@@ -380,14 +380,14 @@ that.ungrab = function() {
         Util.removeEvent(window, 'touchend', onMouseUp);
         Util.removeEvent(c, 'touchend', onMouseUp);
         Util.removeEvent(c, 'touchmove', onMouseMove);
-    } else {
+    }
         Util.removeEvent(c, 'mousedown', onMouseDown);
         Util.removeEvent(window, 'mouseup', onMouseUp);
         Util.removeEvent(c, 'mouseup', onMouseUp);
         Util.removeEvent(c, 'mousemove', onMouseMove);
         Util.removeEvent(c, (Util.Engine.gecko) ? 'DOMMouseScroll' : 'mousewheel',
                 onMouseWheel);
-    }
+    
 
     /* Work around right and middle click browser behaviors */
     Util.removeEvent(document, 'click', onMouseDisable);


### PR DESCRIPTION
When 'ontouchstart' is in document.documentElement, the code just add touch pattern event, which lead to users can't use mouse.
So we should remove the 'else' block to add mouse event for all device.
And I test the code without 'else' block, it works well with touch and mouse.
