### PR TITLE
Add support to token

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1013,7 +1013,7 @@ var UI = {
         if(port) {
             url += ':' + port;
         }
-        url += '/' + path;
+        url += '/' + path + document.location.search;
 
         UI.rfb = new RFB(document.getElementById('noVNC_container'), url,
                          { shared: UI.getSetting('shared'),

--- a/app/ui.js
+++ b/app/ui.js
@@ -164,7 +164,8 @@ var UI = {
         UI.initSetting('resize', 'off');
         UI.initSetting('shared', true);
         UI.initSetting('view_only', false);
-        UI.initSetting('path', 'websockify');
+        UI.initSetting('path', window.location.pathname.split('/').slice(0, -1).join('/') +
+                               '/websockify');
         UI.initSetting('repeaterID', '');
         UI.initSetting('reconnect', false);
         UI.initSetting('reconnect_delay', 5000);
@@ -1013,7 +1014,7 @@ var UI = {
         if(port) {
             url += ':' + port;
         }
-        url += '/' + path + document.location.search;
+        url += path + document.location.search;
 
         UI.rfb = new RFB(document.getElementById('noVNC_container'), url,
                          { shared: UI.getSetting('shared'),


### PR DESCRIPTION
Hi.
I found that noVNC can redirect to any machine by using token with  [websockify](https://github.com/novnc/websockify/issues/3). ([wiki](https://github.com/novnc/websockify/wiki/Token-based-target-selection))

However, it doesn't work on recent version.
After reading code in `app/ui.js`, I found that `path` didn't include query section in URL.
So, just add it easily by directly add  `document.location.search`

Also, the path is always point to `ws://ip:port/websocky`, which make bug when I deploy it, such as I add prefixStrip in the path like `127.0.0.1:8080/mypath/vnc.html`.
The solution is to add `window.location.pathname` in path.
