### PR TITLE
Turn off view drag when scaling

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1278,16 +1278,7 @@ const UI = {
     toggleViewDrag() {
         if (!UI.rfb) return;
 
-        const drag = UI.rfb.dragViewport;
-        UI.setViewDrag(!drag);
-     },
-
-    // Set the view drag mode which moves the viewport on mouse drags
-    setViewDrag(drag) {
-        if (!UI.rfb) return;
-
-        UI.rfb.dragViewport = drag;
-
+        UI.rfb.dragViewport = !UI.rfb.dragViewport;
         UI.updateViewDrag();
     },
 

--- a/app/ui.js
+++ b/app/ui.js
@@ -432,11 +432,7 @@ const UI = {
             UI.keepControlbar();
         }
 
-        // State change disables viewport dragging.
-        // It is enabled (toggled) by direct click on the button
-        UI.setViewDrag(false);
-
-        // State change also closes the password dialog
+        // State change closes the password dialog
         document.getElementById('noVNC_password_dlg')
             .classList.remove('noVNC_open');
     },
@@ -1204,7 +1200,6 @@ const UI = {
                 document.body.msRequestFullscreen();
             }
         }
-        UI.enableDisableViewClip();
         UI.updateFullscreenButton();
     },
 


### PR DESCRIPTION
If viewport drag was active when turning on scaling it wasn't disabled. Since drag isn't allowed (or useful) when scaling, we have to remember to disable it. Fixes #1110.

Also did some code cleanup.