### PR TITLE
Enable scrollbars for all touch devices aside from Android and iOS

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -8,7 +8,8 @@
 
 import * as Log from '../core/util/logging.js';
 import _, { l10n } from './localization.js';
-import { isTouchDevice, isSafari, dragThreshold } from '../core/util/browser.js';
+import { isTouchDevice, isSafari, isIOS, isAndroid, dragThreshold }
+    from '../core/util/browser.js';
 import { setCapture, getPointerEvent } from '../core/util/events.js';
 import KeyTable from "../core/input/keysym.js";
 import keysyms from "../core/input/keysymdef.js";
@@ -1243,8 +1244,8 @@ const UI = {
             // Can't be clipping if viewport is scaled to fit
             UI.forceSetting('view_clip', false);
             UI.rfb.clipViewport  = false;
-        } else if (isTouchDevice) {
-            // Touch devices usually have shit scrollbars
+        } else if (isIOS() || isAndroid()) {
+            // iOS and Android usually have shit scrollbars
             UI.forceSetting('view_clip', true);
             UI.rfb.clipViewport = true;
         } else {

--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -64,6 +64,10 @@ export function isIOS() {
             !!(/ipod/i).exec(navigator.platform));
 }
 
+export function isAndroid() {
+    return navigator && !!(/android/i).exec(navigator.userAgent);
+}
+
 export function isSafari() {
     return navigator && (navigator.userAgent.indexOf('Safari') !== -1 &&
                          navigator.userAgent.indexOf('Chrome') === -1);


### PR DESCRIPTION
Instead of forcing "clip to window" for all touch devices, we only do it for Android and iOS devices instead. This is where the scrollbars are bad.

This allows users on, for example, Windows with touch to still use scroll bars.

This PR should fix issue #1172