### PR TITLE
Add a callback to web socket open event handler

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -184,14 +184,14 @@ export default class RFB extends EventTargetMixin {
         this._sock.on('message', this._handle_message.bind(this));
         this._sock.on('open', () => {
             if (typeof options.onSocketOpen === "function") {
-                let result;
+                let errorDescription;
                 try {
-                    result = options.onSocketOpen(this._sock._websocket);
+                    errorDescription = options.onSocketOpen(this._sock._websocket);
                 } catch (e) {
                     return this._fail("onSocketOpen callback failed: " + e.stack);
                 }
-                if (result) {
-                    return this._fail("onSocketOpen callback failed: " + result);
+                if (errorDescription) {
+                    return this._fail("onSocketOpen callback failed: " + errorDescription);
                 }
             }
 

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -190,8 +190,8 @@ export default class RFB extends EventTargetMixin {
                 } catch (e) {
                     return this._fail("onSocketOpen callback failed: " + e.stack);
                 }
-                if (!result) {
-                    return this._fail("onSocketOpen callback did not pass");
+                if (result) {
+                    return this._fail("onSocketOpen callback failed: " + result);
                 }
             }
 

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -183,6 +183,18 @@ export default class RFB extends EventTargetMixin {
         this._sock = new Websock();
         this._sock.on('message', this._handle_message.bind(this));
         this._sock.on('open', () => {
+            if (typeof options.onSocketOpen === "function") {
+                let result;
+                try {
+                    result = options.onSocketOpen(this._sock._websocket);
+                } catch (e) {
+                    return this._fail("onSocketOpen callback failed: " + e.stack);
+                }
+                if (!result) {
+                    return this._fail("onSocketOpen callback did not pass");
+                }
+            }
+
             if ((this._rfb_connection_state === 'connecting') &&
                 (this._rfb_init_state === '')) {
                 this._rfb_init_state = 'ProtocolVersion';

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -183,22 +183,13 @@ export default class RFB extends EventTargetMixin {
         this._sock = new Websock();
         this._sock.on('message', this._handle_message.bind(this));
         this._sock.on('open', () => {
-            if (typeof options.onSocketOpen === "function") {
-                let errorDescription;
-                try {
-                    errorDescription = options.onSocketOpen(this._sock._websocket);
-                } catch (e) {
-                    return this._fail("onSocketOpen callback failed: " + e.stack);
-                }
-                if (errorDescription) {
-                    return this._fail("onSocketOpen callback failed: " + errorDescription);
-                }
-            }
-
             if ((this._rfb_connection_state === 'connecting') &&
                 (this._rfb_init_state === '')) {
                 this._rfb_init_state = 'ProtocolVersion';
                 Log.Debug("Starting VNC handshake");
+                if (!this.dispatchEvent({type: 'webSocketOpen', ws: this._sock._websocket})) {
+                    return this._fail("webSocketOpen event handler has prevented the further execution");
+                }
             } else {
                 this._fail("Unexpected server connection while " +
                            this._rfb_connection_state);

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -1408,8 +1408,8 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 expect(client._sock).to.have.sent(new Uint8Array([0]));
             });
 
-            it('should fail if onSocketOpen callback returns false', function () {
-                const rfb = new RFB(container, 'wss://host:8675', { onSocketOpen: () => false });
+            it('should fail if onSocketOpen callback returns a failure description', function () {
+                const rfb = new RFB(container, 'wss://host:8675', { onSocketOpen: () => 'Something went wrong' });
                 clock.tick();
                 sinon.spy(rfb, "_fail");
                 rfb._sock._websocket._open();
@@ -1427,7 +1427,6 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should pass if onSocketOpen callback succeeds', function () {
                 const client = make_rfb('wss://host:8675', { onSocketOpen: (ws) => {
                     expect(!!ws).to.be.true;
-                    return true;
                 }});
                 client._rfb_connection_state = 'connecting';
                 client._rfb_init_state = 'SecurityResult';


### PR DESCRIPTION
Such callback might be useful in case one wants to add an additional security layer to the WebSocket communication