### PR TITLE
Snap release latest 20190813

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: novnc
 base: core18 # the base snap is the execution environment for this snap
-version: '1.1.0'
+version: 'latest-20190813'
 summary: Open Source VNC client using HTML5 (WebSockets, Canvas)
 description: |
   Open Source VNC client using HTML5 (WebSockets, Canvas).
@@ -10,11 +10,20 @@ grade: stable
 confinement: strict
 
 parts:
+    websockify:
+        source: https://github.com/novnc/websockify.git
+        plugin: dump
+        organize:
+            websockify/: utils/websockify/websockify/
+            run: utils/websockify/
+        # Avoid file name conflicts by not staging files from websockify that have the same names as those in novnc (docs/unimportant files only)
+        stage:
+            - -README.md
+            - -docs/notes
     novnc:
         source: https://github.com/novnc/noVNC.git #https://github.com/novnc/noVNC/archive/v$SNAPCRAFT_PROJECT_VERSION.tar.gz 
         plugin: dump
         stage-packages:
-            - websockify
             - bash
             - jq
             - python-numpy

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ confinement: strict
 
 parts:
     websockify:
-        source: https://github.com/novnc/websockify.git
+        source: https://github.com/novnc/websockify/archive/v0.9.0.tar.gz
         plugin: dump
         organize:
             websockify/: utils/websockify/websockify/
@@ -22,6 +22,7 @@ parts:
             - -docs/notes
     novnc:
         source: https://github.com/novnc/noVNC.git #https://github.com/novnc/noVNC/archive/v$SNAPCRAFT_PROJECT_VERSION.tar.gz 
+        source-commit: e1d50c8c10563edcacebcaeb32d022906aa003d2
         plugin: dump
         stage-packages:
             - bash


### PR DESCRIPTION
I've modified the Snap to now explicitly pull in the 0.9.0 version of Websockify, instead of the latest from git. Note that this is how Snap packages work, they bundle their dependencies.

I've also fixed the noVNC 'part' to pull in the specific git commit that added Snap support. This is a temporary solution until the next release of noVNC (e.g. 1.2.0) is out