### PR TITLE
feature: Detect parent resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ noVNC uses many modern web technologies so a formal requirement list is
 not available. However these are the minimum versions we are currently
 aware of:
 
-* Chrome 49, Firefox 44, Safari 11, Opera 36, Edge 79
+* Chrome 64, Firefox 79, Safari 13.4, Opera 51, Edge 79
 
 
 ### Server Requirements


### PR DESCRIPTION
Fixes an issue where if the screen div resizes for a reason other than window resize, the canvas wouldn't redraw.

https://github.com/novnc/noVNC/issues/1364