### PR TITLE
Fix license name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "Samuel Mannehed <samuel@cendio.se> (https://github.com/samhed)",
     "Pierre Ossman <ossman@cendio.se> (https://github.com/CendioOssman)"
   ],
-  "license": "MPL 2.0",
+  "license": "MPL-2.0",
   "bugs": {
     "url": "https://github.com/novnc/noVNC/issues"
   },


### PR DESCRIPTION
It's spelled "MPL-2.0" according to https://spdx.org/licenses/.

This is important for license scanners as cockpit's (this came up in https://github.com/cockpit-project/cockpit/pull/5932).