### PR TITLE
Add extended clipboard Pseudo-Encoding

### DIFF
--- a/core/decoders/tight.js
+++ b/core/decoders/tight.js
@@ -160,7 +160,7 @@ export default class TightDecoder {
                 return false;
             }
 
-            data = this._zlibs[streamId].inflate(data, true, uncompressedSize);
+            data = this._zlibs[streamId].inflate(data, uncompressedSize);
             if (data.length != uncompressedSize) {
                 throw new Error("Incomplete zlib block");
             }
@@ -208,7 +208,7 @@ export default class TightDecoder {
                 return false;
             }
 
-            data = this._zlibs[streamId].inflate(data, true, uncompressedSize);
+            data = this._zlibs[streamId].inflate(data, uncompressedSize);
             if (data.length != uncompressedSize) {
                 throw new Error("Incomplete zlib block");
             }

--- a/core/decoders/tight.js
+++ b/core/decoders/tight.js
@@ -160,7 +160,9 @@ export default class TightDecoder {
                 return false;
             }
 
-            data = this._zlibs[streamId].inflate(data, uncompressedSize);
+            this._zlibs[streamId].setInput(data);
+            data = this._zlibs[streamId].inflate(uncompressedSize);
+            this._zlibs[streamId].setInput(null);
         }
 
         display.blitRgbImage(x, y, width, height, data, 0, false);
@@ -205,7 +207,9 @@ export default class TightDecoder {
                 return false;
             }
 
-            data = this._zlibs[streamId].inflate(data, uncompressedSize);
+            this._zlibs[streamId].setInput(data);
+            data = this._zlibs[streamId].inflate(uncompressedSize);
+            this._zlibs[streamId].setInput(null);
         }
 
         // Convert indexed (palette based) image data to RGB

--- a/core/decoders/tight.js
+++ b/core/decoders/tight.js
@@ -161,9 +161,6 @@ export default class TightDecoder {
             }
 
             data = this._zlibs[streamId].inflate(data, uncompressedSize);
-            if (data.length != uncompressedSize) {
-                throw new Error("Incomplete zlib block");
-            }
         }
 
         display.blitRgbImage(x, y, width, height, data, 0, false);
@@ -209,9 +206,6 @@ export default class TightDecoder {
             }
 
             data = this._zlibs[streamId].inflate(data, uncompressedSize);
-            if (data.length != uncompressedSize) {
-                throw new Error("Incomplete zlib block");
-            }
         }
 
         // Convert indexed (palette based) image data to RGB

--- a/core/deflator.js
+++ b/core/deflator.js
@@ -1,0 +1,79 @@
+/*
+ * noVNC: HTML5 VNC client
+ * Copyright (C) 2020 The noVNC Authors
+ * Licensed under MPL 2.0 (see LICENSE.txt)
+ *
+ * See README.md for usage and integration instructions.
+ */
+
+import { deflateInit, deflate } from "../vendor/pako/lib/zlib/deflate.js";
+import { Z_FULL_FLUSH } from "../vendor/pako/lib/zlib/deflate.js";
+import ZStream from "../vendor/pako/lib/zlib/zstream.js";
+
+export default class Deflator {
+    constructor() {
+        this.strm = new ZStream();
+        this.chunkSize = 1024 * 10 * 10;
+        this.outputBuffer = new Uint8Array(this.chunkSize);
+        this.windowBits = 5;
+
+        deflateInit(this.strm, this.windowBits);
+    }
+
+    deflate(inData) {
+        this.strm.input = inData;
+        this.strm.avail_in = this.strm.input.length;
+        this.strm.next_in = 0;
+        this.strm.output = this.outputBuffer;
+        this.strm.avail_out = this.chunkSize;
+        this.strm.next_out = 0;
+
+        let lastRet = deflate(this.strm, Z_FULL_FLUSH);
+        let outData = new Uint8Array(this.strm.output.buffer, 0, this.strm.next_out);
+
+        if (lastRet < 0) {
+            throw new Error("zlib deflate failed");
+        }
+
+        if (this.strm.avail_in > 0) {
+            // Read chunks until done
+
+            let chunks = [outData];
+            let totalLen = outData.length;
+            do {
+                this.strm.output = new Uint8Array(this.chunkSize);
+                this.strm.next_out = 0;
+                this.strm.avail_out = this.chunkSize;
+
+                lastRet = deflate(this.strm, Z_FULL_FLUSH);
+
+                if (lastRet < 0) {
+                    throw new Error("zlib deflate failed");
+                }
+
+                let chunk = new Uint8Array(this.strm.output.buffer, 0, this.strm.next_out);
+                totalLen += chunk.length;
+                chunks.push(chunk);
+            } while (this.strm.avail_in > 0);
+
+            // Combine chunks into a single data
+
+            let newData = new Uint8Array(totalLen);
+            let offset = 0;
+
+            for (let i = 0; i < chunks.length; i++) {
+                newData.set(chunks[i], offset);
+                offset += chunks[i].length;
+            }
+
+            outData = newData;
+        }
+
+        this.strm.input = null;
+        this.strm.avail_in = 0;
+        this.strm.next_in = 0;
+
+        return outData;
+    }
+
+}

