### PR TITLE
Fix rfb._cleanup()

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -444,15 +444,13 @@
         },
 
         _cleanup: function () {
-            if (this._display && this._display.get_context()) {
-                if (!this._view_only) { this._keyboard.ungrab(); }
-                if (!this._view_only) { this._mouse.ungrab(); }
-                this._display.defaultCursor();
-                if (Util.get_logging() !== 'debug') {
-                    // Show noVNC logo on load and when disconnected, unless in
-                    // debug mode
-                    this._display.clear();
-                }
+            if (!this._view_only) { this._keyboard.ungrab(); }
+            if (!this._view_only) { this._mouse.ungrab(); }
+            this._display.defaultCursor();
+            if (Util.get_logging() !== 'debug') {
+                // Show noVNC logo on load and when disconnected, unless in
+                // debug mode
+                this._display.clear();
             }
         },
 


### PR DESCRIPTION
Regression caused by e549ae074fcea9febde32c0fa260a64c15cc1b8e. Things work fine with 84cd0e719ead6a1d99827d00794ef821593564fc. The function display.get_context() was removed but it is still called in rfb.js in _cleanup().

This results in bugs where you for example are be unable to write in text input fields after disconnecting.

@ossman removing this wasn't intended I guess?