### PR TITLE
Fix focus problem after closing the toolbar

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -535,6 +535,7 @@ const UI = {
         UI.closeAllPanels();
         document.getElementById('noVNC_control_bar')
             .classList.remove("noVNC_open");
+        UI.rfb.focus();
     },
 
     toggleControlbar() {


### PR DESCRIPTION
Closing the toolbar would make the focus remain on the toolbar and
not in the session. The only way to switch focus was to click in the
session. This commit will automatically switch back focus to the session
after closing the toolbar.

Tested on:
|| __Windows 10__ | __Windows 10 touch__ | __Linux__ |
|-|-------------|------------|------------|
|Chrome v.80|  ✓|   ✓   |  ✓   |✓|
|Firefox|    ✓ v.74 |   ✓v.73   |✓v.73| 
|IE11|            ✓| ✓ | -  |
|Edge v.44|      ✓ | ✓ | -   |
