### PR TITLE
Fixed the issue where novnc can't be relocated

### DIFF
--- a/vendor/browser-es-module-loader/dist/browser-es-module-loader.js
+++ b/vendor/browser-es-module-loader/dist/browser-es-module-loader.js
@@ -1350,7 +1350,7 @@ WorkerPool.prototype = {
 };
 
 var promiseMap = new Map();
-var babelWorker = new WorkerPool('/vendor/browser-es-module-loader/dist/babel-worker.js', 3);
+var babelWorker = new WorkerPool('vendor/browser-es-module-loader/dist/babel-worker.js', 3);
 babelWorker.onmessage = function (evt) {
     var promFuncs = promiseMap.get(evt.data.key);
     promFuncs.resolve(evt.data);

--- a/vendor/browser-es-module-loader/src/browser-es-module-loader.js
+++ b/vendor/browser-es-module-loader/src/browser-es-module-loader.js
@@ -190,7 +190,7 @@ WorkerPool.prototype = {
 };
 
 var promiseMap = new Map();
-var babelWorker = new WorkerPool('/vendor/browser-es-module-loader/dist/babel-worker.js', 3);
+var babelWorker = new WorkerPool('vendor/browser-es-module-loader/dist/babel-worker.js', 3);
 babelWorker.onmessage = function (evt) {
     var promFuncs = promiseMap.get(evt.data.key);
     promFuncs.resolve(evt.data);


### PR DESCRIPTION
If I try to serve noVNC under a sub directory, like
```
https://somewhere.com/noVNC/
```

It will fail due to browser-es-module-loader.js trying to load babel.js from root. This patch makes noVNC to be relocatable to sub-URL.