### PR TITLE
Correcting path to package.json for running at a path other than root.

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -61,7 +61,7 @@ const UI = {
         // Translate the DOM
         l10n.translateDOM();
 
-        WebUtil.fetchJSON('../package.json')
+        WebUtil.fetchJSON('./package.json')
             .then((packageInfo) => {
                 Array.from(document.getElementsByClassName('noVNC_version')).forEach(el => el.innerText = packageInfo.version);
             })


### PR DESCRIPTION
This should address https://github.com/novnc/noVNC/issues/1355, where users get a 404 on `package.json` if noVNC is running in a directory and not at the root.