### PR TITLE
Fixed --cert Argument Typo in launch.sh

### DIFF
--- a/utils/launch.sh
+++ b/utils/launch.sh
@@ -142,7 +142,7 @@ fi
 
 echo "Starting webserver and WebSockets proxy on port ${PORT}"
 #${HERE}/websockify --web ${WEB} ${CERT:+--cert ${CERT}} ${PORT} ${VNC_DEST} &
-${WEBSOCKIFY} ${SSLONLY} --web ${WEB} ${CERT:+--cert ${CERT}} ${PORT} ${VNC_DEST} &
+${WEBSOCKIFY} ${SSLONLY} --web ${WEB} --cert ${CERT} ${PORT} ${VNC_DEST} &
 proxy_pid="$!"
 sleep 1
 if ! ps -p ${proxy_pid} >/dev/null; then


### PR DESCRIPTION
Fixed a transposition error on line 145 affecting the --cert argument.