### PR TITLE
Dynamically detect scrollbar size

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -8,7 +8,7 @@
 
 import * as Log from '../core/util/logging.js';
 import _, { l10n } from './localization.js';
-import { isTouchDevice, isSafari, isIOS, isAndroid, dragThreshold }
+import { isTouchDevice, isSafari, hasScrollbarGutter, dragThreshold }
     from '../core/util/browser.js';
 import { setCapture, getPointerEvent } from '../core/util/events.js';
 import KeyTable from "../core/input/keysym.js";
@@ -1269,8 +1269,9 @@ const UI = {
             // Can't be clipping if viewport is scaled to fit
             UI.forceSetting('view_clip', false);
             UI.rfb.clipViewport  = false;
-        } else if (isIOS() || isAndroid()) {
-            // iOS and Android usually have shit scrollbars
+        } else if (!hasScrollbarGutter) {
+            // Some platforms have scrollbars that are difficult
+            // to use in our case, so we always use our own panning
             UI.forceSetting('view_clip', true);
             UI.rfb.clipViewport = true;
         } else {

--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -4,6 +4,8 @@
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.
+ *
+ * Browser feature support detection
  */
 
 import * as Log from './logging.js';

--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -79,6 +79,13 @@ try {
 }
 export const hasScrollbarGutter = _hasScrollbarGutter;
 
+/*
+ * The functions for detection of platforms and browsers below are exported
+ * but the use of these should be minimized as much as possible.
+ *
+ * It's better to use feature detection than platform detection.
+ */
+
 export function isMac() {
     return navigator && !!(/mac/i).exec(navigator.platform);
 }

--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -52,6 +52,31 @@ try {
 }
 export const supportsImageMetadata = _supportsImageMetadata;
 
+let _hasScrollbarGutter = true;
+try {
+    // Create invisible container
+    const container = document.createElement('div');
+    container.style.visibility = 'hidden';
+    container.style.overflow = 'scroll'; // forcing scrollbars
+    document.body.appendChild(container);
+
+    // Create a div and place it in the container
+    const child = document.createElement('div');
+    container.appendChild(child);
+
+    // Calculate the difference between the container's full width
+    // and the child's width - the difference is the scrollbars
+    const scrollbarWidth = (container.offsetWidth - child.offsetWidth);
+
+    // Clean up
+    container.parentNode.removeChild(container);
+
+    _hasScrollbarGutter = scrollbarWidth != 0;
+} catch (exc) {
+    Log.Error("Scrollbar test exception: " + exc);
+}
+export const hasScrollbarGutter = _hasScrollbarGutter;
+
 export function isMac() {
     return navigator && !!(/mac/i).exec(navigator.platform);
 }
@@ -65,10 +90,6 @@ export function isIOS() {
            (!!(/ipad/i).exec(navigator.platform) ||
             !!(/iphone/i).exec(navigator.platform) ||
             !!(/ipod/i).exec(navigator.platform));
-}
-
-export function isAndroid() {
-    return navigator && !!(/android/i).exec(navigator.userAgent);
 }
 
 export function isSafari() {


### PR DESCRIPTION
Instead of always disabling scrollbars on iOS and Android, this PR adds dynamic detection for this.

The reason scrollbars were disabled on iOS and Android was that on these platforms the scrollbars were very thin and gets hidden when you don't use them. We can detect this by looking at the size of the scrollbars.

Verified on:

**iOS 13**
- [x] Safari - hidden
- [x] Firefox - hidden
- [x] Chrome - hidden

**Android 9**
- [x] Firefox 69 - hidden
- [x] Chrome 77 - hidden

**Chromebook**
- [x] Firefox - hidden
- [x] Firefox - hidden

**Fedora 31**
- [x] Firefox 69 - shows
- [x] Chrome 77 - shows

**macOS 10.15**
- [x] Safari - hidden
- [x] Firefox - hidden
- [x] Chrome - hidden

**Windows 10**
- [x] Firefox - shows
- [x] Chrome - shows
- [x] IE - shows
- [x] Edge - shows
