### PR TITLE
Save settings immediately

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1052,15 +1052,6 @@ var UI;
                 .classList.remove("noVNC_open");
         },
 
-        toggleConnectPanel: function() {
-            if (document.getElementById('noVNC_connect_dlg')
-                .classList.contains("noVNC_open")) {
-                UI.closeConnectPanel();
-            } else {
-                UI.openConnectPanel();
-            }
-        },
-
         connect: function(event, password) {
             var host = document.getElementById('noVNC_setting_host').value;
             var port = document.getElementById('noVNC_setting_port').value;

--- a/app/ui.js
+++ b/app/ui.js
@@ -146,7 +146,7 @@ var UI;
             UI.initFullscreen();
 
             // Setup event handlers
-            UI.setupWindowEvents();
+            UI.addResizeHandlers();
             UI.addControlbarHandlers();
             UI.addTouchSpecificHandlers();
             UI.addExtraKeysHandlers();
@@ -154,6 +154,8 @@ var UI;
             UI.addConnectionControlHandlers();
             UI.addClipboardHandlers();
             UI.addSettingsHandlers();
+            document.getElementById("noVNC_status")
+                .addEventListener('click', UI.hideStatus);
 
             UI.openControlbar();
 
@@ -235,13 +237,10 @@ var UI;
             UI.initSetting('reconnect_delay', 5000);
         },
 
-        setupWindowEvents: function() {
+        addResizeHandlers: function() {
             window.addEventListener('resize', UI.applyResizeMode);
             window.addEventListener('resize', UI.updateViewClip);
             window.addEventListener('resize', UI.updateViewDrag);
-
-            document.getElementById("noVNC_status")
-                .addEventListener('click', UI.hideStatus);
         },
 
         addControlbarHandlers: function() {

--- a/app/ui.js
+++ b/app/ui.js
@@ -191,7 +191,7 @@ var UI;
 
             // Settings with immediate effects
             UI.initSetting('logging', 'warn');
-            WebUtil.init_logging(UI.getSetting('logging'));
+            UI.updateLogging();
 
             // if port == 80 (or 443) then it won't be present and should be
             // set manually
@@ -868,7 +868,7 @@ var UI;
             UI.saveSetting('reconnect_delay');
 
             // Settings with immediate (non-connected related) effect
-            WebUtil.init_logging(UI.getSetting('logging'));
+            UI.updateLogging();
             UI.updateViewClip();
             UI.updateViewDrag();
             //Util.Debug("<< settingsApply");
@@ -1699,6 +1699,10 @@ var UI;
                 UI.rfb.get_keyboard().set_focused(true);
                 UI.rfb.get_mouse().set_focused(true);
             }
+        },
+
+        updateLogging: function() {
+            WebUtil.init_logging(UI.getSetting('logging'));
         },
 
         updateSessionSize: function(rfb, width, height) {

--- a/app/ui.js
+++ b/app/ui.js
@@ -421,6 +421,8 @@ var UI;
             UI.addSettingChangeHandler('true_color');
             UI.addSettingChangeHandler('cursor');
             UI.addSettingChangeHandler('resize');
+            UI.addSettingChangeHandler('resize', UI.enableDisableViewClip);
+            UI.addSettingChangeHandler('resize', UI.applyResizeMode);
             UI.addSettingChangeHandler('clip');
             UI.addSettingChangeHandler('shared');
             UI.addSettingChangeHandler('view_only');
@@ -505,7 +507,6 @@ var UI;
             }
 
             UI.enableDisableViewClip();
-            document.getElementById('noVNC_setting_resize').disabled = UI.connected;
             document.getElementById('noVNC_setting_shared').disabled = UI.connected;
             document.getElementById('noVNC_setting_view_only').disabled = UI.connected;
             document.getElementById('noVNC_setting_host').disabled = UI.connected;
@@ -1224,6 +1225,8 @@ var UI;
 
                 var display = UI.rfb.get_display();
                 var resizeMode = UI.getSetting('resize');
+                display.set_scale(1);
+                UI.rfb.get_mouse().set_scale(1);
 
                 if (resizeMode === 'remote') {
 

--- a/app/ui.js
+++ b/app/ui.js
@@ -143,9 +143,10 @@ var UI;
                 UI.toggleControlbarSide();
             }
 
-            // Setup and initialize event handlers
+            UI.initFullscreen();
+
+            // Setup event handlers
             UI.setupWindowEvents();
-            UI.setupFullscreen();
             UI.addControlbarHandlers();
             UI.addTouchSpecificHandlers();
             UI.addExtraKeysHandlers();
