### PR TITLE
Document default setting of `focusOnClick`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -24,7 +24,7 @@ protocol stream.
 `focusOnClick`
   - Is a `boolean` indicating if keyboard focus should automatically be
     moved to the remote session when a `mousedown` or `touchstart`
-    event is received.
+    event is received. Enabled by default.
 
 `touchButton`
   - Is a `long` controlling the button mask that should be simulated


### PR DESCRIPTION
Thank you very much for your efforts developing noVNC, they are very much appreciated. noVNC is the central tool I used to build [Agdapad](https://agdapad.quasicoherent.io/).

This pull request updates the API documentation to include the default setting of `focusOnClick`.