### PR TITLE
Add automatic clipboard support

### DIFF
--- a/core/clipboard.js
+++ b/core/clipboard.js
@@ -1,0 +1,46 @@
+export default class Clipboard {
+    constructor(target) {
+        this._target = target;
+
+        this._eventHandlers = {
+            'copy': this._handleCopy.bind(this),
+            'paste': this._handlePaste.bind(this)
+        };
+
+        // ===== EVENT HANDLERS =====
+
+        this.onpaste = () => {};
+    }
+
+    // ===== PRIVATE METHODS =====
+
+    _handleCopy(e) {
+        if (navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(e.clipboardData.getData('text/plain')).catch(() => {/* Do nothing */});
+        }
+    }
+
+    _handlePaste(e) {
+        if (navigator.clipboard.readText) {
+            navigator.clipboard.readText().then(this.onpaste).catch(() => {/* Do nothing */});
+        } else if (e.clipboardData) {
+            this.onpaste(e.clipboardData.getData('text/plain'));
+        }
+    }
+
+    // ===== PUBLIC METHODS =====
+
+    grab() {
+        if (!Clipboard.isSupported) return;
+        this._target.addEventListener('copy', this._eventHandlers.copy);
+        this._target.addEventListener('paste', this._eventHandlers.paste);
+    }
+
+    ungrab() {
+        if (!Clipboard.isSupported) return;
+        this._target.removeEventListener('copy', this._eventHandlers.copy);
+        this._target.removeEventListener('paste', this._eventHandlers.paste);
+    }
+}
+
+Clipboard.isSupported = (navigator && navigator.clipboard) ? true : false;

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1531,7 +1531,12 @@ export default class RFB extends EventTargetMixin {
             if (Clipboard.isSupported) {
                 const clipboardData = new DataTransfer();
                 clipboardData.setData("text/plain", text);
-                this._canvas.dispatchEvent(new ClipboardEvent('copy', { clipboardData }));
+                const clipboardEvent = new ClipboardEvent('paste', { clipboardData });
+                // Force initialization since the constructor is broken in Firefox
+                if (!clipboardEvent.clipboardData.items.length) {
+                    clipboardEvent.clipboardData.items.add(text, "text/plain");
+                }
+                this._canvas.dispatchEvent(clipboardEvent);
             }
 
         } else {

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1531,7 +1531,7 @@ export default class RFB extends EventTargetMixin {
             if (Clipboard.isSupported) {
                 const clipboardData = new DataTransfer();
                 clipboardData.setData("text/plain", text);
-                const clipboardEvent = new ClipboardEvent('paste', { clipboardData });
+                const clipboardEvent = new ClipboardEvent('copy', { clipboardData });
                 // Force initialization since the constructor is broken in Firefox
                 if (!clipboardEvent.clipboardData.items.length) {
                     clipboardEvent.clipboardData.items.add(text, "text/plain");

--- a/docs/API-internal.md
+++ b/docs/API-internal.md
@@ -21,6 +21,8 @@ keysym values.
 * __Display__ (core/display.js): Efficient 2D rendering abstraction
 layered on the HTML5 canvas element.
 
+* __Clipboard__ (core/clipboard.js): Clipboard event handler.
+
 * __Websock__ (core/websock.js): Websock client from websockify
 with transparent binary data support.
 [Websock API](https://github.com/novnc/websockify-js/wiki/websock.js) wiki page.
@@ -28,7 +30,7 @@ with transparent binary data support.
 
 ## 1.2 Callbacks
 
-For the Mouse, Keyboard and Display objects the callback functions are
+For the Mouse, Keyboard, Display and Clipboard objects the callback functions are
 assigned to configuration attributes, just as for the RFB object. The
 WebSock module has a method named 'on' that takes two parameters: the
 callback event name, and the callback function.
@@ -118,3 +120,23 @@ None
 | name    | parameters | description
 | ------- | ---------- | ------------
 | onflush | ()         | A display flush has been requested and we are now ready to resume FBU processing
+
+
+## 2.4 Clipboard Module
+
+### 2.4.1 Configuration Attributes
+
+None
+
+### 2.4.2 Methods
+
+| name               | parameters        | description
+| ------------------ | ----------------- | ------------
+| grab               | ()                | Begin capturing clipboard events
+| ungrab             | ()                | Stop capturing clipboard events
+
+### 2.3.3 Callbacks
+
+| name    | parameters | description
+| ------- | ---------- | ------------
+| onpaste | (text)     | Called with the text content of the clipboard when the user paste something

--- a/tests/test.clipboard.js
+++ b/tests/test.clipboard.js
@@ -1,0 +1,54 @@
+const expect = chai.expect;
+
+import Clipboard from '../core/clipboard.js';
+
+describe('Automatic Clipboard Sync', function () {
+    "use strict";
+
+    if (Clipboard.isSupported) {
+        beforeEach(function () {
+            if (navigator.clipboard.writeText) {
+                sinon.spy(navigator.clipboard, 'writeText');
+            }
+            if (navigator.clipboard.readText) {
+                sinon.spy(navigator.clipboard, 'readText');
+            }
+        });
+
+        afterEach(function () {
+            if (navigator.clipboard.writeText) {
+                navigator.clipboard.writeText.restore();
+            }
+            if (navigator.clipboard.readText) {
+                navigator.clipboard.readText.restore();
+            }
+        });
+    }
+
+    it('incoming clipboard data from the server is copied to the local clipboard', function () {
+        const text = 'Random string for testing';
+        const clipboard = new Clipboard();
+        if (Clipboard.isSupported) {
+            const clipboardData = new DataTransfer();
+            clipboardData.setData("text/plain", text);
+            clipboard._handleCopy(new ClipboardEvent('paste', { clipboardData }));
+            if (navigator.clipboard.writeText) {
+                expect(navigator.clipboard.writeText).to.have.been.calledWith(text);
+            }
+        }
+    });
+
+    it('should copy local pasted data to the server clipboard', function () {
+        const text = 'Another random string for testing';
+        const clipboard = new Clipboard();
+        clipboard.onpaste = pasterText => expect(pasterText).to.equal(text);
+        if (Clipboard.isSupported) {
+            const clipboardData = new DataTransfer();
+            clipboardData.setData("text/plain", text);
+            clipboard._handlePaste(new ClipboardEvent('paste', { clipboardData }));
+            if (navigator.clipboard.readText) {
+                expect(navigator.clipboard.readText).to.have.been.called;
+            }
+        }
+    });
+});

--- a/tests/test.clipboard.js
+++ b/tests/test.clipboard.js
@@ -31,7 +31,12 @@ describe('Automatic Clipboard Sync', function () {
         if (Clipboard.isSupported) {
             const clipboardData = new DataTransfer();
             clipboardData.setData("text/plain", text);
-            clipboard._handleCopy(new ClipboardEvent('paste', { clipboardData }));
+            const clipboardEvent = new ClipboardEvent('paste', { clipboardData });
+            // Force initialization since the constructor is broken in Firefox
+            if (!clipboardEvent.clipboardData.items.length) {
+                clipboardEvent.clipboardData.items.add(text, "text/plain");
+            }
+            clipboard._handleCopy(clipboardEvent);
             if (navigator.clipboard.writeText) {
                 expect(navigator.clipboard.writeText).to.have.been.calledWith(text);
             }
@@ -45,7 +50,12 @@ describe('Automatic Clipboard Sync', function () {
         if (Clipboard.isSupported) {
             const clipboardData = new DataTransfer();
             clipboardData.setData("text/plain", text);
-            clipboard._handlePaste(new ClipboardEvent('paste', { clipboardData }));
+            const clipboardEvent = new ClipboardEvent('paste', { clipboardData });
+            // Force initialization since the constructor is broken in Firefox
+            if (!clipboardEvent.clipboardData.items.length) {
+                clipboardEvent.clipboardData.items.add(text, "text/plain");
+            }
+            clipboard._handlePaste(clipboardEvent);
             if (navigator.clipboard.readText) {
                 expect(navigator.clipboard.readText).to.have.been.called;
             }


### PR DESCRIPTION
This PR adds support for automatic copy-pasting.
So when you are focused on the canvas and paste text it's pasted in the server and when you copy something in the server it's automatically copied to your local keyboard.

I've seen #1301 and #1174. But this takes a very different approach since it adds support for copy-pasting to noVNC's core. And I think that it's quite cleaner.

I've tested it in Safari, Firefox, and Chrome.
Unfortunately, the Clipboard API is only supported by Chrome and the `paste` event is broken (see https://bugs.chromium.org/p/chromium/issues/detail?id=634426).
So it just does nothing in Safari and Firefox, while in Chrome the copying of data works but not the pasting.

So, for now, this is not super useful but it should become better as browser support improves.

WDYT?