### PR TITLE
Add a public getter for the _screen property

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -302,6 +302,8 @@ export default class RFB extends EventTargetMixin {
         this._refreshCursor();
     }
 
+    get screen() { return this._screen; }
+
     // ===== PUBLIC METHODS =====
 
     disconnect() {


### PR DESCRIPTION
The `_screen` property defines a set of hardcoded css properties. By having this accessor we could easily customise them and/or assign new if needed.