### PR TITLE
Passive  listeners, Touch devices

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -257,27 +257,28 @@ var UI = {
 
         document.documentElement
             .addEventListener('mousedown', UI.keepVirtualKeyboard, true);
-
+        
+        // passive event listeners won't call preventDefault() to disable scrolling
         document.getElementById("noVNC_control_bar")
-            .addEventListener('touchstart', UI.activateControlbar);
+            .addEventListener('touchstart', UI.activateControlbar, {passive: true});
         document.getElementById("noVNC_control_bar")
-            .addEventListener('touchmove', UI.activateControlbar);
+            .addEventListener('touchmove', UI.activateControlbar, {passive: true});
         document.getElementById("noVNC_control_bar")
             .addEventListener('touchend', UI.activateControlbar);
         document.getElementById("noVNC_control_bar")
             .addEventListener('input', UI.activateControlbar);
 
         document.getElementById("noVNC_control_bar")
-            .addEventListener('touchstart', UI.keepControlbar);
+            .addEventListener('touchstart', UI.keepControlbar, {passive: true});
         document.getElementById("noVNC_control_bar")
             .addEventListener('input', UI.keepControlbar);
 
         document.getElementById("noVNC_control_bar_handle")
-            .addEventListener('touchstart', UI.controlbarHandleMouseDown);
+            .addEventListener('touchstart', UI.controlbarHandleMouseDown, {passive: true});
         document.getElementById("noVNC_control_bar_handle")
             .addEventListener('touchend', UI.controlbarHandleMouseUp);
         document.getElementById("noVNC_control_bar_handle")
-            .addEventListener('touchmove', UI.dragControlbarHandle);
+            .addEventListener('touchmove', UI.dragControlbarHandle, {passive: true});
     },
 
     addExtraKeysHandlers: function() {


### PR DESCRIPTION
The touch move events need to block the call to preventDefault (), for a better touch response, the delay in scrolling could improve up to 300 [ms], the test was done on Ipad Air 2 with the audit function of Chrome.

With `{passive: true}` touch and wheel listeners, the Developers promises not to call preventDefault () to disable scrolling.

[more info Passive Listeners](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md)