### PR TITLE
Changed the default compression level to 2

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -60,7 +60,8 @@
         ['JPEG_quality_med',      -26 ],
         //['JPEG_quality_hi',     -23 ],
         //['compress_lo',        -255 ],
-        ['compress_hi',          -247 ],
+        ['compress_hi',          -254 ],
+        //['compress_max',       -247 ],
 
         ['DesktopSize',          -223 ],
         ['last_rect',            -224 ],


### PR DESCRIPTION
The old default was to ask for the maximum compression level. This
is against the recommendations in libvncserver/tight.c due to excessive
CPU load. It also causes Vino 3.8.1 (still shipped with Ubuntu 16.04
LTS) to prefer the blurry JPEG compression too much - e.g. red text on
the default background in MATE terminal becomes almost unreadable.

The new default is the recommended compression level for low-color
workloads, according to libvncserver source. Also, it is the maximum
compression level that doesn't trigger the Vino bug with red text in
most cases.

Fixes issue #737.