### PR TITLE
Fix view_only setting with autoconnect

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1019,8 +1019,6 @@ var UI = {
         UI.closeAllPanels();
         UI.closeConnectPanel();
 
-        UI.updateVisualState('connecting');
-
         var url;
 
         url = UI.getSetting('encrypt') ? 'wss' : 'ws';
@@ -1047,6 +1045,7 @@ var UI = {
         UI.rfb.scaleViewport = UI.getSetting('resize') === 'scale';
         UI.rfb.resizeSession = UI.getSetting('resize') === 'remote';
 
+        UI.updateVisualState('connecting');
         UI.updateViewOnly();
     },
 

--- a/app/ui.js
+++ b/app/ui.js
@@ -1021,8 +1021,6 @@ var UI = {
 
         UI.updateVisualState('connecting');
 
-        UI.updateViewOnly();
-
         var url;
 
         url = UI.getSetting('encrypt') ? 'wss' : 'ws';
@@ -1048,6 +1046,8 @@ var UI = {
         UI.rfb.clipViewport = UI.getSetting('view_clip');
         UI.rfb.scaleViewport = UI.getSetting('resize') === 'scale';
         UI.rfb.resizeSession = UI.getSetting('resize') === 'remote';
+
+        UI.updateViewOnly();
     },
 
     disconnect: function() {


### PR DESCRIPTION
I found an issue where the view_only parameter in the url was not respected during automatic connection.

To reproduce, open an url similar to this: .../noVNC/vnc.html?host=...&autoconnect=1&view_only=true&resize=none
After successful connection, the checkbox in the UI on the left side is checked for "
View only", but it is not respected. If I uncheck it and check it again, it is respected.

The following change fixes the bug, although I am not very familiar with the codebase, so this might not be the best solution.