--- a/core/encodings.js
+++ b/core/encodings.js
@@ -27,7 +27,8 @@ export const encodings = {
     pseudoEncodingContinuousUpdates: -313,
     pseudoEncodingCompressLevel9: -247,
     pseudoEncodingCompressLevel0: -256,
-    pseudoEncodingVMwareCursor: 0x574d5664
+    pseudoEncodingVMwareCursor: 0x574d5664,
+    pseudoEncodingExtendedClipboard: 0xc0a1e5ce
 };
 
 export function encodingName(num) {

--- a/core/inflator.js
+++ b/core/inflator.js
@@ -35,7 +35,10 @@ export default class Inflate {
 
         this.strm.avail_out = this.chunkSize;
 
-        inflate(this.strm, 0); // Flush argument not used.
+        let ret = inflate(this.strm, 0); // Flush argument not used.
+        if (ret < 0) {
+            throw new Error("zlib inflate failed");
+        }
 
         if (this.strm.next_out != expected) {
             throw new Error("Incomplete zlib block");

--- a/core/inflator.js
+++ b/core/inflator.js
@@ -37,6 +37,10 @@ export default class Inflate {
 
         inflate(this.strm, 0); // Flush argument not used.
 
+        if (this.strm.next_out != expected) {
+            throw new Error("Incomplete zlib block");
+        }
+
         return new Uint8Array(this.strm.output.buffer, 0, this.strm.next_out);
     }
 

--- a/core/inflator.js
+++ b/core/inflator.js
@@ -19,12 +19,20 @@ export default class Inflate {
         inflateInit(this.strm, this.windowBits);
     }
 
-    inflate(data, expected) {
-        this.strm.input = data;
-        this.strm.avail_in = this.strm.input.length;
-        this.strm.next_in = 0;
-        this.strm.next_out = 0;
+    setInput(data) {
+        if (!data) {
+            //FIXME: flush remaining data.
+            this.strm.input = null;
+            this.strm.avail_in = 0;
+            this.strm.next_in = 0;
+        } else {
+            this.strm.input = data;
+            this.strm.avail_in = this.strm.input.length;
+            this.strm.next_in = 0;
+        }
+    }
 
+    inflate(expected) {
         // resize our output buffer if it's too small
         // (we could just use multiple chunks, but that would cause an extra
         // allocation each time to flatten the chunks)
@@ -33,6 +41,7 @@ export default class Inflate {
             this.strm.output = new Uint8Array(this.chunkSize);
         }
 
+        this.strm.next_out = 0;
         this.strm.avail_out = this.chunkSize;
 
         let ret = inflate(this.strm, 0); // Flush argument not used.

--- a/core/inflator.js
+++ b/core/inflator.js
@@ -42,7 +42,7 @@ export default class Inflate {
         }
 
         this.strm.next_out = 0;
-        this.strm.avail_out = this.chunkSize;
+        this.strm.avail_out = expected;
 
         let ret = inflate(this.strm, 0); // Flush argument not used.
         if (ret < 0) {

--- a/core/inflator.js
+++ b/core/inflator.js
@@ -11,7 +11,7 @@ export default class Inflate {
         inflateInit(this.strm, this.windowBits);
     }
 
-    inflate(data, flush, expected) {
+    inflate(data, expected) {
         this.strm.input = data;
         this.strm.avail_in = this.strm.input.length;
         this.strm.next_in = 0;
@@ -27,7 +27,7 @@ export default class Inflate {
 
         this.strm.avail_out = this.chunkSize;
 
-        inflate(this.strm, flush);
+        inflate(this.strm, 0); // Flush argument not used.
 
         return new Uint8Array(this.strm.output.buffer, 0, this.strm.next_out);
     }

--- a/core/inflator.js
+++ b/core/inflator.js
@@ -1,3 +1,11 @@
+/*
+ * noVNC: HTML5 VNC client
+ * Copyright (C) 2020 The noVNC Authors
+ * Licensed under MPL 2.0 (see LICENSE.txt)
+ *
+ * See README.md for usage and integration instructions.
+ */
+
 import { inflateInit, inflate, inflateReset } from "../vendor/pako/lib/zlib/inflate.js";
 import ZStream from "../vendor/pako/lib/zlib/zstream.js";
 

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1,17 +1,20 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2019 The noVNC Authors
+ * Copyright (C) 2020 The noVNC Authors
  * Licensed under MPL 2.0 (see LICENSE.txt)
  *
  * See README.md for usage and integration instructions.
  *
  */
 
+import { toUnsigned32bit, toSigned32bit } from './util/int.js';
 import * as Log from './util/logging.js';
-import { decodeUTF8 } from './util/strings.js';
+import { encodeUTF8, decodeUTF8 } from './util/strings.js';
 import { dragThreshold } from './util/browser.js';
 import EventTargetMixin from './util/eventtarget.js';
 import Display from "./display.js";
+import Inflator from "./inflator.js";
+import Deflator from "./deflator.js";
 import Keyboard from "./input/keyboard.js";
 import Mouse from "./input/mouse.js";
 import Cursor from "./util/cursor.js";
@@ -32,6 +35,23 @@ import TightPNGDecoder from "./decoders/tightpng.js";
 // How many seconds to wait for a disconnect to finish
 const DISCONNECT_TIMEOUT = 3;
 const DEFAULT_BACKGROUND = 'rgb(40, 40, 40)';
+
+// Extended clipboard pseudo-encoding formats
+const extendedClipboardFormatText   = 1;
+/*eslint-disable no-unused-vars */
+const extendedClipboardFormatRtf    = 1 << 1;
+const extendedClipboardFormatHtml   = 1 << 2;
+const extendedClipboardFormatDib    = 1 << 3;
+const extendedClipboardFormatFiles  = 1 << 4;
+/*eslint-enable */
+
+// Extended clipboard pseudo-encoding actions
+const extendedClipboardActionCaps    = 1 << 24;
+const extendedClipboardActionRequest = 1 << 25;
+const extendedClipboardActionPeek    = 1 << 26;
+const extendedClipboardActionNotify  = 1 << 27;
+const extendedClipboardActionProvide = 1 << 28;
+
 
 export default class RFB extends EventTargetMixin {
     constructor(target, url, options) {
@@ -83,6 +103,10 @@ export default class RFB extends EventTargetMixin {
         this._screen_flags = 0;
 
         this._qemuExtKeyEventSupported = false;
+
+        this._clipboardText = null;
+        this._clipboardServerCapabilitiesActions = {};
+        this._clipboardServerCapabilitiesFormats = {};
 
         // Internal objects
         this._sock = null;              // Websock object
@@ -390,7 +414,21 @@ export default class RFB extends EventTargetMixin {
 
     clipboardPasteFrom(text) {
         if (this._rfb_connection_state !== 'connected' || this._viewOnly) { return; }
-        RFB.messages.clientCutText(this._sock, text);
+
+        if (this._clipboardServerCapabilitiesFormats[extendedClipboardFormatText] &&
+            this._clipboardServerCapabilitiesActions[extendedClipboardActionNotify]) {
+
+            this._clipboardText = text;
+            RFB.messages.extendedClipboardNotify(this._sock, [extendedClipboardFormatText]);
+        } else {
+            let data = new Uint8Array(text.length);
+            for (let i = 0; i < text.length; i++) {
+                // FIXME: text can have values outside of Latin1/Uint8
+                data[i] = text.charCodeAt(i);
+            }
+
+            RFB.messages.clientCutText(this._sock, data);
+        }
     }
 
     // ===== PRIVATE METHODS =====
@@ -1267,6 +1305,7 @@ export default class RFB extends EventTargetMixin {
         encs.push(encodings.pseudoEncodingFence);
         encs.push(encodings.pseudoEncodingContinuousUpdates);
         encs.push(encodings.pseudoEncodingDesktopName);
+        encs.push(encodings.pseudoEncodingExtendedClipboard);
 
         if (this._fb_depth == 24) {
             encs.push(encodings.pseudoEncodingVMwareCursor);
@@ -1325,18 +1364,163 @@ export default class RFB extends EventTargetMixin {
         Log.Debug("ServerCutText");
 
         if (this._sock.rQwait("ServerCutText header", 7, 1)) { return false; }
+
         this._sock.rQskipBytes(3);  // Padding
-        const length = this._sock.rQshift32();
-        if (this._sock.rQwait("ServerCutText", length, 8)) { return false; }
 
-        const text = this._sock.rQshiftStr(length);
+        let length = this._sock.rQshift32();
+        length = toSigned32bit(length);
 
-        if (this._viewOnly) { return true; }
+        if (this._sock.rQwait("ServerCutText content", Math.abs(length), 8)) { return false; }
 
-        this.dispatchEvent(new CustomEvent(
-            "clipboard",
-            { detail: { text: text } }));
+        if (length >= 0) {
+            //Standard msg
+            const text = this._sock.rQshiftStr(length);
+            if (this._viewOnly) {
+                return true;
+            }
 
+            this.dispatchEvent(new CustomEvent(
+                "clipboard",
+                { detail: { text: text } }));
+
+        } else {
+            //Extended msg.
+            length = Math.abs(length);
+            const flags = this._sock.rQshift32();
+            let formats = flags & 0x0000FFFF;
+            let actions = flags & 0xFF000000;
+
+            let isCaps = (!!(actions & extendedClipboardActionCaps));
+            if (isCaps) {
+                this._clipboardServerCapabilitiesFormats = {};
+                this._clipboardServerCapabilitiesActions = {};
+
+                // Update our server capabilities for Formats
+                for (let i = 0; i <= 15; i++) {
+                    let index = 1 << i;
+
+                    // Check if format flag is set.
+                    if ((formats & index)) {
+                        this._clipboardServerCapabilitiesFormats[index] = true;
+                        // We don't send unsolicited clipboard, so we
+                        // ignore the size
+                        this._sock.rQshift32();
+                    }
+                }
+
+                // Update our server capabilities for Actions
+                for (let i = 24; i <= 31; i++) {
+                    let index = 1 << i;
+                    this._clipboardServerCapabilitiesActions[index] = !!(actions & index);
+                }
+
+                /*  Caps handling done, send caps with the clients
+                    capabilities set as a response */
+                let clientActions = [
+                    extendedClipboardActionCaps,
+                    extendedClipboardActionRequest,
+                    extendedClipboardActionPeek,
+                    extendedClipboardActionNotify,
+                    extendedClipboardActionProvide
+                ];
+                RFB.messages.extendedClipboardCaps(this._sock, clientActions, {extendedClipboardFormatText: 0});
+
+            } else if (actions === extendedClipboardActionRequest) {
+                if (this._viewOnly) {
+                    return true;
+                }
+
+                // Check if server has told us it can handle Provide and there is clipboard data to send.
+                if (this._clipboardText != null &&
+                    this._clipboardServerCapabilitiesActions[extendedClipboardActionProvide]) {
+
+                    if (formats & extendedClipboardFormatText) {
+                        RFB.messages.extendedClipboardProvide(this._sock, [extendedClipboardFormatText], [this._clipboardText]);
+                    }
+                }
+
+            } else if (actions === extendedClipboardActionPeek) {
+                if (this._viewOnly) {
+                    return true;
+                }
+
+                if (this._clipboardServerCapabilitiesActions[extendedClipboardActionNotify]) {
+
+                    if (this._clipboardText != null) {
+                        RFB.messages.extendedClipboardNotify(this._sock, [extendedClipboardFormatText]);
+                    } else {
+                        RFB.messages.extendedClipboardNotify(this._sock, []);
+                    }
+                }
+
+            } else if (actions === extendedClipboardActionNotify) {
+                if (this._viewOnly) {
+                    return true;
+                }
+
+                if (this._clipboardServerCapabilitiesActions[extendedClipboardActionRequest]) {
+
+                    if (formats & extendedClipboardFormatText) {
+                        RFB.messages.extendedClipboardRequest(this._sock, [extendedClipboardFormatText]);
+                    }
+                }
+
+            } else if (actions === extendedClipboardActionProvide) {
+                if (this._viewOnly) {
+                    return true;
+                }
+
+                if (!(formats & extendedClipboardFormatText)) {
+                    return true;
+                }
+                // Ignore what we had in our clipboard client side.
+                this._clipboardText = null;
+
+                // FIXME: Should probably verify that this data was actually requested
+                let zlibStream = this._sock.rQshiftBytes(length - 4);
+                let streamInflator = new Inflator();
+                let textData = null;
+
+                streamInflator.setInput(zlibStream);
+                for (let i = 0; i <= 15; i++) {
+                    let format = 1 << i;
+
+                    if (formats & format) {
+
+                        let size = 0x00;
+                        let sizeArray = streamInflator.inflate(4);
+
+                        size |= (sizeArray[0] << 24);
+                        size |= (sizeArray[1] << 16);
+                        size |= (sizeArray[2] << 8);
+                        size |= (sizeArray[3]);
+                        let chunk = streamInflator.inflate(size);
+
+                        if (format === extendedClipboardFormatText) {
+                            textData = chunk;
+                        }
+                    }
+                }
+                streamInflator.setInput(null);
+
+                if (textData !== null) {
+                    textData = String.fromCharCode.apply(null, textData);
+
+                    textData = decodeUTF8(textData);
+                    if ((textData.length > 0) && "\0" === textData.charAt(textData.length - 1)) {
+                        textData = textData.slice(0, -1);
+                    }
+
+                    textData = textData.replace("\r\n", "\n");
+
+                    this.dispatchEvent(new CustomEvent(
+                        "clipboard",
+                        { detail: { text: textData } }));
+                }
+            } else {
+                return this._fail("Unexpected action in extended clipboard message: " + actions);
+            }
+        }
         return true;
     }
 
@@ -1966,8 +2150,102 @@ RFB.messages = {
         sock.flush();
     },
 
-    // TODO(directxman12): make this unicode compatible?
-    clientCutText(sock, text) {
+    // Used to build Notify and Request data.
+    _buildExtendedClipboardFlags(actions, formats) {
+        let data = new Uint8Array(4);
+        let formatFlag = 0x00000000;
+        let actionFlag = 0x00000000;
+
+        for (let i = 0; i < actions.length; i++) {
+            actionFlag |= actions[i];
+        }
+
+        for (let i = 0; i < formats.length; i++) {
+            formatFlag |= formats[i];
+        }
+
+        data[0] = actionFlag >> 24; // Actions
+        data[1] = 0x00;             // Reserved
+        data[2] = 0x00;             // Reserved
+        data[3] = formatFlag;       // Formats
+
+        return data;
+    },
+
+    extendedClipboardProvide(sock, formats, inData) {
+        // Deflate incomming data and their sizes
+        let deflator = new Deflator();
+        let dataToDeflate = [];
+
+        for (let i = 0; i < formats.length; i++) {
+            // We only support the format Text at this time
+            if (formats[i] != extendedClipboardFormatText) {
+                throw new Error("Unsupported extended clipboard format for Provide message.");
+            }
+
+            // Change lone \r or \n into \r\n as defined in rfbproto
+            inData[i] = inData[i].replace(/\r\n|\r|\n/gm, "\r\n");
+
+            // Check if it already has \0
+            let text = encodeUTF8(inData[i] + "\0");
+
+            dataToDeflate.push( (text.length >> 24) & 0xFF,
+                                (text.length >> 16) & 0xFF,
+                                (text.length >>  8) & 0xFF,
+                                (text.length & 0xFF));
+
+            for (let j = 0; j < text.length; j++) {
+                dataToDeflate.push(text.charCodeAt(j));
+            }
+        }
+
+        let deflatedData = deflator.deflate(new Uint8Array(dataToDeflate));
+
+        // Build data  to send
+        let data = new Uint8Array(4 + deflatedData.length);
+        data.set(RFB.messages._buildExtendedClipboardFlags([extendedClipboardActionProvide],
+                                                           formats));
+        data.set(deflatedData, 4);
+
+        RFB.messages.clientCutText(sock, data, true);
+    },
+
+    extendedClipboardNotify(sock, formats) {
+        let flags = RFB.messages._buildExtendedClipboardFlags([extendedClipboardActionNotify],
+                                                              formats);
+        RFB.messages.clientCutText(sock, flags, true);
+    },
+
+    extendedClipboardRequest(sock, formats) {
+        let flags = RFB.messages._buildExtendedClipboardFlags([extendedClipboardActionRequest],
+                                                              formats);
+        RFB.messages.clientCutText(sock, flags, true);
+    },
+
+    extendedClipboardCaps(sock, actions, formats) {
+        let formatKeys = Object.keys(formats);
+        let data  = new Uint8Array(4 + (4 * formatKeys.length));
+
+        formatKeys.map(x => parseInt(x));
+        formatKeys.sort((a, b) =>  a - b);
+
+        data.set(RFB.messages._buildExtendedClipboardFlags(actions, []));
+
+        let loopOffset = 4;
+        for (let i = 0; i < formatKeys.length; i++) {
+            data[loopOffset]     = formats[formatKeys[i]] >> 24;
+            data[loopOffset + 1] = formats[formatKeys[i]] >> 16;
+            data[loopOffset + 2] = formats[formatKeys[i]] >> 8;
+            data[loopOffset + 3] = formats[formatKeys[i]] >> 0;
+
+            loopOffset += 4;
+            data[3] |= (1 << formatKeys[i]); // Update our format flags
+        }
+
+        RFB.messages.clientCutText(sock, data, true);
+    },
+
+    clientCutText(sock, data, extended = false) {
         const buff = sock._sQ;
         const offset = sock._sQlen;
 
@@ -1977,7 +2255,12 @@ RFB.messages = {
         buff[offset + 2] = 0; // padding
         buff[offset + 3] = 0; // padding
 
-        let length = text.length;
+        let length;
+        if (extended) {
+            length = toUnsigned32bit(-data.length);
+        } else {
+            length = data.length;
+        }
 
         buff[offset + 4] = length >> 24;
         buff[offset + 5] = length >> 16;
@@ -1986,24 +2269,25 @@ RFB.messages = {
 
         sock._sQlen += 8;
 
-        // We have to keep track of from where in the text we begin creating the
+        // We have to keep track of from where in the data we begin creating the
         // buffer for the flush in the next iteration.
-        let textOffset = 0;
+        let dataOffset = 0;
 
-        let remaining = length;
+        let remaining = data.length;
         while (remaining > 0) {
 
             let flushSize = Math.min(remaining, (sock._sQbufferSize - sock._sQlen));
             for (let i = 0; i < flushSize; i++) {
-                buff[sock._sQlen + i] =  text.charCodeAt(textOffset + i);
+                buff[sock._sQlen + i] = data[dataOffset + i];
             }
 
             sock._sQlen += flushSize;
             sock.flush();
 
             remaining -= flushSize;
-            textOffset += flushSize;
+            dataOffset += flushSize;
         }
+
     },
 
     setDesktopSize(sock, width, height, id, flags) {

--- a/core/util/int.js
+++ b/core/util/int.js
@@ -1,0 +1,15 @@
+/*
+ * noVNC: HTML5 VNC client
+ * Copyright (C) 2020 The noVNC Authors
+ * Licensed under MPL 2.0 (see LICENSE.txt)
+ *
+ * See README.md for usage and integration instructions.
+ */
+
+export function toUnsigned32bit(toConvert) {
+    return toConvert >>> 0;
+}
+
+export function toSigned32bit(toConvert) {
+    return toConvert | 0;
+}

--- a/tests/test.deflator.js
+++ b/tests/test.deflator.js
@@ -1,0 +1,80 @@
+/* eslint-disable no-console */
+const expect = chai.expect;
+
+import { inflateInit, inflate } from "../vendor/pako/lib/zlib/inflate.js";
+import ZStream from "../vendor/pako/lib/zlib/zstream.js";
+import Deflator from "../core/deflator.js";
+
+function _inflator(compText, expected) {
+    let strm = new ZStream();
+    let chunkSize = 1024 * 10 * 10;
+    strm.output = new Uint8Array(chunkSize);
+
+    inflateInit(strm, 5);
+
+    if (expected > chunkSize) {
+        chunkSize = expected;
+        strm.output = new Uint8Array(chunkSize);
+    }
+
+    strm.input = compText;
+    strm.avail_in = strm.input.length;
+    strm.next_in = 0;
+
+    strm.next_out = 0;
+    strm.avail_out = expected.length;
+
+    let ret = inflate(strm, 0);
+
+    // Check that return code is not an error
+    expect(ret).to.be.greaterThan(-1);
+
+    return new Uint8Array(strm.output.buffer, 0, strm.next_out);
+}
+
+describe('Deflate data', function () {
+
+    it('should be able to deflate messages', function () {
+        let deflator = new Deflator();
+
+        let text = "123asdf";
+        let preText = new Uint8Array(text.length);
+        for (let i = 0; i < preText.length; i++) {
+            preText[i] = text.charCodeAt(i);
+        }
+
+        let compText = deflator.deflate(preText);
+
+        let inflatedText = _inflator(compText, text.length);
+        expect(inflatedText).to.array.equal(preText);
+
+    });
+
+    it('should be able to deflate large messages', function () {
+        let deflator = new Deflator();
+
+        /* Generate a big string with random characters. Used because
+           repetition of letters might be deflated more effectively than
+           random ones. */
+        let text = "";
+        let characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        for (let i = 0; i < 300000; i++) {
+            text += characters.charAt(Math.floor(Math.random() * characters.length));
+        }
+
+        let preText = new Uint8Array(text.length);
+        for (let i = 0; i < preText.length; i++) {
+            preText[i] = text.charCodeAt(i);
+        }
+
+        let compText = deflator.deflate(preText);
+
+        //Check that the compressed size is expected size
+        expect(compText.length).to.be.greaterThan((1024 * 10 * 10) * 2);
+
+        let inflatedText = _inflator(compText, text.length);
+
+        expect(inflatedText).to.array.equal(preText);
+
+    });
+});

--- a/tests/test.int.js
+++ b/tests/test.int.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-console */
+const expect = chai.expect;
+
+import { toUnsigned32bit, toSigned32bit } from '../core/util/int.js';
+
+describe('Integer casting', function () {
+    it('should cast unsigned to signed', function () {
+        let expected = 4294967286;
+        expect(toUnsigned32bit(-10)).to.equal(expected);
+    });
+
+    it('should cast signed to unsigned', function () {
+        let expected = -10;
+        expect(toSigned32bit(4294967286)).to.equal(expected);
+    });
+});

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -291,12 +291,18 @@ describe('Remote Frame Buffer Protocol Client', function () {
         });
 
         describe('#clipboardPasteFrom', function () {
+            beforeEach(function () {
+                sinon.spy(RFB.messages, 'clientCutText');
+            });
+
+            afterEach(function () {
+                RFB.messages.clientCutText.restore();
+            });
+
             it('should send the given text in a paste event', function () {
-                const expected = {_sQ: new Uint8Array(11), _sQlen: 0,
-                                  _sQbufferSize: 11, flush: () => {}};
-                RFB.messages.clientCutText(expected, 'abc');
                 client.clipboardPasteFrom('abc');
-                expect(client._sock).to.have.sent(expected._sQ);
+                expect(RFB.messages.clientCutText).to.have.been.calledOnce;
+                expect(RFB.messages.clientCutText).to.have.been.calledWith(client._sock, 'abc');
             });
 
             it('should flush multiple times for large clipboards', function () {

--- a/vendor/pako/lib/zlib/deflate.js
+++ b/vendor/pako/lib/zlib/deflate.js
@@ -9,51 +9,51 @@ import msg from "./messages.js";
 
 
 /* Allowed flush values; see deflate() and inflate() below for details */
-var Z_NO_FLUSH      = 0;
-var Z_PARTIAL_FLUSH = 1;
-//var Z_SYNC_FLUSH    = 2;
-var Z_FULL_FLUSH    = 3;
-var Z_FINISH        = 4;
-var Z_BLOCK         = 5;
-//var Z_TREES         = 6;
+export const Z_NO_FLUSH      = 0;
+export const Z_PARTIAL_FLUSH = 1;
+//export const Z_SYNC_FLUSH    = 2;
+export const Z_FULL_FLUSH    = 3;
+export const Z_FINISH        = 4;
+export const Z_BLOCK         = 5;
+//export const Z_TREES         = 6;
 
 
 /* Return codes for the compression/decompression functions. Negative values
  * are errors, positive values are used for special but normal events.
  */
-var Z_OK            = 0;
-var Z_STREAM_END    = 1;
-//var Z_NEED_DICT     = 2;
-//var Z_ERRNO         = -1;
-var Z_STREAM_ERROR  = -2;
-var Z_DATA_ERROR    = -3;
-//var Z_MEM_ERROR     = -4;
-var Z_BUF_ERROR     = -5;
-//var Z_VERSION_ERROR = -6;
+export const Z_OK            = 0;
+export const Z_STREAM_END    = 1;
+//export const Z_NEED_DICT     = 2;
+//export const Z_ERRNO         = -1;
+export const Z_STREAM_ERROR  = -2;
+export const Z_DATA_ERROR    = -3;
+//export const Z_MEM_ERROR     = -4;
+export const Z_BUF_ERROR     = -5;
+//export const Z_VERSION_ERROR = -6;
 
 
 /* compression levels */
-//var Z_NO_COMPRESSION      = 0;
-//var Z_BEST_SPEED          = 1;
-//var Z_BEST_COMPRESSION    = 9;
-var Z_DEFAULT_COMPRESSION = -1;
+//export const Z_NO_COMPRESSION      = 0;
+//export const Z_BEST_SPEED          = 1;
+//export const Z_BEST_COMPRESSION    = 9;
+export const Z_DEFAULT_COMPRESSION = -1;
 
 
-var Z_FILTERED            = 1;
-var Z_HUFFMAN_ONLY        = 2;
-var Z_RLE                 = 3;
-var Z_FIXED               = 4;
-var Z_DEFAULT_STRATEGY    = 0;
+export const Z_FILTERED            = 1;
+export const Z_HUFFMAN_ONLY        = 2;
+export const Z_RLE                 = 3;
+export const Z_FIXED               = 4;
+export const Z_DEFAULT_STRATEGY    = 0;
 
 /* Possible values of the data_type field (though see inflate()) */
-//var Z_BINARY              = 0;
-//var Z_TEXT                = 1;
-//var Z_ASCII               = 1; // = Z_TEXT
-var Z_UNKNOWN             = 2;
+//export const Z_BINARY              = 0;
+//export const Z_TEXT                = 1;
+//export const Z_ASCII               = 1; // = Z_TEXT
+export const Z_UNKNOWN             = 2;
 
 
 /* The deflate compression method */
-var Z_DEFLATED  = 8;
+export const Z_DEFLATED  = 8;
 
 /*============================================================================*/
 

--- a/vendor/pako/lib/zlib/inflate.js
+++ b/vendor/pako/lib/zlib/inflate.js
@@ -13,30 +13,30 @@ var DISTS = 2;
 
 
 /* Allowed flush values; see deflate() and inflate() below for details */
-//var Z_NO_FLUSH      = 0;
-//var Z_PARTIAL_FLUSH = 1;
-//var Z_SYNC_FLUSH    = 2;
-//var Z_FULL_FLUSH    = 3;
-var Z_FINISH        = 4;
-var Z_BLOCK         = 5;
-var Z_TREES         = 6;
+//export const Z_NO_FLUSH      = 0;
+//export const Z_PARTIAL_FLUSH = 1;
+//export const Z_SYNC_FLUSH    = 2;
+//export const Z_FULL_FLUSH    = 3;
+export const Z_FINISH        = 4;
+export const Z_BLOCK         = 5;
+export const Z_TREES         = 6;
 
 
 /* Return codes for the compression/decompression functions. Negative values
  * are errors, positive values are used for special but normal events.
  */
-var Z_OK            = 0;
-var Z_STREAM_END    = 1;
-var Z_NEED_DICT     = 2;
-//var Z_ERRNO         = -1;
-var Z_STREAM_ERROR  = -2;
-var Z_DATA_ERROR    = -3;
-var Z_MEM_ERROR     = -4;
-var Z_BUF_ERROR     = -5;
-//var Z_VERSION_ERROR = -6;
+export const Z_OK            = 0;
+export const Z_STREAM_END    = 1;
+export const Z_NEED_DICT     = 2;
+//export const Z_ERRNO         = -1;
+export const Z_STREAM_ERROR  = -2;
+export const Z_DATA_ERROR    = -3;
+export const Z_MEM_ERROR     = -4;
+export const Z_BUF_ERROR     = -5;
+//export const Z_VERSION_ERROR = -6;
 
 /* The deflate compression method */
-var Z_DEFLATED  = 8;
+export const Z_DEFLATED  = 8;
 
 
 /* STATES ====================================================================*/


### PR DESCRIPTION
The current clipboard did not support transferring  Unicode characters. This pull request adds support for extended clipboard pseudo-encoding on the client. The server must also support extended clipboard pseoudo-encoding for this solution to take effect. The servers I know of use this protocol is TigerVNC and UltraVNC.

Fixes #61