### PR TITLE
launch.sh: Check for a local websockify directory

### DIFF
--- a/utils/launch.sh
+++ b/utils/launch.sh
@@ -128,7 +128,7 @@ if [ -n "${KEY}" ]; then
 fi
 
 # try to find websockify (prefer local, try global, then download local)
-if [[ -e ${HERE}/websockify ]]; then
+if [[ -d ${HERE}/websockify ]]; then
     WEBSOCKIFY=${HERE}/websockify/run
 
     if [[ ! -x $WEBSOCKIFY ]]; then


### PR DESCRIPTION
Previously launch.sh would check both for the existence of a local
websockify file and websockify/run file.

This initial check should really be for a local websockify directory
as in packaged environments a file could very well be the actual
executable leading to launch.sh incorrectly attempting to use a local
version of websockify.