### PR TITLE
Optionally read path from cookie

### DIFF
--- a/vnc_lite.html
+++ b/vnc_lite.html
@@ -187,7 +187,11 @@
         }
 
         var password = WebUtil.getConfigVar('password', '');
-        var path = WebUtil.getConfigVar('path', 'websockify');
+        
+        var path = WebUtil.getConfigVar('path', null);
+        if (!path) {
+            path = WebUtil.readCookie('noVNC_setting_path', 'websockify');
+        }
 
         // If a token variable is passed in, set the parameter in a cookie.
         // This is used by nova-novncproxy.


### PR DESCRIPTION
Permit a server to set a fallback path to the websocket without altering the URL via query string or hash fragment. The cookie takes least precedence and is named following the convention of the input id in vnc.html.