### PR TITLE
Change copyright header

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,13 @@
+maintainers:
+- Joel Martin (@kanaka)
+- Solly Ross (@directxman12)
+- Samuel Mannehed for Cendio AB (@samhed)
+- Pierre Ossman for Cendio AB (@CendioOssman)
+maintainersEmeritus:
+- @astrand 
+contributors:
+# There are a bunch of people that should be here.
+# If you want to be on this list, feel free send a PR
+# to add yourself.
+- jalf <git@jalf.dk>
+- NTT corp.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,5 @@
-noVNC is Copyright (C) 2011 Joel Martin <github@martintribe.org>
+noVNC is Copyright (C) 2018 The noVNC Authors
+(https://github.com/novnc/noVNC/blob/master/AUTHORS)
 
 The noVNC core library files are licensed under the MPL 2.0 (Mozilla
 Public License 2.0). The noVNC core library is composed of the

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 noVNC is Copyright (C) 2018 The noVNC Authors
-(https://github.com/novnc/noVNC/blob/master/AUTHORS)
+(./AUTHORS)
 
 The noVNC core library files are licensed under the MPL 2.0 (Mozilla
 Public License 2.0). The noVNC core library is composed of the

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ or deploying the noVNC application in production environments:
 
 ### Authors/Contributors
 
+See [AUTHORS](AUTHORS) for a (full-ish) list of authors.  If you're not on
+that list and you think you should be, feel free to send a PR to fix that.
+
 * Core team:
     * [Joel Martin](https://github.com/kanaka)
     * [Samuel Mannehed](https://github.com/samhed) (Cendio)

--- a/app/localization.js
+++ b/app/localization.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2012 Joel Martin
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.

--- a/app/styles/base.css
+++ b/app/styles/base.css
@@ -1,8 +1,6 @@
 /*
  * noVNC base CSS
- * Copyright (C) 2012 Joel Martin
- * Copyright (C) 2016 Samuel Mannehed for Cendio AB
- * Copyright (C) 2016 Pierre Ossman for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * noVNC is licensed under the MPL 2.0 (see LICENSE.txt)
  * This file is licensed under the 2-Clause BSD license (see LICENSE.txt).
  */

--- a/app/ui.js
+++ b/app/ui.js
@@ -1,8 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2012 Joel Martin
- * Copyright (C) 2018 Samuel Mannehed for Cendio AB
- * Copyright (C) 2016 Pierre Ossman for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.

--- a/app/webutil.js
+++ b/app/webutil.js
@@ -1,7 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2012 Joel Martin
- * Copyright (C) 2013 NTT corp.
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.

--- a/core/display.js
+++ b/core/display.js
@@ -1,7 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2012 Joel Martin
- * Copyright (C) 2015 Samuel Mannehed for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.

--- a/core/encodings.js
+++ b/core/encodings.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2017 Pierre Ossman for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.

--- a/core/input/domkeytable.js
+++ b/core/input/domkeytable.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2017 Pierre Ossman for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 

--- a/core/input/fixedkeys.js
+++ b/core/input/fixedkeys.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2017 Pierre Ossman for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 

--- a/core/input/keyboard.js
+++ b/core/input/keyboard.js
@@ -1,7 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2012 Joel Martin
- * Copyright (C) 2013 Samuel Mannehed for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 

--- a/core/input/mouse.js
+++ b/core/input/mouse.js
@@ -1,7 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2012 Joel Martin
- * Copyright (C) 2013 Samuel Mannehed for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 

--- a/core/input/vkeys.js
+++ b/core/input/vkeys.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2017 Pierre Ossman for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1,8 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2012 Joel Martin
- * Copyright (C) 2018 Samuel Mannehed for Cendio AB
- * Copyright (C) 2018 Pierre Ossman for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.

--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -1,7 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2012 Joel Martin
- * Copyright (C) 2018 Samuel Mannehed for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.

--- a/core/util/cursor.js
+++ b/core/util/cursor.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright 2018 Pierre Ossman for noVNC
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 

--- a/core/util/events.js
+++ b/core/util/events.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2012 Joel Martin
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.

--- a/core/util/eventtarget.js
+++ b/core/util/eventtarget.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright 2017 Pierre Ossman for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.

--- a/core/util/logging.js
+++ b/core/util/logging.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2012 Joel Martin
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.

--- a/core/util/polyfill.js
+++ b/core/util/polyfill.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright 2017 Pierre Ossman for noVNC
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 

--- a/core/util/strings.js
+++ b/core/util/strings.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2012 Joel Martin
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.

--- a/core/websock.js
+++ b/core/websock.js
@@ -1,6 +1,6 @@
 /*
  * Websock: high-performance binary WebSockets
- * Copyright (C) 2012 Joel Martin
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * Websock is similar to the standard WebSocket object but with extra

--- a/po/de.po
+++ b/po/de.po
@@ -1,6 +1,6 @@
 # German translations for noVNC package
 # German translation for noVNC.
-# Copyright (C) 2016 Various Authors
+# Copyright (C) 2018 The noVNC Authors
 # This file is distributed under the same license as the noVNC package.
 # Loek Janssen <loekjanssen@gmail.com>, 2016.
 #

--- a/po/el.po
+++ b/po/el.po
@@ -1,5 +1,5 @@
 # Greek translations for noVNC package.
-# Copyright (C) 2016 Various Authors
+# Copyright (C) 2018 The noVNC Authors
 # This file is distributed under the same license as the noVNC package.
 # Giannis Kosmas <kosmasgiannis@gmail.com>, 2016.
 #

--- a/po/es.po
+++ b/po/es.po
@@ -1,6 +1,6 @@
 # Spanish translations for noVNC package
 # Traducciones al español para el paquete noVNC.
-# Copyright (C) 2018 Various Authors
+# Copyright (C) 2018 The noVNC Authors
 # This file is distributed under the same license as the noVNC package.
 # Juanjo Diaz <juanjo.diazmo@gmail.com>, 2018.
 #

--- a/po/nl.po
+++ b/po/nl.po
@@ -1,6 +1,6 @@
 # Dutch translations for noVNC package
 # Nederlandse vertalingen voor het pakket noVNC.
-# Copyright (C) 2016 Various Authors
+# Copyright (C) 2018 The noVNC Authors
 # This file is distributed under the same license as the noVNC package.
 # Loek Janssen <loekjanssen@gmail.com>, 2016.
 #

--- a/po/noVNC.pot
+++ b/po/noVNC.pot
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Various Authors
+# Copyright (C) YEAR The noVNC Authors
 # This file is distributed under the same license as the noVNC package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,5 +1,5 @@
 # Polish translations for noVNC package.
-# Copyright (C) 2017 Various Authors
+# Copyright (C) 2018 The noVNC Authors
 # This file is distributed under the same license as the noVNC package.
 # Mariusz Jamro <mariusz.jamro@gmail.com>, 2017.
 #

--- a/po/po2js
+++ b/po/po2js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
  * ps2js: gettext .po to noVNC .js converter
- * Copyright (C) 2016 Pierre Ossman
+ * Copyright (C) 2018 The noVNC Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,6 +1,6 @@
 # Swedish translations for noVNC package
 # Svenska översättningar för paket noVNC.
-# Copyright (C) 2016 Various Authors
+# Copyright (C) 2018 The noVNC Authors
 # This file is distributed under the same license as the noVNC package.
 # Samuel Mannehed <samuel@cendio.se>, 2016.
 #

--- a/po/tr.po
+++ b/po/tr.po
@@ -1,6 +1,6 @@
 # Turkish translations for noVNC package
 # Turkish translation for noVNC.
-# Copyright (C) 2016 Various Authors
+# Copyright (C) 2018 The noVNC Authors
 # This file is distributed under the same license as the noVNC package.
 # Ömer ÇAKMAK <farukomercakmak@gmail.com>, 2018.
 #

--- a/po/xgettext-html
+++ b/po/xgettext-html
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /*
  * xgettext-html: HTML gettext parser
- * Copyright (C) 2016 Pierre Ossman
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  */
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,5 +1,5 @@
 # Simplified Chinese translations for noVNC package.
-# Copyright (C) 2018 Various Authors
+# Copyright (C) 2018 The noVNC Authors
 # This file is distributed under the same license as the noVNC package.
 # Peter Dave Hello <hsu@peterdavehello.org>, 2018.
 #

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1,5 +1,5 @@
 # Traditional Chinese translations for noVNC package.
-# Copyright (C) 2018 Various Authors
+# Copyright (C) 2018 The noVNC Authors
 # This file is distributed under the same license as the noVNC package.
 # Peter Dave Hello <hsu@peterdavehello.org>, 2018.
 #

--- a/tests/playback.js
+++ b/tests/playback.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2012 Joel Martin
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  */
 

--- a/utils/genkeysymdef.js
+++ b/utils/genkeysymdef.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 /*
  * genkeysymdef: X11 keysymdef.h to JavaScript converter
- * Copyright 2013 jalf <git@jalf.dk>
- * Copyright 2017 Pierre Ossman for Cendio AB
+ * Copyright (C) 2018 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  */
 

--- a/utils/img2js.py
+++ b/utils/img2js.py
@@ -2,7 +2,7 @@
 
 #
 # Convert image to Javascript compatible base64 Data URI
-# Copyright 2011 Joel Martin
+# Copyright (C) 2018 The noVNC Authors
 # Licensed under MPL 2.0 (see docs/LICENSE.MPL-2.0)
 #
 

--- a/utils/json2graph.py
+++ b/utils/json2graph.py
@@ -2,7 +2,7 @@
 
 '''
 Use matplotlib to generate performance charts
-Copyright 2011 Joel Martin
+Copyright (C) 2018 The noVNC Authors
 Licensed under MPL-2.0 (see docs/LICENSE.MPL-2.0)
 '''
 

--- a/utils/launch.sh
+++ b/utils/launch.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2016 Joel Martin
-# Copyright 2016 Solly Ross
+# Copyright (C) 2018 The noVNC Authors
 # Licensed under MPL 2.0 or any later version (see LICENSE.txt)
 
 usage() {

--- a/vnc.html
+++ b/vnc.html
@@ -4,9 +4,7 @@
 
     <!--
     noVNC example: simple example using default UI
-    Copyright (C) 2012 Joel Martin
-    Copyright (C) 2016 Samuel Mannehed for Cendio AB
-    Copyright (C) 2016 Pierre Ossman for Cendio AB
+    Copyright (C) 2018 The noVNC Authors
     noVNC is licensed under the MPL 2.0 (see LICENSE.txt)
     This file is licensed under the 2-Clause BSD license (see LICENSE.txt).
 

--- a/vnc_lite.html
+++ b/vnc_lite.html
@@ -7,8 +7,7 @@
 
     This is a self-contained file which doesn't import WebUtil or external CSS.
 
-    Copyright (C) 2012 Joel Martin
-    Copyright (C) 2018 Samuel Mannehed for Cendio AB
+    Copyright (C) 2018 The noVNC Authors
     noVNC is licensed under the MPL 2.0 (see LICENSE.txt)
     This file is licensed under the 2-Clause BSD license (see LICENSE.txt).
 


### PR DESCRIPTION
This updates the copyright header to say "The noVNC Authors".  People
who previously had copyright listings are now under the AUTHORS file.

Closes #674 