### PR TITLE
Prefix websocket path with server path

### DIFF
--- a/vnc_lite.html
+++ b/vnc_lite.html
@@ -201,7 +201,7 @@
                 defaultPath = pathName + '/websockify';
             }
         }
-        var path = WebUtil.getConfigVar('path', 'websockify');
+        var path = WebUtil.getConfigVar('path', defaultPath);
 
         // If a token variable is passed in, set the parameter in a cookie.
         // This is used by nova-novncproxy.

--- a/vnc_lite.html
+++ b/vnc_lite.html
@@ -187,6 +187,20 @@
         }
 
         var password = WebUtil.getConfigVar('password', '');
+        
+        var defaultPath = 'websockify';
+        // If noVNC is not being served at the root path,
+        // prefix the default websocket path with the server path.
+        var pathName = window.location.pathname.slice(1);
+        if (pathName.length != 0) { // We are not at the root path
+            if (pathName.slice(-1) == '/') {
+                // There's a trailing slash.
+                defaultPath = pathName + 'websockify';            
+            } else {
+                // There's no trailing slash.
+                defaultPath = pathName + '/websockify';
+            }
+        }
         var path = WebUtil.getConfigVar('path', 'websockify');
 
         // If a token variable is passed in, set the parameter in a cookie.


### PR DESCRIPTION
If noVNC is not served at the root path, prefix the websocket path with the server path.  This makes the path to the websocket consistent with the path to all the other web assets. This is convenient so that users do not need to manually change the path setting, though they still can override it.

For example if the websockify server is at /some/sub/dir, with this patch noVNC will connect to /some/sub/dir/websockify rather than /websockify.