### PR TITLE
Fixes #1075 by removing dependencies on external tools

### DIFF
--- a/utils/launch.sh
+++ b/utils/launch.sh
@@ -70,11 +70,14 @@ while [ "$*" ]; do
 done
 
 # Sanity checks
-which netstat >/dev/null 2>&1 \
-    || die "Must have netstat installed"
-
-netstat -ltn | grep -qs ":${PORT} .*LISTEN" \
-    && die "Port ${PORT} in use. Try --listen PORT"
+if bash -c "exec 7<>/dev/tcp/localhost/${PORT}" &> /dev/null; then
+    exec 7<&-
+    exec 7>&-
+    die "Port ${PORT} in use. Try --listen PORT"
+else
+    exec 7<&-
+    exec 7>&-
+fi
 
 trap "cleanup" TERM QUIT INT EXIT
 


### PR DESCRIPTION

Fixes #1075 

Small issue but if you're going to do something you might as well avoid using deprecated tools :do_not_litter: 

Rather than trying to pick a utility, we should be able to just use bash to check if a port is available or not.

We can probably assume bash is available due to the shebang declaring it.

I've tested this on Red Hat 7, Fedora 27, Ubuntu 16.04 and Debian 9 with the version of bash from the default repos.

I can't test this on a mac, so someone might want to double check that.