### PR TITLE
Restore token forwarding in vnc_lite

### DIFF
--- a/vnc_lite.html
+++ b/vnc_lite.html
@@ -154,6 +154,14 @@
         const password = readQueryVariable('password', '');
         const path = readQueryVariable('path', 'websockify');
 
+        // If a token variable is passed in, forward it in the URL so that it
+        // is accessible by a websockify token plugin
+        var token = WebUtil.getConfigVar('token', null);
+        if (token) {
+            // if token is already present in the path we should use it
+            path = WebUtil.injectParamIfMissing(path, "token", token);
+        }
+
         // | | |         | | |
         // | | | Connect | | |
         // v v v         v v v


### PR DESCRIPTION
This is a partial revert of commit
51f9f0098d306bbc67cc8e02ae547921b6f6585c which intended to remove
unnecessary options.

In OpenStack Nova, we use the vnc_lite (formerly vnc_auto)
functionality as a default in our novnc proxy [1] and the proxy relies
on token validation. We need to be able to access the token in the URL
in our websockify proxy server.

Websockify itself also offers a token plugin feature that requires
forwarding of the token [2]. Restoring token forwarding allows users to
continue using token plugins with vnc_lite.

[1]
https://docs.openstack.org/nova/latest/admin/remote-console-access.html#novnc-based-vnc-console
[2]
https://github.com/novnc/websockify/wiki/Token-based-target-selection