### PR TITLE
Add possibility to set quality ("JPEG Quality Level Pseudo-encoding")

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -275,6 +275,8 @@ export default class RFB extends EventTargetMixin {
             Log.Warn("Specifying showDotCursor as a RFB constructor argument is deprecated");
             this._showDotCursor = options.showDotCursor;
         }
+
+        this._qualityLevel = 6;
     }
 
     // ===== PROPERTIES =====
@@ -336,6 +338,26 @@ export default class RFB extends EventTargetMixin {
 
     get background() { return this._screen.style.background; }
     set background(cssValue) { this._screen.style.background = cssValue; }
+
+    get qualityLevel() {
+        return this._qualityLevel;
+    }
+    set qualityLevel(qualityLevel) {
+        if (!Number.isInteger(qualityLevel) || qualityLevel < 0 || qualityLevel > 9) {
+            Log.Error("qualityLevel must be an integer between 0 and 9");
+            return;
+        }
+
+        if (this._qualityLevel === qualityLevel) {
+            return;
+        }
+
+        this._qualityLevel = qualityLevel;
+
+        if (this._rfb_connection_state === 'connected') {
+            this._sendEncodings();
+        }
+    }
 
     // ===== PUBLIC METHODS =====
 
@@ -1294,7 +1316,7 @@ export default class RFB extends EventTargetMixin {
         encs.push(encodings.encodingRaw);
 
         // Psuedo-encoding settings
-        encs.push(encodings.pseudoEncodingQualityLevel0 + 6);
+        encs.push(encodings.pseudoEncodingQualityLevel0 + this._qualityLevel);
         encs.push(encodings.pseudoEncodingCompressLevel0 + 2);
 
         encs.push(encodings.pseudoEncodingDesktopSize);

--- a/core/util/polyfill.js
+++ b/core/util/polyfill.js
@@ -1,6 +1,6 @@
 /*
  * noVNC: HTML5 VNC client
- * Copyright (C) 2018 The noVNC Authors
+ * Copyright (C) 2020 The noVNC Authors
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 
@@ -52,3 +52,10 @@ if (typeof Object.assign != 'function') {
         window.CustomEvent = CustomEvent;
     }
 })();
+
+/* Number.isInteger() (taken from MDN) */
+Number.isInteger = Number.isInteger || function isInteger(value) {
+    return typeof value === 'number' &&
+      isFinite(value) &&
+      Math.floor(value) === value;
+};

--- a/docs/API.md
+++ b/docs/API.md
@@ -64,6 +64,11 @@ protocol stream.
     to the element containing the remote session screen. The default value is `rgb(40, 40, 40)`
     (solid gray color).
 
+`qualityLevel`
+  - Is an `int` in range `[0-9]` controlling the desired JPEG quality.
+    Value `0` implies low quality and `9` implies high quality.
+    Default value is `6`.
+
 `capabilities` *Read only*
   - Is an `Object` indicating which optional extensions are available
     on the server. Some methods may only be called if the corresponding


### PR DESCRIPTION
This PR adds possibility to change the quality (aka [JPEG Quality Level Pseudo-encoding](https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#jpeg-quality-level-pseudo-encoding)) on the fly. Previously, the value was hardcoded to be `6` (more precisely: `-32 + 6 = -26`).

`RFB` class got a new property `qualityLevel` which can be set immediately after the `RFB` constructor (and then encodings are sent once as part of `ServerInitialisation` state). But it can also be set in `connected` state (and then encodings are sent again).

Values passed to `qualityLevel` setter are strictly verified to be integers in range `[0, 9]`. Hence, for IE11, I have added `Number.isInteger()` polyfill.

This has only been tested against (latest) TigerVNC.

Partially resolves #396, #1150, #1288 and similar.