### PR TITLE
Separate mouse and touch events

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -88,7 +88,7 @@ const UI = {
 
         // Setup event handlers
         UI.addControlbarHandlers();
-        UI.addTouchSpecificHandlers();
+        if (isTouchDevice) {  UI.addTouchSpecificHandlers(); }
         UI.addExtraKeysHandlers();
         UI.addMachineHandlers();
         UI.addConnectionControlHandlers();
@@ -430,7 +430,7 @@ const UI = {
             UI.disableSetting('port');
             UI.disableSetting('path');
             UI.disableSetting('repeaterID');
-            UI.setMouseButton(1);
+            if (isTouchDevice) { UI.setMouseButton(1); }
 
             // Hide the controlbar after 2 seconds
             UI.closeControlbarTimeout = setTimeout(UI.closeControlbar, 2000);
@@ -1661,8 +1661,10 @@ const UI = {
                 .classList.add('noVNC_hidden');
             document.getElementById('noVNC_toggle_extra_keys_button')
                 .classList.add('noVNC_hidden');
-            document.getElementById('noVNC_mouse_button' + UI.rfb.touchButton)
-                .classList.add('noVNC_hidden');
+            if (isTouchDevice) {
+                document.getElementById('noVNC_mouse_button' + UI.rfb.touchButton)
+                    .classList.add('noVNC_hidden');
+            }
             document.getElementById('noVNC_clipboard_button')
                 .classList.add('noVNC_hidden');
         } else {
@@ -1670,8 +1672,10 @@ const UI = {
                 .classList.remove('noVNC_hidden');
             document.getElementById('noVNC_toggle_extra_keys_button')
                 .classList.remove('noVNC_hidden');
-            document.getElementById('noVNC_mouse_button' + UI.rfb.touchButton)
-                .classList.remove('noVNC_hidden');
+            if (isTouchDevice) {
+                document.getElementById('noVNC_mouse_button' + UI.rfb.touchButton)
+                    .classList.remove('noVNC_hidden');
+            }
             document.getElementById('noVNC_clipboard_button')
                 .classList.remove('noVNC_hidden');
         }

--- a/core/input/touch.js
+++ b/core/input/touch.js
@@ -1,0 +1,140 @@
+/*
+ * noVNC: HTML5 VNC client
+ * Copyright (C) 2020 The noVNC Authors
+ * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
+ */
+
+import * as Log from '../util/logging.js';
+import { stopEvent, getPointerEvent } from '../util/events.js';
+
+const TOUCH_MOVE_DELAY = 17; // Minimum wait (ms) between two touch moves
+
+export default class Touch {
+    constructor(target) {
+        this._target = target || document;
+
+        this._doubleClickTimer = null;
+        this._lastTouchPos = null;
+        this._oldTouchMoveTime = 0;
+
+        this._eventHandlers = {
+            'touchstart': this._handleTouchStart.bind(this),
+            'touchend': this._handleTouchEnd.bind(this),
+            'touchmove': this._handleTouchMove.bind(this)
+        };
+
+        // ===== PROPERTIES =====
+
+        this.touchButton = 1;                 // Button mask (1, 2, 4) for touch devices (0 means ignore clicks)
+
+        // ===== EVENT HANDLERS =====
+
+        this.ontouch = () => {}; // Handler for mouse button click/release
+        this.ontouchmove = () => {}; // Handler for mouse movement
+    }
+
+    // ===== PRIVATE METHODS =====
+
+    _handleTouchStart(e) {
+        this._handleTouchAsMouseButton(e, 1);
+    }
+
+    _handleTouchEnd(e) {
+        this._handleTouchAsMouseButton(e, 0);
+    }
+
+    _handleTouchMove(e) {
+        const position = this._getTouchPosition(e);
+
+        // Limit touch move events to one every TOUCH_MOVE_DELAY ms
+        clearTimeout(this.touchMoveTimer);
+        const newTouchMoveTime = Date.now();
+        if (newTouchMoveTime < this._oldTouchMoveTime + TOUCH_MOVE_DELAY) {
+            this.touchMoveTimer = setTimeout(this.ontouchmove.bind(this),
+                                             TOUCH_MOVE_DELAY,
+                                             position.x, position.y);
+        } else {
+            this.ontouchmove(position.x, position.y);
+        }
+        this._oldTouchMoveTime = newTouchMoveTime;
+
+        stopEvent(e);
+    }
+
+    _handleTouchAsMouseButton(e, down) {
+        let position = this._getTouchPosition(e);
+
+        // When two touches occur within 500 ms of each other and are
+        // close enough together a double click is triggered.
+        if (down == 1) {
+            if (this._doubleClickTimer === null) {
+                this._lastTouchPos = position;
+            } else {
+                clearTimeout(this._doubleClickTimer);
+
+                // When the distance between the two touches is small enough
+                // force the position of the latter touch to the position of
+                // the first.
+
+                const xs = this._lastTouchPos.x - position.x;
+                const ys = this._lastTouchPos.y - position.y;
+                const d = Math.sqrt((xs * xs) + (ys * ys));
+
+                // The goal is to trigger on a certain physical width,
+                // the devicePixelRatio brings us a bit closer but is
+                // not optimal.
+                const threshold = 20 * (window.devicePixelRatio || 1);
+                if (d < threshold) {
+                    position = this._lastTouchPos;
+                }
+            }
+            this._doubleClickTimer = setTimeout(() => (this._doubleClickTimer = null), 500);
+        }
+
+        const bmask = this.touchButton;
+
+        Log.Debug("onmousebutton " + (down ? "down" : "up") +
+                  ", x: " + position.x + ", y: " + position.y + ", bmask: " + bmask);
+        this.ontouch(position.x, position.y, down, bmask);
+
+        stopEvent(e);
+    }
+
+   // Get coordinates relative to target
+    _getTouchPosition(e) {
+        const pointerEvent = getPointerEvent(e);
+        const bounds = this._target.getBoundingClientRect();
+        let x;
+        let y;
+        // Clip to target bounds
+        if (pointerEvent.clientX < bounds.left) {
+            x = 0;
+        } else if (pointerEvent.clientX >= bounds.right) {
+            x = bounds.width - 1;
+        } else {
+            x = pointerEvent.clientX - bounds.left;
+        }
+        if (pointerEvent.clientY < bounds.top) {
+            y = 0;
+        } else if (pointerEvent.clientY >= bounds.bottom) {
+            y = bounds.height - 1;
+        } else {
+            y = pointerEvent.clientY - bounds.top;
+        }
+        return { x, y };
+    }
+
+    // ===== PUBLIC METHODS =====
+
+    grab() {
+        this._target.addEventListener('touchstart', this._eventHandlers.touchstart);
+        this._target.addEventListener('touchend', this._eventHandlers.touchend);
+        this._target.addEventListener('touchmove', this._eventHandlers.touchmove);
+    }
+
+    ungrab() {
+        this._target.removeEventListener('touchstart', this._eventHandlers.touchstart);
+        this._target.removeEventListener('touchend', this._eventHandlers.touchend);
+        this._target.removeEventListener('touchmove', this._eventHandlers.touchmove);
+    }
+}

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -311,8 +311,14 @@ export default class RFB extends EventTargetMixin {
 
     get capabilities() { return this._capabilities; }
 
-    get touchButton() { return this._touch.touchButton; }
-    set touchButton(button) { this._touch.touchButton = button; }
+    get touchButton() {
+        if (!this._touch) { return null; }
+        return this._touch.touchButton;
+    }
+    set touchButton(button) {
+        if (!this._touch) { return; }
+        this._touch.touchButton = button;
+    }
 
     get clipViewport() { return this._clipViewport; }
     set clipViewport(viewport) {

--- a/docs/API-internal.md
+++ b/docs/API-internal.md
@@ -11,8 +11,10 @@ official external API.
 
 ## 1.1 Module List
 
-* __Mouse__ (core/input/mouse.js): Mouse input event handler with
-limited touch support.
+* __Mouse__ (core/input/mouse.js): Mouse input event handler.
+
+* __Touch__ (core/input/touch.js): Touch input event handler that converts
+touch events to mouse events.
 
 * __Keyboard__ (core/input/keyboard.js): Keyboard input event handler with
 non-US keyboard support. Translates keyDown and keyUp events to X11
@@ -39,9 +41,7 @@ callback event name, and the callback function.
 
 ### 2.1.1 Configuration Attributes
 
-| name        | type | mode | default  | description
-| ----------- | ---- | ---- | -------- | ------------
-| touchButton | int  | RW   | 1        | Button mask (1, 2, 4) for which click to send on touch devices. 0 means ignore clicks.
+None
 
 ### 2.1.2 Methods
 
@@ -58,29 +58,52 @@ callback event name, and the callback function.
 | onmousemove   | (x, y)              | Handler for mouse movement
 
 
-## 2.2 Keyboard Module
+## 2.2 Touch Module
 
 ### 2.2.1 Configuration Attributes
 
-None
+| name        | type | mode | default  | description
+| ----------- | ---- | ---- | -------- | ------------
+| touchButton | int  | RW   | 1        | Button mask (1, 2, 4) for which click to send on touch devices. 0 means ignore clicks.
 
 ### 2.2.2 Methods
+
+| name   | parameters | description
+| ------ | ---------- | ------------
+| grab   | ()         | Begin capturing touch events
+| ungrab | ()         | Stop capturing touch events
+
+### 2.2.2 Callbacks
+
+| name          | parameters          | description
+| ------------- | ------------------- | ------------
+| ontouch       | (x, y, down, bmask) | Handler for touch event (as button click/release)
+| ontouchmove   | (x, y)              | Handler for touch movement
+
+
+## 2.3 Keyboard Module
+
+### 2.3.1 Configuration Attributes
+
+None
+
+### 2.3.2 Methods
 
 | name   | parameters | description
 | ------ | ---------- | ------------
 | grab   | ()         | Begin capturing keyboard events
 | ungrab | ()         | Stop capturing keyboard events
 
-### 2.2.3 Callbacks
+### 2.3.4 Callbacks
 
 | name       | parameters           | description
 | ---------- | -------------------- | ------------
 | onkeypress | (keysym, code, down) | Handler for key press/release
 
 
-## 2.3 Display Module
+## 2.4 Display Module
 
-### 2.3.1 Configuration Attributes
+### 2.4.1 Configuration Attributes
 
 | name         | type  | mode | default | description
 | ------------ | ----- | ---- | ------- | ------------
@@ -89,7 +112,7 @@ None
 | width        | int   | RO   |         | Display area width
 | height       | int   | RO   |         | Display area height
 
-### 2.3.2 Methods
+### 2.4.2 Methods
 
 | name               | parameters                                              | description
 | ------------------ | ------------------------------------------------------- | ------------
@@ -113,7 +136,7 @@ None
 | drawImage          | (img, x, y)                                             | Draw image and track damage
 | autoscale          | (containerWidth, containerHeight)                       | Scale the display
 
-### 2.3.3 Callbacks
+### 2.4.3 Callbacks
 
 | name    | parameters | description
 | ------- | ---------- | ------------

--- a/tests/test.mouse.js
+++ b/tests/test.mouse.js
@@ -34,7 +34,6 @@ describe('Mouse Event Handling', function () {
         e.preventDefault = sinon.spy();
         return e;
     };
-    const touchevent = mouseevent;
 
     describe('Decode Mouse Events', function () {
         it('should decode mousedown events', function (done) {
@@ -87,131 +86,6 @@ describe('Mouse Event Handling', function () {
                                                { deltaX: 50, deltaY: 0,
                                                  deltaMode: 0}));
         });
-    });
-
-    describe('Double-click for Touch', function () {
-
-        beforeEach(function () { this.clock = sinon.useFakeTimers(); });
-        afterEach(function () { this.clock.restore(); });
-
-        it('should use same pos for 2nd tap if close enough', function (done) {
-            let calls = 0;
-            const mouse = new Mouse(target);
-            mouse.onmousebutton = (x, y, down, bmask) => {
-                calls++;
-                if (calls === 1) {
-                    expect(down).to.be.equal(1);
-                    expect(x).to.be.equal(68);
-                    expect(y).to.be.equal(36);
-                } else if (calls === 3) {
-                    expect(down).to.be.equal(1);
-                    expect(x).to.be.equal(68);
-                    expect(y).to.be.equal(36);
-                    done();
-                }
-            };
-            // touch events are sent in an array of events
-            // with one item for each touch point
-            mouse._handleMouseDown(touchevent(
-                'touchstart', { touches: [{ clientX: 78, clientY: 46 }]}));
-            this.clock.tick(10);
-            mouse._handleMouseUp(touchevent(
-                'touchend', { touches: [{ clientX: 79, clientY: 45 }]}));
-            this.clock.tick(200);
-            mouse._handleMouseDown(touchevent(
-                'touchstart', { touches: [{ clientX: 67, clientY: 35 }]}));
-            this.clock.tick(10);
-            mouse._handleMouseUp(touchevent(
-                'touchend', { touches: [{ clientX: 66, clientY: 36 }]}));
-        });
-
-        it('should not modify 2nd tap pos if far apart', function (done) {
-            let calls = 0;
-            const mouse = new Mouse(target);
-            mouse.onmousebutton = (x, y, down, bmask) => {
-                calls++;
-                if (calls === 1) {
-                    expect(down).to.be.equal(1);
-                    expect(x).to.be.equal(68);
-                    expect(y).to.be.equal(36);
-                } else if (calls === 3) {
-                    expect(down).to.be.equal(1);
-                    expect(x).to.not.be.equal(68);
-                    expect(y).to.not.be.equal(36);
-                    done();
-                }
-            };
-            mouse._handleMouseDown(touchevent(
-                'touchstart', { touches: [{ clientX: 78, clientY: 46 }]}));
-            this.clock.tick(10);
-            mouse._handleMouseUp(touchevent(
-                'touchend', { touches: [{ clientX: 79, clientY: 45 }]}));
-            this.clock.tick(200);
-            mouse._handleMouseDown(touchevent(
-                'touchstart', { touches: [{ clientX: 57, clientY: 35 }]}));
-            this.clock.tick(10);
-            mouse._handleMouseUp(touchevent(
-                'touchend', { touches: [{ clientX: 56, clientY: 36 }]}));
-        });
-
-        it('should not modify 2nd tap pos if not soon enough', function (done) {
-            let calls = 0;
-            const mouse = new Mouse(target);
-            mouse.onmousebutton = (x, y, down, bmask) => {
-                calls++;
-                if (calls === 1) {
-                    expect(down).to.be.equal(1);
-                    expect(x).to.be.equal(68);
-                    expect(y).to.be.equal(36);
-                } else if (calls === 3) {
-                    expect(down).to.be.equal(1);
-                    expect(x).to.not.be.equal(68);
-                    expect(y).to.not.be.equal(36);
-                    done();
-                }
-            };
-            mouse._handleMouseDown(touchevent(
-                'touchstart', { touches: [{ clientX: 78, clientY: 46 }]}));
-            this.clock.tick(10);
-            mouse._handleMouseUp(touchevent(
-                'touchend', { touches: [{ clientX: 79, clientY: 45 }]}));
-            this.clock.tick(500);
-            mouse._handleMouseDown(touchevent(
-                'touchstart', { touches: [{ clientX: 67, clientY: 35 }]}));
-            this.clock.tick(10);
-            mouse._handleMouseUp(touchevent(
-                'touchend', { touches: [{ clientX: 66, clientY: 36 }]}));
-        });
-
-        it('should not modify 2nd tap pos if not touch', function (done) {
-            let calls = 0;
-            const mouse = new Mouse(target);
-            mouse.onmousebutton = (x, y, down, bmask) => {
-                calls++;
-                if (calls === 1) {
-                    expect(down).to.be.equal(1);
-                    expect(x).to.be.equal(68);
-                    expect(y).to.be.equal(36);
-                } else if (calls === 3) {
-                    expect(down).to.be.equal(1);
-                    expect(x).to.not.be.equal(68);
-                    expect(y).to.not.be.equal(36);
-                    done();
-                }
-            };
-            mouse._handleMouseDown(mouseevent(
-                'mousedown', { button: '0x01', clientX: 78, clientY: 46 }));
-            this.clock.tick(10);
-            mouse._handleMouseUp(mouseevent(
-                'mouseup', { button: '0x01', clientX: 79, clientY: 45 }));
-            this.clock.tick(200);
-            mouse._handleMouseDown(mouseevent(
-                'mousedown', { button: '0x01', clientX: 67, clientY: 35 }));
-            this.clock.tick(10);
-            mouse._handleMouseUp(mouseevent(
-                'mouseup', { button: '0x01', clientX: 66, clientY: 36 }));
-        });
-
     });
 
     describe('Accumulate mouse wheel events with small delta', function () {

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -495,28 +495,28 @@ describe('Remote Frame Buffer Protocol Client', function () {
             });
 
             it('should not send button messages when initiating viewport dragging', function () {
-                client._handleMouseButton(13, 9, 0x001);
+                client._handlePointerPress(13, 9, 0x001);
                 expect(RFB.messages.pointerEvent).to.not.have.been.called;
             });
 
             it('should send button messages when release without movement', function () {
                 // Just up and down
-                client._handleMouseButton(13, 9, 0x001);
-                client._handleMouseButton(13, 9, 0x000);
+                client._handlePointerPress(13, 9, 0x001);
+                client._handlePointerPress(13, 9, 0x000);
                 expect(RFB.messages.pointerEvent).to.have.been.calledTwice;
 
                 RFB.messages.pointerEvent.resetHistory();
 
                 // Small movement
-                client._handleMouseButton(13, 9, 0x001);
-                client._handleMouseMove(15, 14);
-                client._handleMouseButton(15, 14, 0x000);
+                client._handlePointerPress(13, 9, 0x001);
+                client._handlePointerMove(15, 14);
+                client._handlePointerPress(15, 14, 0x000);
                 expect(RFB.messages.pointerEvent).to.have.been.calledTwice;
             });
 
             it('should send button message directly when drag is disabled', function () {
                 client.dragViewport = false;
-                client._handleMouseButton(13, 9, 0x001);
+                client._handlePointerPress(13, 9, 0x001);
                 expect(RFB.messages.pointerEvent).to.have.been.calledOnce;
             });
 
@@ -525,15 +525,15 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
                 // Too small movement
 
-                client._handleMouseButton(13, 9, 0x001);
-                client._handleMouseMove(18, 9);
+                client._handlePointerPress(13, 9, 0x001);
+                client._handlePointerMove(18, 9);
 
                 expect(RFB.messages.pointerEvent).to.not.have.been.called;
                 expect(client._display.viewportChangePos).to.not.have.been.called;
 
                 // Sufficient movement
 
-                client._handleMouseMove(43, 9);
+                client._handlePointerMove(43, 9);
 
                 expect(RFB.messages.pointerEvent).to.not.have.been.called;
                 expect(client._display.viewportChangePos).to.have.been.calledOnce;
@@ -543,7 +543,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
                 // Now a small movement should move right away
 
-                client._handleMouseMove(43, 14);
+                client._handlePointerMove(43, 14);
 
                 expect(RFB.messages.pointerEvent).to.not.have.been.called;
                 expect(client._display.viewportChangePos).to.have.been.calledOnce;
@@ -553,9 +553,9 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should not send button messages when dragging ends', function () {
                 // First the movement
 
-                client._handleMouseButton(13, 9, 0x001);
-                client._handleMouseMove(43, 9);
-                client._handleMouseButton(43, 9, 0x000);
+                client._handlePointerPress(13, 9, 0x001);
+                client._handlePointerMove(43, 9);
+                client._handlePointerPress(43, 9, 0x000);
 
                 expect(RFB.messages.pointerEvent).to.not.have.been.called;
             });
@@ -563,15 +563,15 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should terminate viewport dragging on a button up event', function () {
                 // First the dragging movement
 
-                client._handleMouseButton(13, 9, 0x001);
-                client._handleMouseMove(43, 9);
-                client._handleMouseButton(43, 9, 0x000);
+                client._handlePointerPress(13, 9, 0x001);
+                client._handlePointerMove(43, 9);
+                client._handlePointerPress(43, 9, 0x000);
 
                 // Another movement now should not move the viewport
 
                 sinon.spy(client._display, "viewportChangePos");
 
-                client._handleMouseMove(43, 59);
+                client._handlePointerMove(43, 59);
 
                 expect(client._display.viewportChangePos).to.not.have.been.called;
             });
@@ -2727,26 +2727,26 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should not send button messages in view-only mode', function () {
                 client._viewOnly = true;
                 sinon.spy(client._sock, 'flush');
-                client._handleMouseButton(0, 0, 1, 0x001);
+                client._handlePointerPress(0, 0, 1, 0x001);
                 expect(client._sock.flush).to.not.have.been.called;
             });
 
             it('should not send movement messages in view-only mode', function () {
                 client._viewOnly = true;
                 sinon.spy(client._sock, 'flush');
-                client._handleMouseMove(0, 0);
+                client._handlePointerMove(0, 0);
                 expect(client._sock.flush).to.not.have.been.called;
             });
 
             it('should send a pointer event on mouse button presses', function () {
-                client._handleMouseButton(10, 12, 1, 0x001);
+                client._handlePointerPress(10, 12, 1, 0x001);
                 const pointer_msg = {_sQ: new Uint8Array(6), _sQlen: 0, flush: () => {}};
                 RFB.messages.pointerEvent(pointer_msg, 10, 12, 0x001);
                 expect(client._sock).to.have.sent(pointer_msg._sQ);
             });
 
             it('should send a mask of 1 on mousedown', function () {
-                client._handleMouseButton(10, 12, 1, 0x001);
+                client._handlePointerPress(10, 12, 1, 0x001);
                 const pointer_msg = {_sQ: new Uint8Array(6), _sQlen: 0, flush: () => {}};
                 RFB.messages.pointerEvent(pointer_msg, 10, 12, 0x001);
                 expect(client._sock).to.have.sent(pointer_msg._sQ);
@@ -2754,22 +2754,22 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             it('should send a mask of 0 on mouseup', function () {
                 client._mouse_buttonMask = 0x001;
-                client._handleMouseButton(10, 12, 0, 0x001);
+                client._handlePointerPress(10, 12, 0, 0x001);
                 const pointer_msg = {_sQ: new Uint8Array(6), _sQlen: 0, flush: () => {}};
                 RFB.messages.pointerEvent(pointer_msg, 10, 12, 0x000);
                 expect(client._sock).to.have.sent(pointer_msg._sQ);
             });
 
             it('should send a pointer event on mouse movement', function () {
-                client._handleMouseMove(10, 12);
+                client._handlePointerMove(10, 12);
                 const pointer_msg = {_sQ: new Uint8Array(6), _sQlen: 0, flush: () => {}};
                 RFB.messages.pointerEvent(pointer_msg, 10, 12, 0x000);
                 expect(client._sock).to.have.sent(pointer_msg._sQ);
             });
 
             it('should set the button mask so that future mouse movements use it', function () {
-                client._handleMouseButton(10, 12, 1, 0x010);
-                client._handleMouseMove(13, 9);
+                client._handlePointerPress(10, 12, 1, 0x010);
+                client._handlePointerMove(13, 9);
                 const pointer_msg = {_sQ: new Uint8Array(12), _sQlen: 0, flush: () => {}};
                 RFB.messages.pointerEvent(pointer_msg, 10, 12, 0x010);
                 RFB.messages.pointerEvent(pointer_msg, 13, 9, 0x010);

--- a/tests/test.touch.js
+++ b/tests/test.touch.js
@@ -1,0 +1,135 @@
+const expect = chai.expect;
+
+import Touch from '../core/input/touch.js';
+
+describe('Touch Event Handling', function () {
+    "use strict";
+
+    let target;
+
+    beforeEach(function () {
+        // For these tests we can assume that the canvas is 100x100
+        // located at coordinates 10x10
+        target = document.createElement('canvas');
+        target.style.position = "absolute";
+        target.style.top = "10px";
+        target.style.left = "10px";
+        target.style.width = "100px";
+        target.style.height = "100px";
+        document.body.appendChild(target);
+    });
+    afterEach(function () {
+        document.body.removeChild(target);
+        target = null;
+    });
+
+    // The real constructors might not work everywhere we
+    // want to run these tests
+    const mouseevent = (typeArg, MouseEventInit) => {
+        const e = { type: typeArg };
+        for (let key in MouseEventInit) {
+            e[key] = MouseEventInit[key];
+        }
+        e.stopPropagation = sinon.spy();
+        e.preventDefault = sinon.spy();
+        return e;
+    };
+    const touchevent = mouseevent;
+
+    describe('Double-click for Touch', function () {
+
+        beforeEach(function () { this.clock = sinon.useFakeTimers(); });
+        afterEach(function () { this.clock.restore(); });
+
+        it('should use same pos for 2nd tap if close enough', function (done) {
+            let calls = 0;
+            const touch = new Touch(target);
+            touch.ontouch = (x, y, down, bmask) => {
+                calls++;
+                if (calls === 1) {
+                    expect(down).to.be.equal(1);
+                    expect(x).to.be.equal(68);
+                    expect(y).to.be.equal(36);
+                } else if (calls === 3) {
+                    expect(down).to.be.equal(1);
+                    expect(x).to.be.equal(68);
+                    expect(y).to.be.equal(36);
+                    done();
+                }
+            };
+            // touch events are sent in an array of events
+            // with one item for each touch point
+            touch._handleTouchStart(touchevent(
+                'touchstart', { touches: [{ clientX: 78, clientY: 46 }]}));
+            this.clock.tick(10);
+            touch._handleTouchEnd(touchevent(
+                'touchend', { touches: [{ clientX: 79, clientY: 45 }]}));
+            this.clock.tick(200);
+            touch._handleTouchStart(touchevent(
+                'touchstart', { touches: [{ clientX: 67, clientY: 35 }]}));
+            this.clock.tick(10);
+            touch._handleTouchEnd(touchevent(
+                'touchend', { touches: [{ clientX: 66, clientY: 36 }]}));
+        });
+
+        it('should not modify 2nd tap pos if far apart', function (done) {
+            let calls = 0;
+            const touch = new Touch(target);
+            touch.ontouch = (x, y, down, bmask) => {
+                calls++;
+                if (calls === 1) {
+                    expect(down).to.be.equal(1);
+                    expect(x).to.be.equal(68);
+                    expect(y).to.be.equal(36);
+                } else if (calls === 3) {
+                    expect(down).to.be.equal(1);
+                    expect(x).to.not.be.equal(68);
+                    expect(y).to.not.be.equal(36);
+                    done();
+                }
+            };
+            touch._handleTouchStart(touchevent(
+                'touchstart', { touches: [{ clientX: 78, clientY: 46 }]}));
+            this.clock.tick(10);
+            touch._handleTouchEnd(touchevent(
+                'touchend', { touches: [{ clientX: 79, clientY: 45 }]}));
+            this.clock.tick(200);
+            touch._handleTouchStart(touchevent(
+                'touchstart', { touches: [{ clientX: 57, clientY: 35 }]}));
+            this.clock.tick(10);
+            touch._handleTouchEnd(touchevent(
+                'touchend', { touches: [{ clientX: 56, clientY: 36 }]}));
+        });
+
+        it('should not modify 2nd tap pos if not soon enough', function (done) {
+            let calls = 0;
+            const touch = new Touch(target);
+            touch.ontouch = (x, y, down, bmask) => {
+                calls++;
+                if (calls === 1) {
+                    expect(down).to.be.equal(1);
+                    expect(x).to.be.equal(68);
+                    expect(y).to.be.equal(36);
+                } else if (calls === 3) {
+                    expect(down).to.be.equal(1);
+                    expect(x).to.not.be.equal(68);
+                    expect(y).to.not.be.equal(36);
+                    done();
+                }
+            };
+            touch._handleTouchStart(touchevent(
+                'touchstart', { touches: [{ clientX: 78, clientY: 46 }]}));
+            this.clock.tick(10);
+            touch._handleTouchEnd(touchevent(
+                'touchend', { touches: [{ clientX: 79, clientY: 45 }]}));
+            this.clock.tick(500);
+            touch._handleTouchStart(touchevent(
+                'touchstart', { touches: [{ clientX: 67, clientY: 35 }]}));
+            this.clock.tick(10);
+            touch._handleTouchEnd(touchevent(
+                'touchend', { touches: [{ clientX: 66, clientY: 36 }]}));
+        });
+
+    });
+
+});


### PR DESCRIPTION
This PR is an initial step towards #1267 
It separates the mouse event handling from the touch event handling.

A separate step could be to implement multiple Touch modules for different interaction styles a.k.a convert touch events to mouse events in different ways.
For example, one that would work for me would be something like:

| Touch action | Click event |
|------|------|
| Single Tap| Click|
| Long press | Right-click (contextmenu or click event)|
| Press and then drag | Click and drag (mousemove event) |
| Two-finger press and drag | Pan (Wheel event)|
| Two-finger pinch | Zoom (Not sure of the events here) |

A library like hammer.js would make such implementations very easy.