### PR TITLE
Add support for custom logger

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -6,7 +6,7 @@
  * See README.md for usage and integration instructions.
  */
 
-import * as Log from '../core/util/logging.js';
+import { ConsoleLogger, Log } from '../core/util/logging.js';
 import _, { l10n } from './localization.js';
 import { isTouchDevice, isSafari, isIOS, isAndroid, dragThreshold }
     from '../core/util/browser.js';
@@ -1602,7 +1602,10 @@ const UI = {
     },
 
     updateLogging() {
-        WebUtil.init_logging(UI.getSetting('logging'));
+        const param = UI.getSetting('logging')
+            || document.location.href.match(/logging=([A-Za-z0-9._-]*)/)
+            || undefined;
+        RFB.setLogger(new ConsoleLogger(param));
     },
 
     updateDesktopName(e) {

--- a/app/ui.js
+++ b/app/ui.js
@@ -6,7 +6,7 @@
  * See README.md for usage and integration instructions.
  */
 
-import { ConsoleLogger, Log } from '../core/util/logging.js';
+import { ConsoleLogger, log } from '../core/util/logging.js';
 import _, { l10n } from './localization.js';
 import { isTouchDevice, isSafari, isIOS, isAndroid, dragThreshold }
     from '../core/util/browser.js';
@@ -401,7 +401,7 @@ const UI = {
                 document.documentElement.classList.add("noVNC_reconnecting");
                 break;
             default:
-                Log.Error("Invalid visual state: " + state);
+                log.error("Invalid visual state: " + state);
                 UI.showStatus(_("Internal error"), 'error');
                 return;
         }
@@ -765,7 +765,7 @@ const UI = {
             val = ctrl.value;
         }
         WebUtil.writeSetting(name, val);
-        //Log.Debug("Setting saved '" + name + "=" + val + "'");
+        //log.debug("Setting saved '" + name + "=" + val + "'");
         return val;
     },
 
