### PR TITLE
Avoid recursion in Alt check on Firefox

### DIFF
--- a/core/input/keyboard.js
+++ b/core/input/keyboard.js
@@ -301,6 +301,9 @@ export default class Keyboard {
 
     // Firefox Alt workaround, see below
     _checkAlt(e) {
+        if (e.skipCheckAlt) {
+            return;
+        }
         if (e.altKey) {
             return;
         }
@@ -315,6 +318,7 @@ export default class Keyboard {
             const event = new KeyboardEvent('keyup',
                                             { key: downList[code],
                                               code: code });
+            event.skipCheckAlt = true;
             target.dispatchEvent(event);
         });
     }


### PR DESCRIPTION
The Firefox workaround which checks for missing Alt key events may
synthesise new KeyboardEvents. On these events, checkAlt should not be
recursively triggered. Otherwise, we get "too much recursion" errors
whenever the Alt key is pressed.