### PR TITLE
Use `new` when constructing errors

### DIFF
--- a/core/decoders/hextile.js
+++ b/core/decoders/hextile.js
@@ -37,7 +37,7 @@ export default class HextileDecoder {
 
             let subencoding = rQ[rQi];  // Peek
             if (subencoding > 30) {  // Raw
-                throw Error("Illegal hextile subencoding (subencoding: " +
+                throw new Error("Illegal hextile subencoding (subencoding: " +
                             subencoding + ")");
             }
 

--- a/core/decoders/tight.js
+++ b/core/decoders/tight.js
@@ -62,7 +62,7 @@ export default class TightDecoder {
             ret = this._basicRect(this._ctl, x, y, width, height,
                                   sock, display, depth);
         } else {
-            throw Error("Illegal tight compression received (ctl: " +
+            throw new Error("Illegal tight compression received (ctl: " +
                                    this._ctl + ")");
         }
 
@@ -100,7 +100,7 @@ export default class TightDecoder {
     }
 
     _pngRect(x, y, width, height, sock, display, depth) {
-        throw Error("PNG received in standard Tight rect");
+        throw new Error("PNG received in standard Tight rect");
     }
 
     _basicRect(ctl, x, y, width, height, sock, display, depth) {
@@ -135,7 +135,7 @@ export default class TightDecoder {
                                            sock, display, depth);
                 break;
             default:
-                throw Error("Illegal tight filter received (ctl: " +
+                throw new Error("Illegal tight filter received (ctl: " +
                                        this._filter + ")");
         }
 
@@ -164,7 +164,7 @@ export default class TightDecoder {
 
             data = this._zlibs[streamId].inflate(data, true, uncompressedSize);
             if (data.length != uncompressedSize) {
-                throw Error("Incomplete zlib block");
+                throw new Error("Incomplete zlib block");
             }
         }
 
@@ -212,7 +212,7 @@ export default class TightDecoder {
 
             data = this._zlibs[streamId].inflate(data, true, uncompressedSize);
             if (data.length != uncompressedSize) {
-                throw Error("Incomplete zlib block");
+                throw new Error("Incomplete zlib block");
             }
         }
 
@@ -277,7 +277,7 @@ export default class TightDecoder {
     }
 
     _gradientFilter(streamId, x, y, width, height, sock, display, depth) {
-        throw Error("Gradient filter not implemented");
+        throw new Error("Gradient filter not implemented");
     }
 
     _readData(sock) {

--- a/core/decoders/tightpng.js
+++ b/core/decoders/tightpng.js
@@ -24,6 +24,6 @@ export default class TightPNGDecoder extends TightDecoder {
     }
 
     _basicRect(ctl, x, y, width, height, sock, display, depth) {
-        throw Error("BasicCompression received in TightPNG rect");
+        throw new Error("BasicCompression received in TightPNG rect");
     }
 }

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -35,10 +35,10 @@ const DISCONNECT_TIMEOUT = 3;
 export default class RFB extends EventTargetMixin {
     constructor(target, url, options) {
         if (!target) {
-            throw Error("Must specify target");
+            throw new Error("Must specify target");
         }
         if (!url) {
-            throw Error("Must specify URL");
+            throw new Error("Must specify URL");
         }
 
         super();


### PR DESCRIPTION
It's not too relevant since both should work the same according to the spec. However, I think that's good to be consistent.