### PR TITLE
Fullscreen from iframe

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1168,10 +1168,15 @@ const UI = {
  * ------v------*/
 
     toggleFullscreen() {
+        // Determine the document using fullscreen. This may either be
+        // just the "document", but if using the viewer in an iframe, you need
+        // to use the parent window's "document" instead.
         let doc = document;
         if (window.self !== window.top) {
             doc = window.parent.document;
         }
+        // Check the fullscreen status using the correct document as
+        // a reference. The same document is then used to exit fullscreen.
         if (doc.fullscreenElement || // alternative standard method
             doc.mozFullScreenElement || // currently working methods
             doc.webkitFullscreenElement ||
@@ -1186,8 +1191,16 @@ const UI = {
                 doc.msExitFullscreen();
             }
         } else {
+            // To activate fullscreen, we need to find the correct document
+            // element, which is usually "document.documentElement". But when
+            // using the viewer in an iframe, this is actually the iframe
+            // element itself in the parent document.
             let doc_el = document.documentElement;
             if (window.self !== window.top) {
+                // Seek out the correct iframe from the parent document.
+                // This will produce errors if the iframe does not come from
+                // the same origin, so it is advisable to put the viewer in
+                // iframes only if you are on the same server.
                 let iframes = window.parent.document
                     .getElementsByTagName('iframe');
                 for (let i in iframes) {
@@ -1197,6 +1210,8 @@ const UI = {
                     }
                 }
             }
+            // Activate fullscreen. All except MS use the document element for
+            // this. The behaviour of body.msRequestFullscreen is untested.
             if (doc_el.requestFullscreen) {
                 doc_el.requestFullscreen();
             } else if (doc_el.mozRequestFullScreen) {

--- a/app/ui.js
+++ b/app/ui.js
@@ -1206,6 +1206,11 @@ const UI = {
                 for (let i in iframes) {
                     if (iframes[i].contentDocument === document) {
                         doc_el = iframes[i];
+                        // To use .body.msRequestFullscreen in IE, we need to
+                        // set the document element accordingly.
+                        // Note that the <iframe> must have the attribute
+                        // "allowfullscreen" set for IE to allow the feature.
+                        doc = iframes[i].contentDocument;
                         break;
                     }
                 }

--- a/app/ui.js
+++ b/app/ui.js
@@ -1168,7 +1168,7 @@ const UI = {
  * ------v------*/
 
     toggleFullscreen() {
-        var doc = document;
+        let doc = document;
         if (window.self !== window.top) {
             doc = window.parent.document;
         }
@@ -1186,11 +1186,15 @@ const UI = {
                 doc.msExitFullscreen();
             }
         } else {
-            var doc_el = document.documentElement;
+            let doc_el = document.documentElement;
             if (window.self !== window.top) {
-                var iframeid = WebUtil.getQueryVar('iframeid', null);
-                if (iframeid) {
-                    doc_el = window.parent.document.getElementById(iframeid);
+                let iframes = window.parent.document
+                    .getElementsByTagName('iframe');
+                for (let i in iframes) {
+                    if (iframes[i].contentDocument === document) {
+                        doc_el = iframes[i];
+                        break;
+                    }
                 }
             }
             if (doc_el.requestFullscreen) {

--- a/app/ui.js
+++ b/app/ui.js
@@ -1172,24 +1172,38 @@ const UI = {
             document.mozFullScreenElement || // currently working methods
             document.webkitFullscreenElement ||
             document.msFullscreenElement) {
-            if (document.exitFullscreen) {
-                document.exitFullscreen();
-            } else if (document.mozCancelFullScreen) {
-                document.mozCancelFullScreen();
-            } else if (document.webkitExitFullscreen) {
-                document.webkitExitFullscreen();
-            } else if (document.msExitFullscreen) {
-                document.msExitFullscreen();
+            var doc = document;
+            if (window.parent != window) {
+                var iframeid = WebUtil.getQueryVar('iframeid', null);
+                if (iframeid) {
+                    doc = window.parent.document.getElementById(iframeid);
+                }
+            }
+            if (doc.exitFullscreen) {
+                doc.exitFullscreen();
+            } else if (doc.mozCancelFullScreen) {
+                doc.mozCancelFullScreen();
+            } else if (doc.webkitExitFullscreen) {
+                doc.webkitExitFullscreen();
+            } else if (doc.msExitFullscreen) {
+                doc.msExitFullscreen();
             }
         } else {
-            if (document.documentElement.requestFullscreen) {
-                document.documentElement.requestFullscreen();
-            } else if (document.documentElement.mozRequestFullScreen) {
-                document.documentElement.mozRequestFullScreen();
-            } else if (document.documentElement.webkitRequestFullscreen) {
-                document.documentElement.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
-            } else if (document.body.msRequestFullscreen) {
-                document.body.msRequestFullscreen();
+            var doc = document.documentElement;
+            if (window.parent != window) {
+                var iframeid = WebUtil.getQueryVar('iframeid', null);
+                if (iframeid) {
+                    doc = window.parent.document.getElementById(iframeid);
+                }
+            }
+            if (doc.requestFullscreen) {
+                doc.requestFullscreen();
+            } else if (doc.mozRequestFullScreen) {
+                doc.mozRequestFullScreen();
+            } else if (doc.webkitRequestFullscreen) {
+                doc.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
+            } else if (doc.body.msRequestFullscreen) {
+                doc.body.msRequestFullscreen();
             }
         }
         UI.updateFullscreenButton();

--- a/app/ui.js
+++ b/app/ui.js
@@ -1198,13 +1198,17 @@ const UI = {
             let doc_el = document.documentElement;
             if (window.self !== window.top) {
                 // Seek out the correct iframe from the parent document.
-                // This will produce errors if the iframe does not come from
-                // the same origin, so it is advisable to put the viewer in
-                // iframes only if you are on the same server.
                 let iframes = window.parent.document
                     .getElementsByTagName('iframe');
                 for (let i in iframes) {
-                    if (iframes[i].contentDocument === document) {
+                    let content_doc = null;
+                    try {
+                        content_doc = iframes[i].contentDocument;
+                    } catch (err) {
+                        // I may not be permitted to read the contentDocument
+                        // of the iframe, but then it can't be me, so ignore.
+                    }
+                    if (content_doc === document) {
                         doc_el = iframes[i];
                         // To use .body.msRequestFullscreen in IE, we need to
                         // set the document element accordingly.

--- a/app/ui.js
+++ b/app/ui.js
@@ -1168,17 +1168,14 @@ const UI = {
  * ------v------*/
 
     toggleFullscreen() {
-        if (document.fullscreenElement || // alternative standard method
-            document.mozFullScreenElement || // currently working methods
-            document.webkitFullscreenElement ||
-            document.msFullscreenElement) {
-            var doc = document;
-            if (window.parent != window) {
-                var iframeid = WebUtil.getQueryVar('iframeid', null);
-                if (iframeid) {
-                    doc = window.parent.document.getElementById(iframeid);
-                }
-            }
+        var doc = document;
+        if (window.self !== window.top) {
+            doc = window.parent.document;
+        }
+        if (doc.fullscreenElement || // alternative standard method
+            doc.mozFullScreenElement || // currently working methods
+            doc.webkitFullscreenElement ||
+            doc.msFullscreenElement) {
             if (doc.exitFullscreen) {
                 doc.exitFullscreen();
             } else if (doc.mozCancelFullScreen) {
@@ -1189,19 +1186,19 @@ const UI = {
                 doc.msExitFullscreen();
             }
         } else {
-            var doc = document.documentElement;
-            if (window.parent != window) {
+            var doc_el = document.documentElement;
+            if (window.self !== window.top) {
                 var iframeid = WebUtil.getQueryVar('iframeid', null);
                 if (iframeid) {
-                    doc = window.parent.document.getElementById(iframeid);
+                    doc_el = window.parent.document.getElementById(iframeid);
                 }
             }
-            if (doc.requestFullscreen) {
-                doc.requestFullscreen();
-            } else if (doc.mozRequestFullScreen) {
-                doc.mozRequestFullScreen();
-            } else if (doc.webkitRequestFullscreen) {
-                doc.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
+            if (doc_el.requestFullscreen) {
+                doc_el.requestFullscreen();
+            } else if (doc_el.mozRequestFullScreen) {
+                doc_el.mozRequestFullScreen();
+            } else if (doc_el.webkitRequestFullscreen) {
+                doc_el.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
             } else if (doc.body.msRequestFullscreen) {
                 doc.body.msRequestFullscreen();
             }


### PR DESCRIPTION
The request for this feature comes from making a page consisting of several `<iframe>`s, each with a noVNC viewer inside it.

In this setup, the fullscreen buttons do not work as expected, they just do nothing. 

This is because the `ui.js` implementation of `toggleFullscreen()` has no awareness for the fullscreen window actually being the parent window of the viewer.

Making the fullscreen buttons work is actually quite straightforward, except for the identification of the correct `<iframe>` in the parent window.

To solve the problem, I read a request variable, `iframeid`, and use that to select the correct element to put into fullscreen mode.

Testing the feature:

- build a simple page containing a viewer in an `<iframe>`,
- give the iframe an arbitrary `id` attribute,
- pass that value to the viewer as URL parameter `iframeid`,
- click the fullscreen button in the `<iframe>` — the viewer should go fullscreen,
- click the fullscreen button again — the viewer should jump back into its cage.
