### PR TITLE
QEMU Pointer Motion Change Pseudo-encoding

### DIFF
--- a/core/encodings.js
+++ b/core/encodings.js
@@ -19,6 +19,7 @@ export const encodings = {
     pseudoEncodingDesktopSize: -223,
     pseudoEncodingLastRect: -224,
     pseudoEncodingCursor: -239,
+    pseudoEncodingQEMUPointerMotionChange: -257,
     pseudoEncodingQEMUExtendedKeyEvent: -258,
     pseudoEncodingExtendedDesktopSize: -308,
     pseudoEncodingXvp: -309,


### PR DESCRIPTION
From [community docs](https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#777qemu-pointer-motion-change-pseudo-encoding):

> ### 7.7.7   QEMU Pointer Motion Change Pseudo-encoding
> A client that supports this encoding declares that is able to send pointer motion events either as absolute coordinates, or relative deltas. The server can switch between different pointer motion modes by sending a rectangle with this encoding. If the x-position in the update is 1, the server is requesting absolute coordinates, which is the RFB protocol default when this encoding is not supported. If the x-position in the update is 0, the server is requesting relative deltas.
> 
> When relative delta mode is active, the semantics of the PointerEvent message are changed. The x-position and y-position fields are to be treated as S16 quantities, denoting the delta from the last position. A client can compute the signed deltas with the logic:
> 
> `uint16 dx = x + 0x7FFF - last_x`
> `uint16 dy = y + 0x7FFF - last_y`
> If the client needs to send an updated button-mask without any associated motion, it should use the value 0x7FFF in the x-position and y-position fields of the PointerEvent
> 
> Servers are advised to implement this pseudo-encoding if the virtual desktop is associated a input device that expects relative coordinates, for example, a virtual machine with a PS/2 mouse. Prior to this extension, a server with such a input device would have to perform the absolute to relative delta conversion itself. This can result in the client pointer hitting an "invisible wall".
> 
> Clients are advised that when generating events in relative pointer mode, they should grab and hide the local pointer. When the local pointer hits any edge of the client window, it should be warped back by 100 pixels. This ensures that continued movement of the user's input device will continue to generate relative deltas and thus avoid the "invisible wall" problem.

I implemented it.  But i doesn't have much knowledge to make autotests for it (I'm backender). But i tested it manually. Please verify and merge to upstream.