### PR TITLE
Loads keysym.js

### DIFF
--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -77,7 +77,7 @@
         // Load supporting scripts
         Util.load_scripts(["webutil.js", "base64.js", "websock.js", "des.js",
                            "keysymdef.js", "keyboard.js", "input.js", "display.js",
-                           "jsunzip.js", "rfb.js"]);
+                           "jsunzip.js", "rfb.js", "keysym.js"]);
 
         var rfb;
 


### PR DESCRIPTION
Without it, `XK_ISO_Level3_Shift` (at least) is undefined.
