### PR TITLE
Work around broken Alt keyup in Firefox

### DIFF
--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -56,6 +56,10 @@ export function isEdge() {
     return navigator && !!(/edge/i).exec(navigator.userAgent);
 }
 
+export function isFirefox() {
+    return navigator && !!(/firefox/i).exec(navigator.userAgent);
+}
+
 export function isWindows() {
     return navigator && !!(/win/i).exec(navigator.platform);
 }


### PR DESCRIPTION
Firefox no longer sends keyup events properly for the Alt keys. Try to sniff out the state of the Alt key by monitoring other events that include its state.

Relevant Firefox bugs:

https://bugzilla.mozilla.org/show_bug.cgi?id=1335347
https://bugzilla.mozilla.org/show_bug.cgi?id=1435717