### PR TITLE
Initalize cached 16x16 tile.

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -69,6 +69,7 @@ export default function Display(target) {
         throw new Error("Canvas does not support createImageData");
     }
 
+    this._tile16x16 = this._drawCtx.createImageData(16, 16);
     Log.Debug("<< Display.constructor");
 };
 


### PR DESCRIPTION
Without this, noVNC will display a blank screen when dealing with a server that sends 16 by 16 tiles.