@@ -935,9 +935,9 @@ const UI = {
     },
 
     clipboardReceive(e) {
-        Log.Debug(">> UI.clipboardReceive: " + e.detail.text.substr(0, 40) + "...");
+        log.debug(">> UI.clipboardReceive: " + e.detail.text.substr(0, 40) + "...");
         document.getElementById('noVNC_clipboard_text').value = e.detail.text;
-        Log.Debug("<< UI.clipboardReceive");
+        log.debug("<< UI.clipboardReceive");
     },
 
     clipboardClear() {
@@ -947,9 +947,9 @@ const UI = {
 
     clipboardSend() {
         const text = document.getElementById('noVNC_clipboard_text').value;
-        Log.Debug(">> UI.clipboardSend: " + text.substr(0, 40) + "...");
+        log.debug(">> UI.clipboardSend: " + text.substr(0, 40) + "...");
         UI.rfb.clipboardPasteFrom(text);
-        Log.Debug("<< UI.clipboardSend");
+        log.debug("<< UI.clipboardSend");
     },
 
 /* ------^-------
@@ -991,7 +991,7 @@ const UI = {
         UI.hideStatus();
 
         if (!host) {
-            Log.Error("Can't connect when host is: " + host);
+            log.error("Can't connect when host is: " + host);
             UI.showStatus(_("Must set host"), 'error');
             return;
         }
@@ -1147,7 +1147,7 @@ const UI = {
         setTimeout(() => document
             .getElementById('noVNC_password_input').focus(), 100);
 
-        Log.Warn("Server asked for a password");
+        log.warn("Server asked for a password");
         UI.showStatus(_("Password is required"), "warning");
     },
 
@@ -1625,7 +1625,7 @@ const UI = {
                         // It is common that the browsers require audio to be
                         // initiated from a user action.
                     } else {
-                        Log.Error("Unable to play bell: " + e);
+                        log.error("Unable to play bell: " + e);
                     }
                 });
             }
@@ -1656,7 +1656,7 @@ if (l10n.language !== "en" && l10n.dictionary === undefined) {
         // wait for translations to load before loading the UI
         UI.prime();
     }, (err) => {
-        Log.Error("Failed to load translations: " + err);
+        log.error("Failed to load translations: " + err);
         UI.prime();
     });
 } else {

--- a/app/webutil.js
+++ b/app/webutil.js
@@ -6,19 +6,6 @@
  * See README.md for usage and integration instructions.
  */
 
-import { init_logging as main_init_logging } from '../core/util/logging.js';
-
-// init log level reading the logging HTTP param
-export function init_logging(level) {
-    "use strict";
-    if (typeof level !== "undefined") {
-        main_init_logging(level);
-    } else {
-        const param = document.location.href.match(/logging=([A-Za-z0-9._-]*)/);
-        main_init_logging(param || undefined);
-    }
-}
-
 // Read a query string variable
 export function getQueryVar(name, defVal) {
     "use strict";

--- a/core/base64.js
+++ b/core/base64.js
@@ -4,7 +4,7 @@
 
 // From: http://hg.mozilla.org/mozilla-central/raw-file/ec10630b1a54/js/src/devtools/jint/sunspider/string-base64.js
 
-import { Log } from './util/logging.js';
+import { log } from './util/logging.js';
 
 export default {
     /* Convert data (an array of integers) to a Base64 string. */
@@ -75,7 +75,7 @@ export default {
             const padding = (data.charAt(i) === this.base64Pad);
             // Skip illegal characters and whitespace
             if (c === -1) {
-                Log.Error("Illegal character code " + data.charCodeAt(i) + " at position " + i);
+                log.error("Illegal character code " + data.charCodeAt(i) + " at position " + i);
                 continue;
             }
 

--- a/core/base64.js
+++ b/core/base64.js
@@ -4,7 +4,7 @@
 
 // From: http://hg.mozilla.org/mozilla-central/raw-file/ec10630b1a54/js/src/devtools/jint/sunspider/string-base64.js
 
-import * as Log from './util/logging.js';
+import { Log } from './util/logging.js';
 
 export default {
     /* Convert data (an array of integers) to a Base64 string. */

--- a/core/decoders/hextile.js
+++ b/core/decoders/hextile.js
@@ -9,7 +9,7 @@
  *
  */
 
-import { Log } from '../util/logging.js';
+import { log } from '../util/logging.js';
 
 export default class HextileDecoder {
     constructor() {
@@ -84,7 +84,7 @@ export default class HextileDecoder {
             if (subencoding === 0) {
                 if (this._lastsubencoding & 0x01) {
                     // Weird: ignore blanks are RAW
-                    Log.Debug("     Ignoring blank after RAW");
+                    log.debug("     Ignoring blank after RAW");
                 } else {
                     display.fillRect(tx, ty, tw, th, this._background);
                 }

--- a/core/decoders/hextile.js
+++ b/core/decoders/hextile.js
@@ -9,7 +9,7 @@
  *
  */
 
-import * as Log from '../util/logging.js';
+import { Log } from '../util/logging.js';
 
 export default class HextileDecoder {
     constructor() {

--- a/core/decoders/tight.js
+++ b/core/decoders/tight.js
@@ -10,7 +10,7 @@
  *
  */
 
-import * as Log from '../util/logging.js';
+import { Log } from '../util/logging.js';
 import Inflator from "../inflator.js";
 
 export default class TightDecoder {

--- a/core/decoders/tight.js
+++ b/core/decoders/tight.js
@@ -10,7 +10,7 @@
  *
  */
 
-import { Log } from '../util/logging.js';
+import { log } from '../util/logging.js';
 import Inflator from "../inflator.js";
 
 export default class TightDecoder {
@@ -39,7 +39,7 @@ export default class TightDecoder {
             for (let i = 0; i < 4; i++) {
                 if ((this._ctl >> i) & 1) {
                     this._zlibs[i].reset();
-                    Log.Info("Reset zlib stream " + i);
+                    log.info("Reset zlib stream " + i);
                 }
             }
 

--- a/core/display.js
+++ b/core/display.js
@@ -6,7 +6,7 @@
  * See README.md for usage and integration instructions.
  */
 
-import { Log } from './util/logging.js';
+import { log } from './util/logging.js';
 import Base64 from "./base64.js";
 
 let SUPPORTS_IMAGEDATA_CONSTRUCTOR = false;
@@ -35,7 +35,7 @@ export default class Display {
         this._tile_x = 0;
         this._tile_y = 0;
 
-        Log.Debug(">> Display.constructor");
+        log.debug(">> Display.constructor");
 
         // The visible canvas
         this._target = target;
@@ -65,7 +65,7 @@ export default class Display {
                                right: this._backbuffer.width,
                                bottom: this._backbuffer.height };
 
-        Log.Debug("User Agent: " + navigator.userAgent);
+        log.debug("User Agent: " + navigator.userAgent);
 
         this.clear();
 
@@ -75,7 +75,7 @@ export default class Display {
         }
 
         this._tile16x16 = this._drawCtx.createImageData(16, 16);
-        Log.Debug("<< Display.constructor");
+        log.debug("<< Display.constructor");
 
         // ===== PROPERTIES =====
 
@@ -146,7 +146,7 @@ export default class Display {
         if (deltaX === 0 && deltaY === 0) {
             return;
         }
-        Log.Debug("viewportChange deltaX: " + deltaX + ", deltaY: " + deltaY);
+        log.debug("viewportChange deltaX: " + deltaX + ", deltaY: " + deltaY);
 
         vp.x += deltaX;
         vp.y += deltaY;
@@ -162,7 +162,7 @@ export default class Display {
             typeof(width) === "undefined" ||
             typeof(height) === "undefined") {
 
-            Log.Debug("Setting viewport to full display region");
+            log.debug("Setting viewport to full display region");
             width = this._fb_width;
             height = this._fb_height;
         }

--- a/core/display.js
+++ b/core/display.js
@@ -6,7 +6,7 @@
  * See README.md for usage and integration instructions.
  */
 
-import * as Log from './util/logging.js';
+import { Log } from './util/logging.js';
 import Base64 from "./base64.js";
 
 let SUPPORTS_IMAGEDATA_CONSTRUCTOR = false;

--- a/core/input/keyboard.js
+++ b/core/input/keyboard.js
@@ -4,7 +4,7 @@
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 
-import * as Log from '../util/logging.js';
+import { Log } from '../util/logging.js';
 import { stopEvent } from '../util/events.js';
 import * as KeyboardUtil from "./util.js";
 import KeyTable from "./keysym.js";

--- a/core/input/keyboard.js
+++ b/core/input/keyboard.js
@@ -4,7 +4,7 @@
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 
-import { Log } from '../util/logging.js';
+import { log } from '../util/logging.js';
 import { stopEvent } from '../util/events.js';
 import * as KeyboardUtil from "./util.js";
 import KeyTable from "./keysym.js";
@@ -50,7 +50,7 @@ export default class Keyboard {
             delete this._keyDownList[code];
         }
 
-        Log.Debug("onkeyevent " + (down ? "down" : "up") +
+        log.debug("onkeyevent " + (down ? "down" : "up") +
                   ", keysym: " + keysym, ", code: " + code);
         this.onkeyevent(keysym, code, down);
     }
@@ -220,7 +220,7 @@ export default class Keyboard {
         this._pendingKey = null;
 
         if (!keysym) {
-            Log.Info('keypress with no keysym:', e);
+            log.info('keypress with no keysym:', e);
             return;
         }
 
@@ -292,11 +292,11 @@ export default class Keyboard {
     }
 
     _allKeysUp() {
-        Log.Debug(">> Keyboard.allKeysUp");
+        log.debug(">> Keyboard.allKeysUp");
         for (let code in this._keyDownList) {
             this._sendKeyEvent(this._keyDownList[code], code, false);
         }
-        Log.Debug("<< Keyboard.allKeysUp");
+        log.debug("<< Keyboard.allKeysUp");
     }
 
     // Firefox Alt workaround, see below
@@ -322,7 +322,7 @@ export default class Keyboard {
     // ===== PUBLIC METHODS =====
 
     grab() {
-        //Log.Debug(">> Keyboard.grab");
+        //log.debug(">> Keyboard.grab");
 
         this._target.addEventListener('keydown', this._eventHandlers.keydown);
         this._target.addEventListener('keyup', this._eventHandlers.keyup);
@@ -344,11 +344,11 @@ export default class Keyboard {
                                             passive: true }));
         }
 
-        //Log.Debug("<< Keyboard.grab");
+        //log.debug("<< Keyboard.grab");
     }
 
     ungrab() {
-        //Log.Debug(">> Keyboard.ungrab");
+        //log.debug(">> Keyboard.ungrab");
 
         if (browser.isWindows() && browser.isFirefox()) {
             const handler = this._eventHandlers.checkalt;
@@ -365,6 +365,6 @@ export default class Keyboard {
         // Release (key up) all keys that are in a down state
         this._allKeysUp();
 
-        //Log.Debug(">> Keyboard.ungrab");
+        //log.debug(">> Keyboard.ungrab");
     }
 }

--- a/core/input/mouse.js
+++ b/core/input/mouse.js
@@ -4,7 +4,7 @@
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 
-import { Log } from '../util/logging.js';
+import { log } from '../util/logging.js';
 import { isTouchDevice } from '../util/browser.js';
 import { setCapture, stopEvent, getPointerEvent } from '../util/events.js';
 
@@ -94,7 +94,7 @@ export default class Mouse {
                     (e.button & 0x4) / 2;   // Middle
         }
 
-        Log.Debug("onmousebutton " + (down ? "down" : "up") +
+        log.debug("onmousebutton " + (down ? "down" : "up") +
                   ", x: " + pos.x + ", y: " + pos.y + ", bmask: " + bmask);
         this.onmousebutton(pos.x, pos.y, down, bmask);
 

--- a/core/input/mouse.js
+++ b/core/input/mouse.js
@@ -4,7 +4,7 @@
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 
-import * as Log from '../util/logging.js';
+import { Log } from '../util/logging.js';
 import { isTouchDevice } from '../util/browser.js';
 import { setCapture, stopEvent, getPointerEvent } from '../util/events.js';
 

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -7,7 +7,7 @@
  *
  */
 
-import { Log, setLogger } from './util/logging.js';
+import { log, setLogger } from './util/logging.js';
 import { decodeUTF8 } from './util/strings.js';
 import { dragThreshold } from './util/browser.js';
 import EventTargetMixin from './util/eventtarget.js';
@@ -121,7 +121,7 @@ export default class RFB extends EventTargetMixin {
         };
 
         // main setup
-        Log.Debug(">> RFB.constructor");
+        log.debug(">> RFB.constructor");
 
         // Create DOM elements
         this._screen = document.createElement('div');
@@ -168,7 +168,7 @@ export default class RFB extends EventTargetMixin {
         try {
             this._display = new Display(this._canvas);
         } catch (exc) {
-            Log.Error("Display exception: " + exc);
+            log.error("Display exception: " + exc);
             throw exc;
         }
         this._display.onflush = this._onFlush.bind(this);
@@ -189,14 +189,14 @@ export default class RFB extends EventTargetMixin {
             if ((this._rfb_connection_state === 'connecting') &&
                 (this._rfb_init_state === '')) {
                 this._rfb_init_state = 'ProtocolVersion';
-                Log.Debug("Starting VNC handshake");
+                log.debug("Starting VNC handshake");
             } else {
                 this._fail("Unexpected server connection while " +
                            this._rfb_connection_state);
             }
         });
         this._sock.on('close', (e) => {
-            Log.Debug("WebSocket on-close event");
+            log.debug("WebSocket on-close event");
             let msg = "";
             if (e.code) {
                 msg = "(code: " + e.code;
@@ -229,13 +229,13 @@ export default class RFB extends EventTargetMixin {
             }
             this._sock.off('close');
         });
-        this._sock.on('error', e => Log.Warn("WebSocket on-error event"));
+        this._sock.on('error', e => log.warn("WebSocket on-error event"));
 
         // Slight delay of the actual connection so that the caller has
         // time to set up callbacks
         setTimeout(this._updateConnectionState.bind(this, 'connecting'));
 
-        Log.Debug("<< RFB.constructor");
+        log.debug("<< RFB.constructor");
 
         // ===== PROPERTIES =====
 
@@ -328,7 +328,7 @@ export default class RFB extends EventTargetMixin {
 
     sendCtrlAltDel() {
         if (this._rfb_connection_state !== 'connected' || this._viewOnly) { return; }
-        Log.Info("Sending Ctrl-Alt-Del");
+        log.info("Sending Ctrl-Alt-Del");
 
         this.sendKey(KeyTable.XK_Control_L, "ControlLeft", true);
         this.sendKey(KeyTable.XK_Alt_L, "AltLeft", true);
@@ -367,14 +367,14 @@ export default class RFB extends EventTargetMixin {
             // 0 is NoSymbol
             keysym = keysym || 0;
 
-            Log.Info("Sending key (" + (down ? "down" : "up") + "): keysym " + keysym + ", scancode " + scancode);
+            log.info("Sending key (" + (down ? "down" : "up") + "): keysym " + keysym + ", scancode " + scancode);
 
             RFB.messages.QEMUExtendedKeyEvent(this._sock, keysym, down, scancode);
         } else {
             if (!keysym) {
                 return;
             }
-            Log.Info("Sending keysym (" + (down ? "down" : "up") + "): " + keysym);
+            log.info("Sending keysym (" + (down ? "down" : "up") + "): " + keysym);
             RFB.messages.keyEvent(this._sock, keysym, down ? 1 : 0);
         }
     }
@@ -395,9 +395,9 @@ export default class RFB extends EventTargetMixin {
     // ===== PRIVATE METHODS =====
 
     _connect() {
-        Log.Debug(">> RFB.connect");
+        log.debug(">> RFB.connect");
 
-        Log.Info("connecting to " + this._url);
+        log.info("connecting to " + this._url);
 
         try {
             // WebSocket.onopen transitions to the RFB init states
@@ -424,11 +424,11 @@ export default class RFB extends EventTargetMixin {
         this._canvas.addEventListener("mousedown", this._eventHandlers.focusCanvas);
         this._canvas.addEventListener("touchstart", this._eventHandlers.focusCanvas);
 
-        Log.Debug("<< RFB.connect");
+        log.debug("<< RFB.connect");
     }
 
     _disconnect() {
-        Log.Debug(">> RFB.disconnect");
+        log.debug(">> RFB.disconnect");
         this._cursor.detach();
         this._canvas.removeEventListener("mousedown", this._eventHandlers.focusCanvas);
         this._canvas.removeEventListener("touchstart", this._eventHandlers.focusCanvas);
@@ -447,7 +447,7 @@ export default class RFB extends EventTargetMixin {
             }
         }
         clearTimeout(this._resizeTimeout);
-        Log.Debug("<< RFB.disconnect");
+        log.debug("<< RFB.disconnect");
     }
 
     _focusCanvas(event) {
@@ -532,7 +532,7 @@ export default class RFB extends EventTargetMixin {
                                     Math.floor(size.w), Math.floor(size.h),
                                     this._screen_id, this._screen_flags);
 
-        Log.Debug('Requested new desktop size: ' +
+        log.debug('Requested new desktop size: ' +
                    size.w + 'x' + size.h);
     }
 
@@ -565,13 +565,13 @@ export default class RFB extends EventTargetMixin {
         const oldstate = this._rfb_connection_state;
 
         if (state === oldstate) {
-            Log.Debug("Already in state '" + state + "', ignoring");
+            log.debug("Already in state '" + state + "', ignoring");
             return;
         }
 
         // The 'disconnected' state is permanent for each RFB object
         if (oldstate === 'disconnected') {
-            Log.Error("Tried changing state of a disconnected RFB object");
+            log.error("Tried changing state of a disconnected RFB object");
             return;
         }
 
@@ -579,7 +579,7 @@ export default class RFB extends EventTargetMixin {
         switch (state) {
             case 'connected':
                 if (oldstate !== 'connecting') {
-                    Log.Error("Bad transition to connected state, " +
+                    log.error("Bad transition to connected state, " +
                                "previous connection state: " + oldstate);
                     return;
                 }
@@ -587,7 +587,7 @@ export default class RFB extends EventTargetMixin {
 
             case 'disconnected':
                 if (oldstate !== 'disconnecting') {
-                    Log.Error("Bad transition to disconnected state, " +
+                    log.error("Bad transition to disconnected state, " +
                                "previous connection state: " + oldstate);
                     return;
                 }
@@ -595,7 +595,7 @@ export default class RFB extends EventTargetMixin {
 
             case 'connecting':
                 if (oldstate !== '') {
-                    Log.Error("Bad transition to connecting state, " +
+                    log.error("Bad transition to connecting state, " +
                                "previous connection state: " + oldstate);
                     return;
                 }
@@ -603,14 +603,14 @@ export default class RFB extends EventTargetMixin {
 
             case 'disconnecting':
                 if (oldstate !== 'connected' && oldstate !== 'connecting') {
-                    Log.Error("Bad transition to disconnecting state, " +
+                    log.error("Bad transition to disconnecting state, " +
                                "previous connection state: " + oldstate);
                     return;
                 }
                 break;
 
             default:
-                Log.Error("Unknown connection state: " + state);
+                log.error("Unknown connection state: " + state);
                 return;
         }
 
@@ -618,10 +618,10 @@ export default class RFB extends EventTargetMixin {
 
         this._rfb_connection_state = state;
 
-        Log.Debug("New state '" + state + "', was '" + oldstate + "'.");
+        log.debug("New state '" + state + "', was '" + oldstate + "'.");
 
         if (this._disconnTimer && state !== 'disconnecting') {
-            Log.Debug("Clearing disconnect timer");
+            log.debug("Clearing disconnect timer");
             clearTimeout(this._disconnTimer);
             this._disconnTimer = null;
 
@@ -642,7 +642,7 @@ export default class RFB extends EventTargetMixin {
                 this._disconnect();
 
                 this._disconnTimer = setTimeout(() => {
-                    Log.Error("Disconnection timed out.");
+                    log.error("Disconnection timed out.");
                     this._updateConnectionState('disconnected');
                 }, DISCONNECT_TIMEOUT * 1000);
                 break;
@@ -663,16 +663,16 @@ export default class RFB extends EventTargetMixin {
     _fail(details) {
         switch (this._rfb_connection_state) {
             case 'disconnecting':
-                Log.Error("Failed when disconnecting: " + details);
+                log.error("Failed when disconnecting: " + details);
                 break;
             case 'connected':
-                Log.Error("Failed while connected: " + details);
+                log.error("Failed while connected: " + details);
                 break;
             case 'connecting':
-                Log.Error("Failed when connecting: " + details);
+                log.error("Failed when connecting: " + details);
                 break;
             default:
-                Log.Error("RFB failure: " + details);
+                log.error("RFB failure: " + details);
                 break;
         }
         this._rfb_clean_disconnect = false; //This is sent to the UI
@@ -692,13 +692,13 @@ export default class RFB extends EventTargetMixin {
 
     _handle_message() {
         if (this._sock.rQlen === 0) {
-            Log.Warn("handle_message called on an empty receive queue");
+            log.warn("handle_message called on an empty receive queue");
             return;
         }
 
         switch (this._rfb_connection_state) {
             case 'disconnected':
-                Log.Error("Got data while disconnected");
+                log.error("Got data while disconnected");
                 break;
             case 'connected':
                 while (true) {
@@ -794,7 +794,7 @@ export default class RFB extends EventTargetMixin {
         }
 
         const sversion = this._sock.rQshiftStr(12).substr(4, 7);
-        Log.Info("Server ProtocolVersion: " + sversion);
+        log.info("Server ProtocolVersion: " + sversion);
         let is_repeater = 0;
         switch (sversion) {
             case "000.000":  // UltraVNC repeater
@@ -834,7 +834,7 @@ export default class RFB extends EventTargetMixin {
         const cversion = "00" + parseInt(this._rfb_version, 10) +
                        ".00" + ((this._rfb_version * 10) % 10);
         this._sock.send_string("RFB " + cversion + "\n");
-        Log.Debug('Sent ProtocolVersion: ' + cversion);
+        log.debug('Sent ProtocolVersion: ' + cversion);
 
         this._rfb_init_state = 'Security';
     }
@@ -864,7 +864,7 @@ export default class RFB extends EventTargetMixin {
             }
 
             const types = this._sock.rQshiftBytes(num_types);
-            Log.Debug("Server security types: " + types);
+            log.debug("Server security types: " + types);
 
             // Look for each auth in preferred order
             if (includes(1, types)) {
@@ -894,7 +894,7 @@ export default class RFB extends EventTargetMixin {
         }
 
         this._rfb_init_state = 'Authentication';
-        Log.Debug('Authenticating using scheme: ' + this._rfb_auth_scheme);
+        log.debug('Authenticating using scheme: ' + this._rfb_auth_scheme);
 
         return this._init_msg(); // jump to authentication
     }
@@ -981,7 +981,7 @@ export default class RFB extends EventTargetMixin {
             serverSupportedTunnelTypes[cap_code] = { vendor: cap_vendor, signature: cap_signature };
         }
 
-        Log.Debug("Server Tight tunnel types: " + serverSupportedTunnelTypes);
+        log.debug("Server Tight tunnel types: " + serverSupportedTunnelTypes);
 
         // Siemens touch panels have a VNC server that supports NOTUNNEL,
         // but forgets to advertise it. Try to detect such servers by
@@ -989,7 +989,7 @@ export default class RFB extends EventTargetMixin {
         if (serverSupportedTunnelTypes[1] &&
             (serverSupportedTunnelTypes[1].vendor === "SICR") &&
             (serverSupportedTunnelTypes[1].signature === "SCHANNEL")) {
-            Log.Debug("Detected Siemens server. Assuming NOTUNNEL support.");
+            log.debug("Detected Siemens server. Assuming NOTUNNEL support.");
             serverSupportedTunnelTypes[0] = { vendor: 'TGHT', signature: 'NOTUNNEL' };
         }
 
@@ -1000,7 +1000,7 @@ export default class RFB extends EventTargetMixin {
                 return this._fail("Client's tunnel type had the incorrect " +
                                   "vendor or signature");
             }
-            Log.Debug("Selected tunnel type: " + clientSupportedTunnelTypes[0]);
+            log.debug("Selected tunnel type: " + clientSupportedTunnelTypes[0]);
             this._sock.send([0, 0, 0, 0]);  // use NOTUNNEL
             return false; // wait until we receive the sub auth count to continue
         } else {
@@ -1046,12 +1046,12 @@ export default class RFB extends EventTargetMixin {
             serverSupportedTypes.push(capabilities);
         }
 
-        Log.Debug("Server Tight authentication types: " + serverSupportedTypes);
+        log.debug("Server Tight authentication types: " + serverSupportedTypes);
 
         for (let authType in clientSupportedTypes) {
             if (serverSupportedTypes.indexOf(authType) != -1) {
                 this._sock.send([0, 0, 0, clientSupportedTypes[authType]]);
-                Log.Debug("Selected authentication type: " + authType);
+                log.debug("Selected authentication type: " + authType);
 
                 switch (authType) {
                     case 'STDVNOAUTH__':  // no auth
@@ -1102,7 +1102,7 @@ export default class RFB extends EventTargetMixin {
 
         if (status === 0) { // OK
             this._rfb_init_state = 'ClientInitialisation';
-            Log.Debug('Authentication OK');
+            log.debug('Authentication OK');
             return this._init_msg();
         } else {
             if (this._rfb_version >= 3.8) {
@@ -1175,7 +1175,7 @@ export default class RFB extends EventTargetMixin {
 
         // NB(directxman12): these are down here so that we don't run them multiple times
         //                   if we backtrack
-        Log.Info("Screen: " + width + "x" + height +
+        log.info("Screen: " + width + "x" + height +
                   ", bpp: " + bpp + ", depth: " + depth +
                   ", big_endian: " + big_endian +
                   ", true_color: " + true_color +
@@ -1187,15 +1187,15 @@ export default class RFB extends EventTargetMixin {
                   ", blue_shift: " + blue_shift);
 
         if (big_endian !== 0) {
-            Log.Warn("Server native endian is not little endian");
+            log.warn("Server native endian is not little endian");
         }
 
         if (red_shift !== 16) {
-            Log.Warn("Server native red-shift is not 16");
+            log.warn("Server native red-shift is not 16");
         }
 
         if (blue_shift !== 0) {
-            Log.Warn("Server native blue-shift is not 0");
+            log.warn("Server native blue-shift is not 0");
         }
 
         // we're past the point where we could backtrack, so it's safe to call this
@@ -1211,7 +1211,7 @@ export default class RFB extends EventTargetMixin {
         this._fb_depth = 24;
 
         if (this._fb_name === "Intel(r) AMT KVM") {
-            Log.Warn("Intel AMT KVM only supports 8/16 bit depths. Using low color mode.");
+            log.warn("Intel AMT KVM only supports 8/16 bit depths. Using low color mode.");
             this._fb_depth = 8;
         }
 
@@ -1296,13 +1296,13 @@ export default class RFB extends EventTargetMixin {
     }
 
     _handle_set_colour_map_msg() {
-        Log.Debug("SetColorMapEntries");
+        log.debug("SetColorMapEntries");
 
         return this._fail("Unexpected SetColorMapEntries message");
     }
 
     _handle_server_cut_text() {
-        Log.Debug("ServerCutText");
+        log.debug("ServerCutText");
 
         if (this._sock.rQwait("ServerCutText header", 7, 1)) { return false; }
         this._sock.rQskipBytes(3);  // Padding
@@ -1329,7 +1329,7 @@ export default class RFB extends EventTargetMixin {
         if (this._sock.rQwait("ServerFence payload", length, 9)) { return false; }
 
         if (length > 64) {
-            Log.Warn("Bad payload length (" + length + ") in fence response");
+            log.warn("Bad payload length (" + length + ") in fence response");
             length = 64;
         }
 
@@ -1370,11 +1370,11 @@ export default class RFB extends EventTargetMixin {
 
         switch (xvp_msg) {
             case 0:  // XVP_FAIL
-                Log.Error("XVP Operation Failed");
+                log.error("XVP Operation Failed");
                 break;
             case 1:  // XVP_INIT
                 this._rfb_xvp_ver = xvp_ver;
-                Log.Info("XVP extensions enabled (version " + this._rfb_xvp_ver + ")");
+                log.info("XVP extensions enabled (version " + this._rfb_xvp_ver + ")");
                 this._setCapability("power", true);
                 break;
             default:
@@ -1407,7 +1407,7 @@ export default class RFB extends EventTargetMixin {
                 return this._handle_set_colour_map_msg();
 
             case 2:  // Bell
-                Log.Debug("Bell");
+                log.debug("Bell");
                 this.dispatchEvent(new CustomEvent(
                     "bell",
                     { detail: {} }));
@@ -1423,7 +1423,7 @@ export default class RFB extends EventTargetMixin {
                 if (first) {
                     this._enabledContinuousUpdates = true;
                     this._updateContinuousUpdates();
-                    Log.Info("Enabling continuous updates.");
+                    log.info("Enabling continuous updates.");
                 } else {
                     // FIXME: We need to send a framebufferupdaterequest here
                     // if we add support for turning off continuous updates
@@ -1438,7 +1438,7 @@ export default class RFB extends EventTargetMixin {
 
             default:
                 this._fail("Unexpected server message (type " + msg_type + ")");
-                Log.Debug("sock.rQslice(0, 30): " + this._sock.rQslice(0, 30));
+                log.debug("sock.rQslice(0, 30): " + this._sock.rQslice(0, 30));
                 return true;
         }
     }
@@ -1629,7 +1629,7 @@ export default class RFB extends EventTargetMixin {
                     msg = "Unknown reason";
                     break;
             }
-            Log.Warn("Server did not accept the resize request: "
+            log.warn("Server did not accept the resize request: "
                      + msg);
         } else {
             this._resize(this._FBU.width, this._FBU.height);
@@ -1679,7 +1679,7 @@ export default class RFB extends EventTargetMixin {
 
     _xvpOp(ver, op) {
         if (this._rfb_xvp_ver < ver) { return; }
-        Log.Info("Sending XVP operation " + op + " (version " + ver + ")");
+        log.info("Sending XVP operation " + op + " (version " + ver + ")");
         RFB.messages.xvpOp(this._sock, ver, op);
     }
 

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -7,7 +7,7 @@
  *
  */
 
-import * as Log from './util/logging.js';
+import { Log, setLogger } from './util/logging.js';
 import { decodeUTF8 } from './util/strings.js';
 import { dragThreshold } from './util/browser.js';
 import EventTargetMixin from './util/eventtarget.js';
@@ -309,6 +309,10 @@ export default class RFB extends EventTargetMixin {
     set background(cssValue) { this._screen.style.background = cssValue; }
 
     // ===== PUBLIC METHODS =====
+
+    static setLogger(logger) {
+        setLogger(logger);
+    }
 
     disconnect() {
         this._updateConnectionState('disconnecting');

--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -6,7 +6,7 @@
  * See README.md for usage and integration instructions.
  */
 
-import * as Log from './logging.js';
+import { Log } from './logging.js';
 
 // Touch detection
 export let isTouchDevice = ('ontouchstart' in document.documentElement) ||

--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -6,7 +6,7 @@
  * See README.md for usage and integration instructions.
  */
 
-import { Log } from './logging.js';
+import { log } from './logging.js';
 
 // Touch detection
 export let isTouchDevice = ('ontouchstart' in document.documentElement) ||
@@ -34,14 +34,14 @@ export function supportsCursorURIs() {
             target.style.cursor = 'url("data:image/x-icon;base64,AAACAAEACAgAAAIAAgA4AQAAFgAAACgAAAAIAAAAEAAAAAEAIAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAD/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////AAAAAAAAAAAAAAAAAAAAAA==") 2 2, default';
 
             if (target.style.cursor) {
-                Log.Info("Data URI scheme cursor supported");
+                log.info("Data URI scheme cursor supported");
                 _cursor_uris_supported = true;
             } else {
-                Log.Warn("Data URI scheme cursor not supported");
+                log.warn("Data URI scheme cursor not supported");
                 _cursor_uris_supported = false;
             }
         } catch (exc) {
-            Log.Error("Data URI scheme cursor test exception: " + exc);
+            log.error("Data URI scheme cursor test exception: " + exc);
             _cursor_uris_supported = false;
         }
     }

--- a/core/util/logging.js
+++ b/core/util/logging.js
@@ -10,47 +10,69 @@
  * Logging/debug routines
  */
 
-let _log_level = 'warn';
+export const LogLevels = {
+    none: 'none',
+    debug: 'debug',
+    info: 'info',
+    warn: 'warn',
+    error: 'error'
+};
 
-let Debug = () => {};
-let Info = () => {};
-let Warn = () => {};
-let Error = () => {};
+export class  NoopLogger {
+    Debug() {}
+    Info() {}
+    Warn() {}
+    Error() {}
+}
 
-export function init_logging(level) {
-    if (typeof level === 'undefined') {
-        level = _log_level;
-    } else {
-        _log_level = level;
-    }
+export class ConsoleLogger {
+    constructor(level) {
+        this._logLevels = {
+            debug: 0,
+            info: 1,
+            warn: 2,
+            error: 3
+        };
 
-    Debug = Info = Warn = Error = () => {};
+        this.logLevel = level;
+        this._logLevel = this._logLevels[level];
 
-    if (typeof window.console !== "undefined") {
-        /* eslint-disable no-console, no-fallthrough */
-        switch (level) {
-            case 'debug':
-                Debug = console.debug.bind(window.console);
-            case 'info':
-                Info  = console.info.bind(window.console);
-            case 'warn':
-                Warn  = console.warn.bind(window.console);
-            case 'error':
-                Error = console.error.bind(window.console);
-            case 'none':
-                break;
-            default:
-                throw new window.Error("invalid logging type '" + level + "'");
+        if (this._logLevel === undefined) {
+            throw new Error('Invalid logging level \'' + level + '\'');
         }
-        /* eslint-enable no-console, no-fallthrough */
+    }
+
+    Debug(...args) {
+        if (this._logLevel <= this._logLevels.debug) {
+            // eslint-disable-next-line no-console
+            console.debug.apply(console, args);
+        }
+    }
+
+    Info(...args) {
+        if (this._logLevel <= this._logLevels.info) {
+            // eslint-disable-next-line no-console
+            console.info.apply(console, args);
+        }
+    }
+
+    Warn(...args) {
+        if (this._logLevel <= this._logLevels.warn) {
+            // eslint-disable-next-line no-console
+            console.warn.apply(console, args);
+        }
+    }
+
+    Error(...args) {
+        if (this._logLevel <= this._logLevels.error) {
+            // eslint-disable-next-line no-console
+            console.error.apply(console, args);
+        }
     }
 }
 
-export function get_logging() {
-    return _log_level;
+export let Log = window.console ? new ConsoleLogger(LogLevels.warn) : new NoopLogger();
+
+export function setLogger(logger) {
+    Log = logger;
 }
-
-export { Debug, Info, Warn, Error };
-
-// Initialize logging level
-init_logging();

--- a/core/util/logging.js
+++ b/core/util/logging.js
@@ -19,10 +19,10 @@ export const LogLevels = {
 };
 
 export class  NoopLogger {
-    Debug() {}
-    Info() {}
-    Warn() {}
-    Error() {}
+    debug() {}
+    info() {}
+    warn() {}
+    error() {}
 }
 
 export class ConsoleLogger {
@@ -42,28 +42,28 @@ export class ConsoleLogger {
         }
     }
 
-    Debug(...args) {
+    debug(...args) {
         if (this._logLevel <= this._logLevels.debug) {
             // eslint-disable-next-line no-console
             console.debug.apply(console, args);
         }
     }
 
-    Info(...args) {
+    info(...args) {
         if (this._logLevel <= this._logLevels.info) {
             // eslint-disable-next-line no-console
             console.info.apply(console, args);
         }
     }
 
-    Warn(...args) {
+    warn(...args) {
         if (this._logLevel <= this._logLevels.warn) {
             // eslint-disable-next-line no-console
             console.warn.apply(console, args);
         }
     }
 
-    Error(...args) {
+    error(...args) {
         if (this._logLevel <= this._logLevels.error) {
             // eslint-disable-next-line no-console
             console.error.apply(console, args);
@@ -71,8 +71,8 @@ export class ConsoleLogger {
     }
 }
 
-export let Log = window.console ? new ConsoleLogger(LogLevels.warn) : new NoopLogger();
+export let log = window.console ? new ConsoleLogger(LogLevels.warn) : new NoopLogger();
 
 export function setLogger(logger) {
-    Log = logger;
+    log = logger;
 }

--- a/core/websock.js
+++ b/core/websock.js
@@ -12,7 +12,7 @@
  * read binary data off of the receive queue.
  */
 
-import * as Log from './util/logging.js';
+import { Log } from './util/logging.js';
 
 // this has performance issues in some versions Chromium, and
 // doesn't gain a tremendous amount of performance increase in Firefox

--- a/core/websock.js
+++ b/core/websock.js
@@ -12,7 +12,7 @@
  * read binary data off of the receive queue.
  */
 
-import { Log } from './util/logging.js';
+import { log } from './util/logging.js';
 
 // this has performance issues in some versions Chromium, and
 // doesn't gain a tremendous amount of performance increase in Firefox
@@ -186,23 +186,23 @@ export default class Websock {
 
         this._websocket.onmessage = this._recv_message.bind(this);
         this._websocket.onopen = () => {
-            Log.Debug('>> WebSock.onopen');
+            log.debug('>> WebSock.onopen');
             if (this._websocket.protocol) {
-                Log.Info("Server choose sub-protocol: " + this._websocket.protocol);
+                log.info("Server choose sub-protocol: " + this._websocket.protocol);
             }
 
             this._eventHandlers.open();
-            Log.Debug("<< WebSock.onopen");
+            log.debug("<< WebSock.onopen");
         };
         this._websocket.onclose = (e) => {
-            Log.Debug(">> WebSock.onclose");
+            log.debug(">> WebSock.onclose");
             this._eventHandlers.close(e);
-            Log.Debug("<< WebSock.onclose");
+            log.debug("<< WebSock.onclose");
         };
         this._websocket.onerror = (e) => {
-            Log.Debug(">> WebSock.onerror: " + e);
+            log.debug(">> WebSock.onerror: " + e);
             this._eventHandlers.error(e);
-            Log.Debug("<< WebSock.onerror: " + e);
+            log.debug("<< WebSock.onerror: " + e);
         };
     }
 
@@ -210,7 +210,7 @@ export default class Websock {
         if (this._websocket) {
             if ((this._websocket.readyState === WebSocket.OPEN) ||
                     (this._websocket.readyState === WebSocket.CONNECTING)) {
-                Log.Info("Closing WebSocket connection");
+                log.info("Closing WebSocket connection");
                 this._websocket.close();
             }
 
@@ -284,7 +284,7 @@ export default class Websock {
                 this._expand_compact_rQ();
             }
         } else {
-            Log.Debug("Ignoring empty message");
+            log.debug("Ignoring empty message");
         }
     }
 }

--- a/tests/playback.js
+++ b/tests/playback.js
@@ -5,7 +5,7 @@
  */
 
 import RFB from '../core/rfb.js';
-import { Log } from '../core/util/logging.js';
+import { log } from '../core/util/logging.js';
 
 // Immediate polyfill
 if (window.setImmediate === undefined) {
@@ -106,7 +106,7 @@ export default class RecordingPlayer {
         }
 
         if (this._frame_index >= this._frame_length) {
-            Log.Debug('Finished, no more frames');
+            log.debug('Finished, no more frames');
             this._finish();
             return;
         }

--- a/tests/playback.js
+++ b/tests/playback.js
@@ -5,7 +5,7 @@
  */
 
 import RFB from '../core/rfb.js';
-import * as Log from '../core/util/logging.js';
+import { Log } from '../core/util/logging.js';
 
 // Immediate polyfill
 if (window.setImmediate === undefined) {

--- a/tests/test.util.js
+++ b/tests/test.util.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 const expect = chai.expect;
 
-import { Log, ConsoleLogger, LogLevels, setLogger } from '../core/util/logging.js';
+import { log, ConsoleLogger, LogLevels, setLogger } from '../core/util/logging.js';
 
 describe('Utils', function () {
     "use strict";
@@ -24,34 +24,34 @@ describe('Utils', function () {
 
             it('should use noop for levels lower than the min level', function () {
                 setLogger(new ConsoleLogger(LogLevels.warn));
-                Log.Debug('hi');
-                Log.Info('hello');
+                log.debug('hi');
+                log.info('hello');
                 expect(console.debug).to.not.have.been.called;
                 expect(console.info).to.not.have.been.called;
             });
 
             it('should use console.debug for Debug', function () {
                 setLogger(new ConsoleLogger(LogLevels.debug));
-                Log.Debug('dbg');
+                log.debug('dbg');
                 expect(console.debug).to.have.been.calledWith('dbg');
             });
 
             it('should use console.info for Info', function () {
                 setLogger(new ConsoleLogger(LogLevels.info));
-                Log.Info('inf');
+                log.info('inf');
                 expect(console.info).to.have.been.calledWith('inf');
             });
 
             it('should use console.warn for Warn', function () {
                 setLogger(new ConsoleLogger(LogLevels.warn));
-                Log.Warn('wrn');
+                log.warn('wrn');
                 expect(console.warn).to.have.been.called;
                 expect(console.warn).to.have.been.calledWith('wrn');
             });
 
             it('should use console.error for Error', function () {
                 setLogger(new ConsoleLogger(LogLevels.error));
-                Log.Error('err');
+                log.error('err');
                 expect(console.error).to.have.been.called;
                 expect(console.error).to.have.been.calledWith('err');
             });

--- a/tests/test.util.js
+++ b/tests/test.util.js
@@ -1,60 +1,60 @@
 /* eslint-disable no-console */
 const expect = chai.expect;
 
-import * as Log from '../core/util/logging.js';
+import { Log, ConsoleLogger, LogLevels, setLogger } from '../core/util/logging.js';
 
 describe('Utils', function () {
     "use strict";
 
-    describe('logging functions', function () {
-        beforeEach(function () {
-            sinon.spy(console, 'log');
-            sinon.spy(console, 'debug');
-            sinon.spy(console, 'warn');
-            sinon.spy(console, 'error');
-            sinon.spy(console, 'info');
-        });
+    describe('logging', function () {
+        describe('Console Logger', function () {
+            beforeEach(function () {
+                sinon.spy(console, 'debug');
+                sinon.spy(console, 'warn');
+                sinon.spy(console, 'error');
+                sinon.spy(console, 'info');
+            });
 
-        afterEach(function () {
-            console.log.restore();
-            console.debug.restore();
-            console.warn.restore();
-            console.error.restore();
-            console.info.restore();
-            Log.init_logging();
-        });
+            afterEach(function () {
+                console.debug.restore();
+                console.warn.restore();
+                console.error.restore();
+                console.info.restore();
+            });
 
-        it('should use noop for levels lower than the min level', function () {
-            Log.init_logging('warn');
-            Log.Debug('hi');
-            Log.Info('hello');
-            expect(console.log).to.not.have.been.called;
-        });
+            it('should use noop for levels lower than the min level', function () {
+                setLogger(new ConsoleLogger(LogLevels.warn));
+                Log.Debug('hi');
+                Log.Info('hello');
+                expect(console.debug).to.not.have.been.called;
+                expect(console.info).to.not.have.been.called;
+            });
 
-        it('should use console.debug for Debug', function () {
-            Log.init_logging('debug');
-            Log.Debug('dbg');
-            expect(console.debug).to.have.been.calledWith('dbg');
-        });
+            it('should use console.debug for Debug', function () {
+                setLogger(new ConsoleLogger(LogLevels.debug));
+                Log.Debug('dbg');
+                expect(console.debug).to.have.been.calledWith('dbg');
+            });
 
-        it('should use console.info for Info', function () {
-            Log.init_logging('debug');
-            Log.Info('inf');
-            expect(console.info).to.have.been.calledWith('inf');
-        });
+            it('should use console.info for Info', function () {
+                setLogger(new ConsoleLogger(LogLevels.info));
+                Log.Info('inf');
+                expect(console.info).to.have.been.calledWith('inf');
+            });
 
-        it('should use console.warn for Warn', function () {
-            Log.init_logging('warn');
-            Log.Warn('wrn');
-            expect(console.warn).to.have.been.called;
-            expect(console.warn).to.have.been.calledWith('wrn');
-        });
+            it('should use console.warn for Warn', function () {
+                setLogger(new ConsoleLogger(LogLevels.warn));
+                Log.Warn('wrn');
+                expect(console.warn).to.have.been.called;
+                expect(console.warn).to.have.been.calledWith('wrn');
+            });
 
-        it('should use console.error for Error', function () {
-            Log.init_logging('error');
-            Log.Error('err');
-            expect(console.error).to.have.been.called;
-            expect(console.error).to.have.been.calledWith('err');
+            it('should use console.error for Error', function () {
+                setLogger(new ConsoleLogger(LogLevels.error));
+                Log.Error('err');
+                expect(console.error).to.have.been.called;
+                expect(console.error).to.have.been.calledWith('err');
+            });
         });
     });
 


### PR DESCRIPTION
Closes #243 

This PR establishes a new `Logger` interface:
```ts
interface Logger {
  debug(...args) {}
  info(...args) {}
  warn(...args) {}
  error(...args) {}
}
```

and create a static setter in the RBF object (`setLogger`) that can receive any instance of such interface and set it as generic logger for all noVNC related classes.

In `logging.js` the are to example implementation of such interface: `NoopLogger` and `ConsoleLogger`.