### PR TITLE
rfb: Allow port to be optionally appended to URI

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -273,9 +273,9 @@
             this._rfb_password = (password !== undefined) ? password : "";
             this._rfb_path = (path !== undefined) ? path : "";
 
-            if (!this._rfb_host || !this._rfb_port) {
+            if (!this._rfb_host) {
                 return this._fail(
-                    _("Must set host and port"));
+                    _("Must set host"));
             }
 
             this._rfb_init_state = '';
@@ -379,7 +379,12 @@
                 uri = this._encrypt ? 'wss' : 'ws';
             }
 
-            uri += '://' + this._rfb_host + ':' + this._rfb_port + '/' + this._rfb_path;
+            uri += '://' + this._rfb_host;
+            if(this._rfb_port) {
+                uri += ':' + this._rfb_port;
+            }
+            uri += '/' + this._rfb_path;
+
             Util.Info("connecting to " + uri);
 
             try {

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -81,15 +81,6 @@ describe('Remote Frame Buffer Protocol Client', function() {
                 expect(client._updateConnectionState).to.not.have.been.called;
                 expect(client._rfb_connection_state).to.equal('');
             });
-
-            it('should not try to connect if we are missing a port', function () {
-                client._fail = sinon.spy();
-                client._rfb_connection_state = '';
-                client.connect('abc');
-                expect(client._fail).to.have.been.calledOnce;
-                expect(client._updateConnectionState).to.not.have.been.called;
-                expect(client._rfb_connection_state).to.equal('');
-            });
         });
 
         describe('#disconnect', function () {
@@ -486,6 +477,13 @@ describe('Remote Frame Buffer Protocol Client', function() {
                 client._rfb_path = 'PATH';
                 client._updateConnectionState('connecting');
                 expect(client._sock.open).to.have.been.calledWith('ws://HOST:8675/PATH');
+            });
+
+            it('should not include a port in the uri if not specified in connect', function () {
+                sinon.spy(client._sock, 'open');
+                client.set_encrypt(true);
+                client.connect('HOST', undefined)
+                expect(client._sock.open).to.have.been.calledWith('wss://HOST/');
             });
         });
 


### PR DESCRIPTION
Supports server configurations that might prefer wss:// connections
on the default port, then proxies them through the web server to the
VNC server.

This proxy configuration is helpful on servers using self-signed
certificates.  Accessing the https://<host>/vnc_auto.html page and
adding an exception for that host is sufficient to also satisfy the
wss://<host>/ request, unlike requests to wss://<host>:<port>/ which
may require an extra exception.