### PR TITLE
Optimize receive buffer

### DIFF
--- a/core/websock.js
+++ b/core/websock.js
@@ -247,12 +247,12 @@ export default class Websock {
         if (resizeNeeded) {
             const old_rQbuffer = this._rQ.buffer;
             this._rQ = new Uint8Array(this._rQbufferSize);
-            this._rQ.set(new Uint8Array(old_rQbuffer, this._rQi));
+            this._rQ.set(new Uint8Array(old_rQbuffer, this._rQi, this._rQlen - this._rQi));
         } else {
             if (ENABLE_COPYWITHIN) {
-                this._rQ.copyWithin(0, this._rQi);
+                this._rQ.copyWithin(0, this._rQi, this._rQlen);
             } else {
-                this._rQ.set(new Uint8Array(this._rQ.buffer, this._rQi));
+                this._rQ.set(new Uint8Array(this._rQ.buffer, this._rQi, this._rQlen - this._rQi));
             }
         }
 


### PR DESCRIPTION
Fix two inefficiencies in how and when we compact the websocket receive buffer.
In most browsers, the impact of this is negligible, but on a high-res monitor in IE11, these issues could freeze the buffer for over half a second when a large FBU is received.

With these changes, compactions effectively disappear from IE11's profiler graph.