### PR TITLE
Auto copy-paste with navigator.clipboard API

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -916,7 +916,7 @@ const UI = {
  * ------v------*/
 
     writeLocalClipboard(text) {
-        if (typeof navigator.clipboard !== "undefined" && typeof navigator.clipboard.readText !== "undefined") {
+        if (typeof navigator.clipboard !== "undefined" && typeof navigator.clipboard.writeText !== "undefined") {
             navigator.clipboard.writeText(text).then(() => {
                 let debugMessage = text.substr(0, 40) + "...";
                 Log.Debug('>> UI.setClipboardText: navigator.clipboard.writeText with ' + debugMessage);

--- a/app/ui.js
+++ b/app/ui.js
@@ -322,6 +322,8 @@ const UI = {
         document.getElementById("noVNC_clipboard_button")
             .addEventListener('click', UI.toggleClipboardPanel);
         document.getElementById("noVNC_clipboard_text")
+            .addEventListener('input', UI.syncClipboardPanelToLocalClipboard);
+        document.getElementById("noVNC_clipboard_text")
             .addEventListener('change', UI.clipboardSend);
         document.getElementById("noVNC_clipboard_clear_button")
             .addEventListener('click', UI.clipboardClear);
@@ -986,9 +988,15 @@ const UI = {
     clipboardSend() {
         const text = document.getElementById('noVNC_clipboard_text').value;
         Log.Debug(">> UI.clipboardSend: " + text.substr(0, 40) + "...");
-        UI.writeLocalClipboard(text);
         UI.rfb.clipboardPasteFrom(text);
         Log.Debug("<< UI.clipboardSend");
+    },
+
+    syncClipboardPanelToLocalClipboard() {
+        // Reads text from clipboard panel and set it to local clipboard
+        // Mainly used to synchronize clipboard panel with local clipboard
+        const text = document.getElementById('noVNC_clipboard_text').value;
+        UI.writeLocalClipboard(text);
     },
 
 /* ------^-------

--- a/app/ui.js
+++ b/app/ui.js
@@ -915,6 +915,9 @@ const UI = {
  *   CLIPBOARD
  * ------v------*/
 
+    // Read and write text to local clipboard is currently only supported in Chrome 66+ and Opera53+
+    // further information at https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
+
     writeLocalClipboard(text) {
         if (typeof navigator.clipboard !== "undefined" && typeof navigator.clipboard.writeText !== "undefined") {
             navigator.clipboard.writeText(text).then(() => {

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -234,6 +234,8 @@ export default class RFB extends EventTargetMixin {
         // time to set up callbacks
         setTimeout(this._updateConnectionState.bind(this, 'connecting'));
 
+        this.oncanvasfocus = () => {}; // Handler for canvas focused
+
         Log.Debug("<< RFB.constructor");
 
         // ===== PROPERTIES =====
@@ -381,6 +383,7 @@ export default class RFB extends EventTargetMixin {
     }
 
     focus() {
+        this.oncanvasfocus();
         this._canvas.focus();
     }
 

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -270,8 +270,10 @@ describe('Remote Frame Buffer Protocol Client', function () {
         describe('#focus', function () {
             it('should move focus to canvas object', function () {
                 client._canvas.focus = sinon.spy();
+                client.oncanvasfocus = sinon.spy();
                 client.focus();
                 expect(client._canvas.focus).to.have.been.calledOnce;
+                expect(client.oncanvasfocus).to.have.been.calledOnce;
             });
         });
 


### PR DESCRIPTION
Hi!
I added the automatical copy-paste function that is available through the `navigator.clipboard` API in some browsers (e.g. Google Chrome) as mentioned earlier in PR #1174.

Co-authored-by: bulldozier <kentdozier@gmail.com>