@@ -177,6 +178,20 @@ var UI;
 
             if (typeof callback === "function") {
                 callback(UI.rfb);
+            }
+        },
+
+        initFullscreen: function() {
+            // Only show the button if fullscreen is properly supported
+            // * Safari doesn't support alphanumerical input while in fullscreen
+            if (!UI.isSafari &&
+                (document.documentElement.requestFullscreen ||
+                 document.documentElement.mozRequestFullScreen ||
+                 document.documentElement.webkitRequestFullscreen ||
+                 document.body.msRequestFullscreen)) {
+                document.getElementById('noVNC_fullscreen_button')
+                    .classList.remove("noVNC_hidden");
+                UI.addFullscreenHandlers();
             }
         },
 
@@ -227,20 +242,6 @@ var UI;
 
             document.getElementById("noVNC_status")
                 .addEventListener('click', UI.hideStatus);
-        },
-
-        setupFullscreen: function() {
-            // Only show the button if fullscreen is properly supported
-            // * Safari doesn't support alphanumerical input while in fullscreen
-            if (!UI.isSafari &&
-                (document.documentElement.requestFullscreen ||
-                 document.documentElement.mozRequestFullScreen ||
-                 document.documentElement.webkitRequestFullscreen ||
-                 document.body.msRequestFullscreen)) {
-                document.getElementById('noVNC_fullscreen_button')
-                    .classList.remove("noVNC_hidden");
-                UI.addFullscreenHandlers();
-            }
         },
 
         addControlbarHandlers: function() {

--- a/app/ui.js
+++ b/app/ui.js
@@ -237,6 +237,34 @@ var UI;
             UI.initSetting('reconnect_delay', 5000);
         },
 
+        initRFB: function() {
+            try {
+                UI.rfb = new RFB({'target': document.getElementById('noVNC_canvas'),
+                                  'onNotification': UI.notification,
+                                  'onUpdateState': UI.updateState,
+                                  'onDisconnected': UI.disconnectFinished,
+                                  'onPasswordRequired': UI.passwordRequired,
+                                  'onXvpInit': UI.updateXvpButton,
+                                  'onClipboard': UI.clipboardReceive,
+                                  'onBell': UI.bell,
+                                  'onFBUComplete': UI.initialResize,
+                                  'onFBResize': UI.updateSessionSize,
+                                  'onDesktopName': UI.updateDesktopName});
+                return true;
+            } catch (exc) {
+                var msg = "Unable to create RFB client -- " + exc;
+                Util.Error(msg);
+                UI.showStatus(msg, 'error');
+                return false;
+            }
+        },
+
+/* ------^-------
+ *     /INIT
+ * ==============
+ * EVENT HANDLERS
+ * ------v------*/
+
         addResizeHandlers: function() {
             window.addEventListener('resize', UI.applyResizeMode);
             window.addEventListener('resize', UI.updateViewClip);
@@ -416,30 +444,8 @@ var UI;
             window.addEventListener('msfullscreenchange', UI.updateFullscreenButton);
         },
 
-        initRFB: function() {
-            try {
-                UI.rfb = new RFB({'target': document.getElementById('noVNC_canvas'),
-                                  'onNotification': UI.notification,
-                                  'onUpdateState': UI.updateState,
-                                  'onDisconnected': UI.disconnectFinished,
-                                  'onPasswordRequired': UI.passwordRequired,
-                                  'onXvpInit': UI.updateXvpButton,
-                                  'onClipboard': UI.clipboardReceive,
-                                  'onBell': UI.bell,
-                                  'onFBUComplete': UI.initialResize,
-                                  'onFBResize': UI.updateSessionSize,
-                                  'onDesktopName': UI.updateDesktopName});
-                return true;
-            } catch (exc) {
-                var msg = "Unable to create RFB client -- " + exc;
-                Util.Error(msg);
-                UI.showStatus(msg, 'error');
-                return false;
-            }
-        },
-
 /* ------^-------
- *     /INIT
+ * /EVENT HANDLERS
  * ==============
  *     VISUAL
  * ------v------*/

--- a/vnc.html
+++ b/vnc.html
@@ -248,10 +248,6 @@
                             </li>
                         </ul></div>
                     </li>
-                    <li><hr></li>
-                    <li>
-                        <input type="button" id="noVNC_settings_apply" value="Apply" class="noVNC_submit" />
-                    </li>
                 </ul>
             </div>
             </div>


### PR DESCRIPTION
Instead of saving settings when clicking on apply or toggling the settings panel, save them immediately after a change. This is more in line with how most modern interfaces work and saves us from having two different 'states' to keep track of in the UI code (cookie and HTML-elem value).