### PR TITLE
Handle fractional screen sizes

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -168,6 +168,9 @@ export default class Display {
             height = this._fb_height;
         }
 
+        width = Math.floor(width);
+        height = Math.floor(height);
+
         if (width > this._fb_width) {
             width = this._fb_width;
         }
@@ -524,8 +527,8 @@ export default class Display {
         //                   style width to a number, the canvas is cleared.
         //                   However, if you set the style width to a string
         //                   ('NNNpx'), the canvas is scaled without clearing.
-        const width = Math.round(factor * vp.w) + 'px';
-        const height = Math.round(factor * vp.h) + 'px';
+        const width = factor * vp.w + 'px';
+        const height = factor * vp.h + 'px';
 
         if ((this._target.style.width !== width) ||
             (this._target.style.height !== height)) {

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -546,7 +546,8 @@ export default class RFB extends EventTargetMixin {
         }
 
         const size = this._screenSize();
-        RFB.messages.setDesktopSize(this._sock, size.w, size.h,
+        RFB.messages.setDesktopSize(this._sock,
+                                    Math.floor(size.w), Math.floor(size.h),
                                     this._screen_id, this._screen_flags);
 
         Log.Debug('Requested new desktop size: ' +
@@ -555,8 +556,8 @@ export default class RFB extends EventTargetMixin {
 
     // Gets the the size of the available screen
     _screenSize() {
-        return { w: this._screen.offsetWidth,
-                 h: this._screen.offsetHeight };
+        let r = this._screen.getBoundingClientRect();
+        return { w: r.width, h: r.height };
     }
 
     _fixScrollbars() {

--- a/tests/test.mouse.js
+++ b/tests/test.mouse.js
@@ -5,12 +5,23 @@ import Mouse from '../core/input/mouse.js';
 describe('Mouse Event Handling', function() {
     "use strict";
 
-    // This function is only used on target (the canvas)
-    // and for these tests we can assume that the canvas is 100x100
-    // located at coordinates 10x10
-    sinon.stub(Element.prototype, 'getBoundingClientRect').returns(
-        {left: 10, right: 110, top: 10, bottom: 110, width: 100, height: 100});
-    const target = document.createElement('canvas');
+    let target;
+
+    beforeEach(function () {
+        // For these tests we can assume that the canvas is 100x100
+        // located at coordinates 10x10
+        target = document.createElement('canvas');
+        target.style.position = "absolute";
+        target.style.top = "10px";
+        target.style.left = "10px";
+        target.style.width = "100px";
+        target.style.height = "100px";
+        document.body.appendChild(target);
+    });
+    afterEach(function () {
+        document.body.removeChild(target);
+        target = null;
+    });
 
     // The real constructors might not work everywhere we
     // want to run these tests


### PR DESCRIPTION
With high DPI systems we can end up with a container with a size that
is not an integer number of CSS pixels. Make sure we can handle those
cases by allowing a fractional size for the output canvas. Framebuffer
size and viewport coordinates are still restricted to integer dimensions
though.

Based on initial patch by Alexander E. Patrakov.

Fixes #1111.

More testing is needed. I don't have access to a full set of browsers right now.