### PR TITLE
fix of error - 'code 400, message Client must support 'binary' or 'base64' protocol

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -72,7 +72,7 @@ export default class RFB extends EventTargetMixin {
         this._rfb_credentials = options.credentials || {};
         this._shared = 'shared' in options ? !!options.shared : true;
         this._repeaterID = options.repeaterID || '';
-        this._wsProtocols = options.wsProtocols || [];
+        this._wsProtocols = options.wsProtocols || ["binary"];
 
         // Internal state
         this._rfb_connection_state = '';


### PR DESCRIPTION
In accordance with rfc6455 (page 5) https://tools.ietf.org/html/rfc6455  :
>>> The handshake from the client looks as follows:
bla bla bla
>>>Sec-WebSocket-Protocol: chat, superchat
we need Sec-WebSocket-Protocol: binary

Without fix we could get 'code 400', for example:
websockify --web=. --cert=/etc/ssl/novnc.pem 8888 localhost:5900

WebSocket server settings:
  - Listen on :8888
  - Flash security policy server
  - Web server. Web root: /home/user/noVNC
  - SSL/TLS support
  - proxying from :8888 to localhost:5900
Home.local - - [06/Apr/2020 13:43:24] code 400, message Client must support 'binary' or 'base64' protocol
Home.local - - [06/Apr/2020 13:43:24] code 404, message File not found

and we can see regular handshake in the right place, just after fix:
user@ubuntu:~/noVNC$ sudo strace -f websockify --web=. --cert=/etc/ssl/novnc.pem 8888 localhost:5900  2>&1 | grep Sec-WebSocket-Protocol
[pid 13746] sendto(4, "Sec-WebSocket-Protocol: binary\r\n", 32, 0, NULL, 0) = 32

PS
tested with clients:
FireFox 74.0.1 (32-bit), Chrome 80.0.3987.149 (32-bit)


