### PR TITLE
Only load ES6 module loader polyfill if needed

### DIFF
--- a/vnc_lite.html
+++ b/vnc_lite.html
@@ -60,7 +60,20 @@
 
     <!-- promise polyfills promises for IE11 -->
     <script src="vendor/promise.js"></script>
-    <script src="vendor/browser-es-module-loader/dist/browser-es-module-loader.js"></script>
+    <!-- ES2015/ES6 modules polyfill -->
+    <script type="module">
+        window._noVNC_has_module_support = true;
+    </script>
+    <script>
+        window.addEventListener("load", function() {
+            if (window._noVNC_has_module_support) return;
+            var loader = document.createElement("script");
+            loader.src = "vendor/browser-es-module-loader/dist/browser-es-module-loader.js";
+            document.head.appendChild(loader);
+        });
+    </script>
+
+    <!-- actual script modules -->
     <script type="module">
         // Load supporting scripts
         import * as WebUtil from './app/webutil.js';


### PR DESCRIPTION
Safari and Chrome now have native support for modules, so we need to make sure we only load our polyfill when actually needed.