### PR TITLE
add get-only connectionState property and dispatch CustomEvent when state is connecting

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -312,6 +312,9 @@ RFB.prototype = {
         }
     },
 
+    get connectionState() { return this._rfb_connection_state; },
+    set connectionState(val) { Log.Error("Cannot assign value " + val + " to get-only property connectionState"); },
+
     // ===== PUBLIC METHODS =====
 
     disconnect: function () {
@@ -646,6 +649,8 @@ RFB.prototype = {
 
         switch (state) {
             case 'connecting':
+                var event = new CustomEvent("connecting", { detail: {} });
+                this.dispatchEvent(event);
                 this._connect();
                 break;
 

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -823,6 +823,23 @@ describe('Remote Frame Buffer Protocol Client', function() {
                 this.clock.tick();
                 expect(client._sock.open).to.have.been.calledOnce;
             });
+
+            it('should result in a connecting event if state is updated to connecting through the correct function', function () {
+                var client = make_rfb();
+                var spy = sinon.spy();
+                client.addEventListener("connecting", spy);
+                client._rfb_connection_state = '';
+                client._updateConnectionState('connecting');
+                expect(spy).to.have.been.calledOnce;
+            });
+
+            it('should not result in a connecting event if state is updated to connecting via direct assignment', function () {
+                var client = make_rfb();
+                var spy = sinon.spy();
+                client.addEventListener("connecting", spy);
+                client._rfb_connection_state = 'connecting';
+                expect(spy).to.not.have.been.called;
+            });
         });
 
         describe('connected', function () {
@@ -912,6 +929,27 @@ describe('Remote Frame Buffer Protocol Client', function() {
                 expect(spy.args[0].length).to.equal(1);
             });
         });
+
+        describe('connectionState getter', function () {
+            var client;
+            beforeEach(function () {
+                client = new RFB(document.createElement('div'), 'ws://HOST:8675/PATH');
+            });
+
+            it('should get the internal connection state', function () {
+                client._rfb_connection_state = 'connecting';
+                client._updateConnectionState('connected');
+                var state = client.connectionState;
+                expect(state).to.equal('connected');
+            });
+
+            it('should disallow manually changing the state', function () {
+                client._rfb_connection_state = 'connecting';
+                client.connectionState = 'connected';
+                var state = client.connectionState;
+                expect(state).to.equal('connecting');
+            });
+        });        
     });
 
     describe('Protocol Initialization States', function () {


### PR DESCRIPTION
**This is a:** feature

**What does it change:**
- `RFB.prototype.connectionState` can be used to get, but not set, `_rfb_connection_state`
- A `CustomEvent` is dispatched when state is updated to `connecting`.
- Adds tests for both

**Why?**

Getter: through public properties/methods, there does not seem to be a direct way of telling what the state of the connection is at any given moment. Being able to get the value on request enables custom UI behavior based on the precise state without hacking into the internal API.

"Connecting" event: as the 'disconnect' and 'connect' events are surely perceived to be useful by most contributors/users of this library, surely 'connecting' is valuable as well, as that event can be used to display custom progress indicators and the like.