### PR TITLE
Use "nomodule" instead of manual check

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ noVNC uses many modern web technologies so a formal requirement list is
 not available. However these are the minimum versions we are currently
 aware of:
 
-* Chrome 49, Firefox 44, Safari 10, Opera 36, IE 11, Edge 12
+* Chrome 49, Firefox 44, Safari 11, Opera 36, IE 11, Edge 12
 
 
 ### Server Requirements

--- a/utils/use_require.js
+++ b/utils/use_require.js
@@ -105,27 +105,11 @@ function transform_html(legacy_scripts, only_legacy) {
                     new_script += `    <script src="${legacy_scripts[i]}"></script>\n`;
                 }
             } else {
-            // Otherwise detect if it's a modern browser and select
-            // variant accordingly
-                new_script += `\
-    <script type="module">\n\
-        window._noVNC_has_module_support = true;\n\
-    </script>\n\
-    <script>\n\
-        window.addEventListener("load", function() {\n\
-            if (window._noVNC_has_module_support) return;\n\
-            let legacy_scripts = ${JSON.stringify(legacy_scripts)};\n\
-            for (let i = 0;i < legacy_scripts.length;i++) {\n\
-                let script = document.createElement("script");\n\
-                script.src = legacy_scripts[i];\n\
-                script.async = false;\n\
-                document.head.appendChild(script);\n\
-            }\n\
-        });\n\
-    </script>\n`;
-
-            // Original, ES6 modules
+                // Otherwise include both modules and legacy fallbacks
                 new_script += '    <script type="module" crossorigin="anonymous" src="app/ui.js"></script>\n';
+                for (let i = 0;i < legacy_scripts.length;i++) {
+                    new_script += '    <script nomodule src="${legacy_scripts[i]}"></script>\n';
+                }
             }
 
             contents = contents.slice(0, start_ind) + `${new_script}\n` + contents.slice(end_ind);

--- a/vnc.html
+++ b/vnc.html
@@ -57,17 +57,7 @@
     <!-- promise polyfills promises for IE11 -->
     <script src="vendor/promise.js"></script>
     <!-- ES2015/ES6 modules polyfill -->
-    <script type="module">
-        window._noVNC_has_module_support = true;
-    </script>
-    <script>
-        window.addEventListener("load", function() {
-            if (window._noVNC_has_module_support) return;
-            var loader = document.createElement("script");
-            loader.src = "vendor/browser-es-module-loader/dist/browser-es-module-loader.js";
-            document.head.appendChild(loader);
-        });
-    </script>
+    <script nomodule src="vendor/browser-es-module-loader/dist/browser-es-module-loader.js"></script>
     <!-- actual script modules -->
     <script type="module" crossorigin="anonymous" src="app/ui.js"></script>
     <!-- end scripts -->

--- a/vnc_lite.html
+++ b/vnc_lite.html
@@ -61,18 +61,7 @@
     <script src="vendor/promise.js"></script>
 
     <!-- ES2015/ES6 modules polyfill -->
-    <script type="module">
-        window._noVNC_has_module_support = true;
-    </script>
-    <script>
-        window.addEventListener("load", function() {
-            if (window._noVNC_has_module_support) return;
-            const loader = document.createElement("script");
-            loader.src = "vendor/browser-es-module-loader/dist/" +
-                "browser-es-module-loader.js";
-            document.head.appendChild(loader);
-        });
-    </script>
+    <script nomodule src="vendor/browser-es-module-loader/dist/browser-es-module-loader.js"></script>
 
     <!-- actual script modules -->
     <script type="module" crossorigin="anonymous">


### PR DESCRIPTION
Very few browsers are left in the wild that supports modules but not "nomodule", so let's simplify our handling a bit.

See here:

https://caniuse.com/#search=nomodule

It's basically Safari 10 (on both iOS and macOS) that is the issue, and there seems to be few devices out there still using it.