### PR TITLE
Convert key code 219 to XK_bracketleft for passthrough of ctrl-[

### DIFF
--- a/core/input/util.js
+++ b/core/input/util.js
@@ -229,6 +229,7 @@ var KeyboardUtil = {};
             case 0xbc: return KeyTable.XK_comma;
             case 0xbd: return KeyTable.XK_minus;
             case 0xbe: return KeyTable.XK_period;
+            case 0xdb: return KeyTable.XK_bracketleft;
         }
 
         return nonCharacterKey({keyCode: keycode});


### PR DESCRIPTION
Added a single conversion from key code 219 to XK_bracketleft so that ctrl-[
passes through noVNC into the server session.  This is useful for editing with
vi/vim as ctrl-[ acts as the ESC key but allows one to leave their fingers on
the home row.