### PR TITLE
Fix typo causing mouse to be grabbed

### DIFF
--- a/include/rfb.js
+++ b/include/rfb.js
@@ -550,7 +550,7 @@ var RFB;
             if (down) {
                 this._mouse_buttonMask |= bmask;
             } else {
-                this._mouse_buttonMaks ^= bmask;
+                this._mouse_buttonMask ^= bmask;
             }
 
             if (this._viewportDrag) {


### PR DESCRIPTION
The mouse was getting stuck in the down state
