### PR TITLE
Fix test playback

### DIFF
--- a/tests/playback.js
+++ b/tests/playback.js
@@ -89,18 +89,18 @@ export default class RecordingPlayer {
         this._trafficManagement = (trafficManagement === undefined) ? !realtime : trafficManagement;
 
         this._running = true;
-
-        this._queueNextPacket();
     }
 
     // _enablePlaybackMode mocks out things not required for running playback
     _enablePlaybackMode() {
+        const self = this;
         this._rfb._sock.send = () => {};
         this._rfb._sock.close = () => {};
         this._rfb._sock.flush = () => {};
         this._rfb._sock.open = function () {
             this.init();
             this._eventHandlers.open();
+            self._queueNextPacket();
         };
     }
 

--- a/tests/vnc_playback.html
+++ b/tests/vnc_playback.html
@@ -2,8 +2,22 @@
 <html>
     <head>
         <title>VNC Playback</title>
-        <script src="/vendor/browser-es-module-loader/dist/browser-es-module-loader.js"></script>
-        <script type="module" src="./playback.js"></script>
+        <!-- promise polyfills promises for IE11 -->
+        <script src="../vendor/promise.js"></script>
+        <!-- ES2015/ES6 modules polyfill -->
+        <script type="module">
+            window._noVNC_has_module_support = true;
+        </script>
+        <script>
+            window.addEventListener("load", function() {
+                if (window._noVNC_has_module_support) return;
+                var loader = document.createElement("script");
+                loader.src = "vendor/browser-es-module-loader/dist/browser-es-module-loader.js";
+                document.head.appendChild(loader);
+            });
+        </script>
+        <!-- actual script modules -->
+        <script type="module" src="./playback-ui.js"></script>
     </head>
     <body>
 

--- a/tests/vnc_playback.html
+++ b/tests/vnc_playback.html
@@ -12,7 +12,7 @@
             window.addEventListener("load", function() {
                 if (window._noVNC_has_module_support) return;
                 var loader = document.createElement("script");
-                loader.src = "vendor/browser-es-module-loader/dist/browser-es-module-loader.js";
+                loader.src = "../vendor/browser-es-module-loader/dist/browser-es-module-loader.js";
                 document.head.appendChild(loader);
             });
         </script>

--- a/utils/launch.sh
+++ b/utils/launch.sh
@@ -24,6 +24,8 @@ usage() {
     echo "                          Default: ./"
     echo "    --ssl-only            Disable non-https connections."
     echo "                                    "
+    echo "    --record FILE         Record traffic to FILE.session.js"
+    echo "                                    "
     exit 2
 }
 
@@ -36,6 +38,7 @@ CERT=""
 WEB=""
 proxy_pid=""
 SSLONLY=""
+RECORD_ARG=""
 
 die() {
     echo "$*"
@@ -63,6 +66,7 @@ while [ "$*" ]; do
     --cert)    CERT="${OPTARG}"; shift            ;;
     --web)     WEB="${OPTARG}"; shift            ;;
     --ssl-only) SSLONLY="--ssl-only"             ;;
+    --record) RECORD_ARG="--record ${OPTARG}"; shift ;;
     -h|--help) usage                              ;;
     -*) usage "Unknown chrooter option: ${param}" ;;
     *) break                                      ;;
@@ -145,7 +149,7 @@ fi
 
 echo "Starting webserver and WebSockets proxy on port ${PORT}"
 #${HERE}/websockify --web ${WEB} ${CERT:+--cert ${CERT}} ${PORT} ${VNC_DEST} &
-${WEBSOCKIFY} ${SSLONLY} --web ${WEB} ${CERT:+--cert ${CERT}} ${PORT} ${VNC_DEST} &
+${WEBSOCKIFY} ${SSLONLY} --web ${WEB} ${CERT:+--cert ${CERT}} ${PORT} ${VNC_DEST} ${RECORD_ARG} &
 proxy_pid="$!"
 sleep 1
 if ! ps -p ${proxy_pid} >/dev/null; then


### PR DESCRIPTION
This fixes playback.js, which got broken somewhere along the way during the refactors.  It also adds the ability to pass `--record` through `utils/launch.sh` to websockify, for easier recording for test purposes.