### PR TITLE
Remove double unescaping of title

### DIFF
--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -206,7 +206,7 @@
         document.getElementById('xvpResetButton').onclick = xvpReset;
 
         WebUtil.init_logging(WebUtil.getConfigVar('logging', 'warn'));
-        document.title = unescape(WebUtil.getConfigVar('title', 'noVNC'));
+        document.title = WebUtil.getConfigVar('title', 'noVNC');
         // By default, use the host and port of server that served this file
         var host = WebUtil.getConfigVar('host', window.location.hostname);
         var port = WebUtil.getConfigVar('port', window.location.port);


### PR DESCRIPTION
Commit fa5b334dcbe7a5dab21580b54cc2f5f142600379 by Joel Martin changed
getQueryVal() to always decode the value using decodeURIComponent(), but
unescape() is still used for extracting the title, leading to
double-unescaping.

As unescape() is deprecated anyway, remove the last user.

Cc: Joel Martin <github@martintribe.org>
Cc: Anthony Young <sleepsonthefloor@gmail.com>