### PR TITLE
Add allowQEMUExtKeyEvent option, which allows the qemu keyboard exten…

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -202,6 +202,10 @@ var UI;
         initRFB: function() {
             try {
                 UI.rfb = new RFB({'target': document.getElementById('noVNC_canvas'),
+                                  // If you have qemu guests that are still running with the '-k en-us' (or any other keymap), you'll need
+                                  // to set this to false, or each keypress will result in messages like:
+                                  // Unknown key released (translated set 2, code 0x0 on isa0060/serio0).
+                                  'allowQEMUExtKeyEvent': true,
                                   'onUpdateState': UI.updateState,
                                   'onXvpInit': UI.updateXvpButton,
                                   'onClipboard': UI.clipboardReceive,

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -155,6 +155,7 @@
         'wsProtocols': ['binary'],              // Protocols to use in the WebSocket connection
         'repeaterID': '',                       // [UltraVNC] RepeaterID to connect to
         'viewportDrag': false,                  // Move the viewport on mouse drags
+        'allowQEMUExtKeyEvent': true,           // Should the QEMU extended keymap support be available
 
         // Callback functions
         'onUpdateState': function () { },       // onUpdateState(rfb, state, oldstate, statusMsg): state update/change
@@ -1323,6 +1324,7 @@
         ['wsProtocols', 'rw', 'arr'],           // Protocols to use in the WebSocket connection
         ['repeaterID', 'rw', 'str'],            // [UltraVNC] RepeaterID to connect to
         ['viewportDrag', 'rw', 'bool'],         // Move the viewport on mouse drags
+        ['allowQEMUExtKeyEvent', 'rw', 'bool'], // Should the QEMU keyboard extensions be allowed
 
         // Callback functions
         ['onUpdateState', 'rw', 'func'],        // onUpdateState(rfb, state, oldstate, statusMsg): RFB state update/change
@@ -2320,7 +2322,7 @@
             this._FBU.rects--;
 
             var keyboardEvent = document.createEvent("keyboardEvent");
-            if (keyboardEvent.code !== undefined) {
+            if (this.allowQEMUExtKeyEvent && keyboardEvent.code !== undefined) {
                 this._qemuExtKeyEventSupported = true;
                 this._keyboard.setQEMUVNCKeyboardHandler();
             }

--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -233,10 +233,16 @@
                                'local_cursor': WebUtil.getConfigVar('cursor', true),
                                'shared':       WebUtil.getConfigVar('shared', true),
                                'view_only':    WebUtil.getConfigVar('view_only', false),
+                               // If you have qemu guests that are still running with the '-k en-us' (or any other keymap), you'll need
+                               // to set this to false, or each keypress will result in messages like:
+                               // Unknown key released (translated set 2, code 0x0 on isa0060/serio0).
+                               'allowQEMUExtKeyEvent': true,
+
                                'onUpdateState':  updateState,
                                'onXvpInit':    xvpInit,
                                'onPasswordRequired':  passwordRequired,
-                               'onFBUComplete': FBUComplete});
+                               'onFBUComplete': FBUComplete,
+                });
             } catch (exc) {
                 updateState(null, 'fatal', null, 'Unable to create RFB client -- ' + exc);
                 return; // don't continue trying to connect


### PR DESCRIPTION
Add allowQEMUExtKeyEvent option, which allows the qemu keyboard extensions to be disabled.  This is required for compatability with instances that are still running with a '-k' option on the command line.

Setting this to false would fix the issues reported in #666 
