### PR TITLE
[optional] Use relative path for socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ recordings
 *.swp
 *~
 noVNC-*.tgz
+.idea/

--- a/app/ui.js
+++ b/app/ui.js
@@ -161,7 +161,9 @@ const UI = {
         UI.initSetting('resize', 'off');
         UI.initSetting('shared', true);
         UI.initSetting('view_only', false);
-        UI.initSetting('path', 'websockify');
+
+        let socketUrl = (window.location.pathname || '').replace(/\/[\w\.]+$/, '/websockify');
+        UI.initSetting('path', socketUrl || '/websockify');
         UI.initSetting('repeaterID', '');
         UI.initSetting('reconnect', false);
         UI.initSetting('reconnect_delay', 5000);
@@ -1012,7 +1014,7 @@ const UI = {
         if(port) {
             url += ':' + port;
         }
-        url += '/' + path;
+        url += path;
 
         UI.rfb = new RFB(document.getElementById('noVNC_container'), url,
                          { shared: UI.getSetting('shared'),

--- a/app/ui.js
+++ b/app/ui.js
@@ -162,7 +162,7 @@ const UI = {
         UI.initSetting('shared', true);
         UI.initSetting('view_only', false);
 
-        let socketUrl = (window.location.pathname || '').replace(/\/[\w\.]+$/, '/websockify');
+        let socketUrl = (window.location.pathname || '/').replace(/\/([^/]+)?$/, '/websockify');
         UI.initSetting('path', socketUrl || '/websockify');
         UI.initSetting('repeaterID', '');
         UI.initSetting('reconnect', false);


### PR DESCRIPTION
In out case we run multiple novnc instances and this is looks like:
`server/pc1/vnc.html`
`server/pc2/vnc.html`

And i had a problem yesterday that socket trying to connect to `server/websock` instead of `server/pc1/websock`, that is correct in my case.

I see that you already have issue like this. This code should handle both cases.