### PR TITLE
Hide clipboard side bar button when view only mode

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1621,12 +1621,16 @@ const UI = {
                 .classList.add('noVNC_hidden');
             document.getElementById('noVNC_mouse_button' + UI.rfb.touchButton)
                 .classList.add('noVNC_hidden');
+            document.getElementById('noVNC_clipboard_button')
+                .classList.add('noVNC_hidden');
         } else {
             document.getElementById('noVNC_keyboard_button')
                 .classList.remove('noVNC_hidden');
             document.getElementById('noVNC_toggle_extra_keys_button')
                 .classList.remove('noVNC_hidden');
             document.getElementById('noVNC_mouse_button' + UI.rfb.touchButton)
+                .classList.remove('noVNC_hidden');
+            document.getElementById('noVNC_clipboard_button')
                 .classList.remove('noVNC_hidden');
         }
     },


### PR DESCRIPTION
The clipboard side bar button serves no purpose if user uses 'View Only' mode. This commit hides this button in those instances.

Tested on Fedora 31 in Firefox 73 and Chrome 80.

Fixes #1368