### PR TITLE
Enforce camelCase

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,5 +44,6 @@
                                                    "named": "never",
                                                    "asyncArrow": "always" }],
         "switch-colon-spacing": ["error"],
+        "camelcase": ["error", { allow: ["^XK_", "^XF86XK_"] }],
     }
 }

--- a/app/ui.js
+++ b/app/ui.js
@@ -1683,7 +1683,7 @@ const UI = {
     },
 
     updateLogging() {
-        WebUtil.init_logging(UI.getSetting('logging'));
+        WebUtil.initLogging(UI.getSetting('logging'));
     },
 
     updateDesktopName(e) {

--- a/app/ui.js
+++ b/app/ui.js
@@ -37,9 +37,9 @@ const UI = {
     lastKeyboardinput: null,
     defaultKeyboardinputLen: 100,
 
-    inhibit_reconnect: true,
-    reconnect_callback: null,
-    reconnect_password: null,
+    inhibitReconnect: true,
+    reconnectCallback: null,
+    reconnectPassword: null,
 
     prime() {
         return WebUtil.initSettings().then(() => {
@@ -394,25 +394,25 @@ const UI = {
         document.documentElement.classList.remove("noVNC_disconnecting");
         document.documentElement.classList.remove("noVNC_reconnecting");
 
-        const transition_elem = document.getElementById("noVNC_transition_text");
+        const transitionElem = document.getElementById("noVNC_transition_text");
         switch (state) {
             case 'init':
                 break;
             case 'connecting':
-                transition_elem.textContent = _("Connecting...");
+                transitionElem.textContent = _("Connecting...");
                 document.documentElement.classList.add("noVNC_connecting");
                 break;
             case 'connected':
                 document.documentElement.classList.add("noVNC_connected");
                 break;
             case 'disconnecting':
-                transition_elem.textContent = _("Disconnecting...");
+                transitionElem.textContent = _("Disconnecting...");
                 document.documentElement.classList.add("noVNC_disconnecting");
                 break;
             case 'disconnected':
                 break;
             case 'reconnecting':
-                transition_elem.textContent = _("Reconnecting...");
+                transitionElem.textContent = _("Reconnecting...");
                 document.documentElement.classList.add("noVNC_reconnecting");
                 break;
             default:
@@ -452,11 +452,11 @@ const UI = {
             .classList.remove('noVNC_open');
     },
 
-    showStatus(text, status_type, time) {
+    showStatus(text, statusType, time) {
         const statusElem = document.getElementById('noVNC_status');
 
-        if (typeof status_type === 'undefined') {
-            status_type = 'normal';
+        if (typeof statusType === 'undefined') {
+            statusType = 'normal';
         }
 
         // Don't overwrite more severe visible statuses and never
@@ -466,14 +466,14 @@ const UI = {
                 return;
             }
             if (statusElem.classList.contains("noVNC_status_warn") &&
-                status_type === 'normal') {
+                statusType === 'normal') {
                 return;
             }
         }
 
         clearTimeout(UI.statusTimeout);
 
-        switch (status_type) {
+        switch (statusType) {
             case 'error':
                 statusElem.classList.remove("noVNC_status_warn");
                 statusElem.classList.remove("noVNC_status_normal");
@@ -503,7 +503,7 @@ const UI = {
         }
 
         // Error messages do not timeout
-        if (status_type !== 'error') {
+        if (statusType !== 'error') {
             UI.statusTimeout = window.setTimeout(UI.hideStatus, time);
         }
     },
@@ -1003,7 +1003,7 @@ const UI = {
 
         if (typeof password === 'undefined') {
             password = WebUtil.getConfigVar('password');
-            UI.reconnect_password = password;
+            UI.reconnectPassword = password;
         }
 
         if (password === null) {
@@ -1060,7 +1060,7 @@ const UI = {
         UI.connected = false;
 
         // Disable automatic reconnecting
-        UI.inhibit_reconnect = true;
+        UI.inhibitReconnect = true;
 
         UI.updateVisualState('disconnecting');
 
@@ -1068,20 +1068,20 @@ const UI = {
     },
 
     reconnect() {
-        UI.reconnect_callback = null;
+        UI.reconnectCallback = null;
 
         // if reconnect has been disabled in the meantime, do nothing.
-        if (UI.inhibit_reconnect) {
+        if (UI.inhibitReconnect) {
             return;
         }
 
-        UI.connect(null, UI.reconnect_password);
+        UI.connect(null, UI.reconnectPassword);
     },
 
     cancelReconnect() {
-        if (UI.reconnect_callback !== null) {
-            clearTimeout(UI.reconnect_callback);
-            UI.reconnect_callback = null;
+        if (UI.reconnectCallback !== null) {
+            clearTimeout(UI.reconnectCallback);
+            UI.reconnectCallback = null;
         }
 
         UI.updateVisualState('disconnected');
@@ -1092,7 +1092,7 @@ const UI = {
 
     connectFinished(e) {
         UI.connected = true;
-        UI.inhibit_reconnect = false;
+        UI.inhibitReconnect = false;
 
         let msg;
         if (UI.getSetting('encrypt')) {
@@ -1126,11 +1126,11 @@ const UI = {
             } else {
                 UI.showStatus(_("Failed to connect to server"), 'error');
             }
-        } else if (UI.getSetting('reconnect', false) === true && !UI.inhibit_reconnect) {
+        } else if (UI.getSetting('reconnect', false) === true && !UI.inhibitReconnect) {
             UI.updateVisualState('reconnecting');
 
             const delay = parseInt(UI.getSetting('reconnect_delay'));
-            UI.reconnect_callback = setTimeout(UI.reconnect, delay);
+            UI.reconnectCallback = setTimeout(UI.reconnect, delay);
             return;
         } else {
             UI.updateVisualState('disconnected');
@@ -1203,7 +1203,7 @@ const UI = {
         inputElemPassword.value = "";
 
         UI.rfb.sendCredentials({ username: username, password: password });
-        UI.reconnect_password = password;
+        UI.reconnectPassword = password;
         document.getElementById('noVNC_credentials_dlg')
             .classList.remove('noVNC_open');
     },
@@ -1634,8 +1634,8 @@ const UI = {
  * ------v------*/
 
     setMouseButton(num) {
-        const view_only = UI.rfb.viewOnly;
-        if (UI.rfb && !view_only) {
+        const viewOnly = UI.rfb.viewOnly;
+        if (UI.rfb && !viewOnly) {
             UI.rfb.touchButton = num;
         }
 
@@ -1643,7 +1643,7 @@ const UI = {
         for (let b = 0; b < blist.length; b++) {
             const button = document.getElementById('noVNC_mouse_button' +
                                                  blist[b]);
-            if (blist[b] === num && !view_only) {
+            if (blist[b] === num && !viewOnly) {
                 button.classList.remove("noVNC_hidden");
             } else {
                 button.classList.add("noVNC_hidden");

--- a/app/webutil.js
+++ b/app/webutil.js
@@ -184,7 +184,7 @@ export function injectParamIfMissing(path, param, value) {
     const elem = document.createElement('a');
     elem.href = path;
 
-    const param_eq = encodeURIComponent(param) + "=";
+    const paramEq = encodeURIComponent(param) + "=";
     let query;
     if (elem.search) {
         query = elem.search.slice(1).split('&');
@@ -192,8 +192,8 @@ export function injectParamIfMissing(path, param, value) {
         query = [];
     }
 
-    if (!query.some(v => v.startsWith(param_eq))) {
-        query.push(param_eq + encodeURIComponent(value));
+    if (!query.some(v => v.startsWith(paramEq))) {
+        query.push(paramEq + encodeURIComponent(value));
         elem.search = "?" + query.join("&");
     }
 

--- a/app/webutil.js
+++ b/app/webutil.js
@@ -6,16 +6,16 @@
  * See README.md for usage and integration instructions.
  */
 
-import { init_logging as main_init_logging } from '../core/util/logging.js';
+import { initLogging as mainInitLogging } from '../core/util/logging.js';
 
 // init log level reading the logging HTTP param
-export function init_logging(level) {
+export function initLogging(level) {
     "use strict";
     if (typeof level !== "undefined") {
-        main_init_logging(level);
+        mainInitLogging(level);
     } else {
         const param = document.location.href.match(/logging=([A-Za-z0-9._-]*)/);
-        main_init_logging(param || undefined);
+        mainInitLogging(param || undefined);
     }
 }
 

--- a/core/base64.js
+++ b/core/base64.js
@@ -57,12 +57,12 @@ export default {
     /* eslint-enable comma-spacing */
 
     decode(data, offset = 0) {
-        let data_length = data.indexOf('=') - offset;
-        if (data_length < 0) { data_length = data.length - offset; }
+        let dataLength = data.indexOf('=') - offset;
+        if (dataLength < 0) { dataLength = data.length - offset; }
 
         /* Every four characters is 3 resulting numbers */
-        const result_length = (data_length >> 2) * 3 + Math.floor((data_length % 4) / 1.5);
-        const result = new Array(result_length);
+        const resultLength = (dataLength >> 2) * 3 + Math.floor((dataLength % 4) / 1.5);
+        const result = new Array(resultLength);
 
         // Convert one by one.
 

--- a/core/decoders/hextile.js
+++ b/core/decoders/hextile.js
@@ -17,10 +17,10 @@ export default class HextileDecoder {
 
     decodeRect(x, y, width, height, sock, display, depth) {
         if (this._tiles === 0) {
-            this._tiles_x = Math.ceil(width / 16);
-            this._tiles_y = Math.ceil(height / 16);
-            this._total_tiles = this._tiles_x * this._tiles_y;
-            this._tiles = this._total_tiles;
+            this._tilesX = Math.ceil(width / 16);
+            this._tilesY = Math.ceil(height / 16);
+            this._totalTiles = this._tilesX * this._tilesY;
+            this._tiles = this._totalTiles;
         }
 
         while (this._tiles > 0) {
@@ -39,11 +39,11 @@ export default class HextileDecoder {
                             subencoding + ")");
             }
 
-            const curr_tile = this._total_tiles - this._tiles;
-            const tile_x = curr_tile % this._tiles_x;
-            const tile_y = Math.floor(curr_tile / this._tiles_x);
-            const tx = x + tile_x * 16;
-            const ty = y + tile_y * 16;
+            const currTile = this._totalTiles - this._tiles;
+            const tileX = currTile % this._tilesX;
+            const tileY = Math.floor(currTile / this._tilesX);
+            const tx = x + tileX * 16;
+            const ty = y + tileY * 16;
             const tw = Math.min(16, (x + width) - tx);
             const th = Math.min(16, (y + height) - ty);
 

--- a/core/decoders/raw.js
+++ b/core/decoders/raw.js
@@ -24,15 +24,15 @@ export default class RawDecoder {
             return false;
         }
 
-        const cur_y = y + (height - this._lines);
-        const curr_height = Math.min(this._lines,
-                                     Math.floor(sock.rQlen / bytesPerLine));
+        const curY = y + (height - this._lines);
+        const currHeight = Math.min(this._lines,
+                                    Math.floor(sock.rQlen / bytesPerLine));
         let data = sock.rQ;
         let index = sock.rQi;
 
         // Convert data if needed
         if (depth == 8) {
-            const pixels = width * curr_height;
+            const pixels = width * currHeight;
             const newdata = new Uint8Array(pixels * 4);
             for (let i = 0; i < pixels; i++) {
                 newdata[i * 4 + 0] = ((data[index + i] >> 0) & 0x3) * 255 / 3;
@@ -44,9 +44,9 @@ export default class RawDecoder {
             index = 0;
         }
 
-        display.blitImage(x, cur_y, width, curr_height, data, index);
-        sock.rQskipBytes(curr_height * bytesPerLine);
-        this._lines -= curr_height;
+        display.blitImage(x, curY, width, currHeight, data, index);
+        sock.rQskipBytes(currHeight * bytesPerLine);
+        this._lines -= currHeight;
         if (this._lines > 0) {
             return false;
         }

--- a/core/deflator.js
+++ b/core/deflator.js
@@ -21,12 +21,14 @@ export default class Deflator {
     }
 
     deflate(inData) {
+        /* eslint-disable camelcase */
         this.strm.input = inData;
         this.strm.avail_in = this.strm.input.length;
         this.strm.next_in = 0;
         this.strm.output = this.outputBuffer;
         this.strm.avail_out = this.chunkSize;
         this.strm.next_out = 0;
+        /* eslint-enable camelcase */
 
         let lastRet = deflate(this.strm, Z_FULL_FLUSH);
         let outData = new Uint8Array(this.strm.output.buffer, 0, this.strm.next_out);
@@ -41,9 +43,11 @@ export default class Deflator {
             let chunks = [outData];
             let totalLen = outData.length;
             do {
+                /* eslint-disable camelcase */
                 this.strm.output = new Uint8Array(this.chunkSize);
                 this.strm.next_out = 0;
                 this.strm.avail_out = this.chunkSize;
+                /* eslint-enable camelcase */
 
                 lastRet = deflate(this.strm, Z_FULL_FLUSH);
 
@@ -69,9 +73,11 @@ export default class Deflator {
             outData = newData;
         }
 
+        /* eslint-disable camelcase */
         this.strm.input = null;
         this.strm.avail_in = 0;
         this.strm.next_in = 0;
+        /* eslint-enable camelcase */
 
         return outData;
     }

--- a/core/display.js
+++ b/core/display.js
@@ -13,7 +13,6 @@ import { supportsImageMetadata } from './util/browser.js';
 export default class Display {
     constructor(target) {
         this._drawCtx = null;
-        this._c_forceCanvas = false;
 
         this._renderQ = [];  // queue drawing actions for in-oder rendering
         this._flushing = false;

--- a/core/inflator.js
+++ b/core/inflator.js
@@ -22,6 +22,7 @@ export default class Inflate {
     setInput(data) {
         if (!data) {
             //FIXME: flush remaining data.
+            /* eslint-disable camelcase */
             this.strm.input = null;
             this.strm.avail_in = 0;
             this.strm.next_in = 0;
@@ -29,6 +30,7 @@ export default class Inflate {
             this.strm.input = data;
             this.strm.avail_in = this.strm.input.length;
             this.strm.next_in = 0;
+            /* eslint-enable camelcase */
         }
     }
 
@@ -41,8 +43,10 @@ export default class Inflate {
             this.strm.output = new Uint8Array(this.chunkSize);
         }
 
+        /* eslint-disable camelcase */
         this.strm.next_out = 0;
         this.strm.avail_out = expected;
+        /* eslint-enable camelcase */
 
         let ret = inflate(this.strm, 0); // Flush argument not used.
         if (ret < 0) {

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -69,28 +69,28 @@ export default class RFB extends EventTargetMixin {
 
         // Connection details
         options = options || {};
-        this._rfb_credentials = options.credentials || {};
+        this._rfbCredentials = options.credentials || {};
         this._shared = 'shared' in options ? !!options.shared : true;
         this._repeaterID = options.repeaterID || '';
         this._wsProtocols = options.wsProtocols || [];
 
         // Internal state
-        this._rfb_connection_state = '';
-        this._rfb_init_state = '';
-        this._rfb_auth_scheme = -1;
-        this._rfb_clean_disconnect = true;
+        this._rfbConnectionState = '';
+        this._rfbInitState = '';
+        this._rfbAuthScheme = -1;
+        this._rfbCleanDisconnect = true;
 
         // Server capabilities
-        this._rfb_version = 0;
-        this._rfb_max_version = 3.8;
-        this._rfb_tightvnc = false;
-        this._rfb_vencrypt_state = 0;
-        this._rfb_xvp_ver = 0;
+        this._rfbVersion = 0;
+        this._rfbMaxVersion = 3.8;
+        this._rfbTightVNC = false;
+        this._rfbVeNCryptState = 0;
+        this._rfbXvpVer = 0;
 
-        this._fb_width = 0;
-        this._fb_height = 0;
+        this._fbWidth = 0;
+        this._fbHeight = 0;
 
-        this._fb_name = "";
+        this._fbName = "";
 
         this._capabilities = { power: false };
 
@@ -100,8 +100,8 @@ export default class RFB extends EventTargetMixin {
         this._enabledContinuousUpdates = false;
 
         this._supportsSetDesktopSize = false;
-        this._screen_id = 0;
-        this._screen_flags = 0;
+        this._screenID = 0;
+        this._screenFlags = 0;
 
         this._qemuExtKeyEventSupported = false;
 
@@ -133,7 +133,7 @@ export default class RFB extends EventTargetMixin {
         };
 
         // Mouse state
-        this._mouse_buttonMask = 0;
+        this._mouseButtonMask = 0;
         this._viewportDragging = false;
         this._viewportDragPos = {};
         this._viewportHasMoved = false;
@@ -206,16 +206,16 @@ export default class RFB extends EventTargetMixin {
 
         this._sock = new Websock();
         this._sock.on('message', () => {
-            this._handle_message();
+            this._handleMessage();
         });
         this._sock.on('open', () => {
-            if ((this._rfb_connection_state === 'connecting') &&
-                (this._rfb_init_state === '')) {
-                this._rfb_init_state = 'ProtocolVersion';
+            if ((this._rfbConnectionState === 'connecting') &&
+                (this._rfbInitState === '')) {
+                this._rfbInitState = 'ProtocolVersion';
                 Log.Debug("Starting VNC handshake");
             } else {
                 this._fail("Unexpected server connection while " +
-                           this._rfb_connection_state);
+                           this._rfbConnectionState);
             }
         });
         this._sock.on('close', (e) => {
@@ -228,7 +228,7 @@ export default class RFB extends EventTargetMixin {
                 }
                 msg += ")";
             }
-            switch (this._rfb_connection_state) {
+            switch (this._rfbConnectionState) {
                 case 'connecting':
                     this._fail("Connection closed " + msg);
                     break;
@@ -286,8 +286,8 @@ export default class RFB extends EventTargetMixin {
     set viewOnly(viewOnly) {
         this._viewOnly = viewOnly;
 
-        if (this._rfb_connection_state === "connecting" ||
-            this._rfb_connection_state === "connected") {
+        if (this._rfbConnectionState === "connecting" ||
+            this._rfbConnectionState === "connected") {
             if (viewOnly) {
                 this._keyboard.ungrab();
                 this._mouse.ungrab();
@@ -355,7 +355,7 @@ export default class RFB extends EventTargetMixin {
 
         this._qualityLevel = qualityLevel;
 
-        if (this._rfb_connection_state === 'connected') {
+        if (this._rfbConnectionState === 'connected') {
             this._sendEncodings();
         }
     }
@@ -375,7 +375,7 @@ export default class RFB extends EventTargetMixin {
 
         this._compressionLevel = compressionLevel;
 
-        if (this._rfb_connection_state === 'connected') {
+        if (this._rfbConnectionState === 'connected') {
             this._sendEncodings();
         }
     }
@@ -390,12 +390,12 @@ export default class RFB extends EventTargetMixin {
     }
 
     sendCredentials(creds) {
-        this._rfb_credentials = creds;
-        setTimeout(this._init_msg.bind(this), 0);
+        this._rfbCredentials = creds;
+        setTimeout(this._initMsg.bind(this), 0);
     }
 
     sendCtrlAltDel() {
-        if (this._rfb_connection_state !== 'connected' || this._viewOnly) { return; }
+        if (this._rfbConnectionState !== 'connected' || this._viewOnly) { return; }
         Log.Info("Sending Ctrl-Alt-Del");
 
         this.sendKey(KeyTable.XK_Control_L, "ControlLeft", true);
@@ -421,7 +421,7 @@ export default class RFB extends EventTargetMixin {
     // Send a key press. If 'down' is not specified then send a down key
     // followed by an up key.
     sendKey(keysym, code, down) {
-        if (this._rfb_connection_state !== 'connected' || this._viewOnly) { return; }
+        if (this._rfbConnectionState !== 'connected' || this._viewOnly) { return; }
 
         if (down === undefined) {
             this.sendKey(keysym, code, true);
@@ -456,7 +456,7 @@ export default class RFB extends EventTargetMixin {
     }
 
     clipboardPasteFrom(text) {
-        if (this._rfb_connection_state !== 'connected' || this._viewOnly) { return; }
+        if (this._rfbConnectionState !== 'connected' || this._viewOnly) { return; }
 
         if (this._clipboardServerCapabilitiesFormats[extendedClipboardFormatText] &&
             this._clipboardServerCapabilitiesActions[extendedClipboardActionNotify]) {
@@ -546,10 +546,10 @@ export default class RFB extends EventTargetMixin {
     }
 
     _setDesktopName(name) {
-        this._fb_name = name;
+        this._fbName = name;
         this.dispatchEvent(new CustomEvent(
             "desktopname",
-            { detail: { name: this._fb_name } }));
+            { detail: { name: this._fbName } }));
     }
 
     _windowResize(event) {
@@ -574,19 +574,19 @@ export default class RFB extends EventTargetMixin {
     // Update state of clipping in Display object, and make sure the
     // configured viewport matches the current screen size
     _updateClip() {
-        const cur_clip = this._display.clipViewport;
-        let new_clip = this._clipViewport;
+        const curClip = this._display.clipViewport;
+        let newClip = this._clipViewport;
 
         if (this._scaleViewport) {
             // Disable viewport clipping if we are scaling
-            new_clip = false;
+            newClip = false;
         }
 
-        if (cur_clip !== new_clip) {
-            this._display.clipViewport = new_clip;
+        if (curClip !== newClip) {
+            this._display.clipViewport = newClip;
         }
 
-        if (new_clip) {
+        if (newClip) {
             // When clipping is enabled, the screen is limited to
             // the size of the container.
             const size = this._screenSize();
@@ -619,7 +619,7 @@ export default class RFB extends EventTargetMixin {
         const size = this._screenSize();
         RFB.messages.setDesktopSize(this._sock,
                                     Math.floor(size.w), Math.floor(size.h),
-                                    this._screen_id, this._screen_flags);
+                                    this._screenID, this._screenFlags);
 
         Log.Debug('Requested new desktop size: ' +
                    size.w + 'x' + size.h);
@@ -651,7 +651,7 @@ export default class RFB extends EventTargetMixin {
      *   disconnected - permanent state
      */
     _updateConnectionState(state) {
-        const oldstate = this._rfb_connection_state;
+        const oldstate = this._rfbConnectionState;
 
         if (state === oldstate) {
             Log.Debug("Already in state '" + state + "', ignoring");
@@ -705,7 +705,7 @@ export default class RFB extends EventTargetMixin {
 
         // State change actions
 
-        this._rfb_connection_state = state;
+        this._rfbConnectionState = state;
 
         Log.Debug("New state '" + state + "', was '" + oldstate + "'.");
 
@@ -739,7 +739,7 @@ export default class RFB extends EventTargetMixin {
             case 'disconnected':
                 this.dispatchEvent(new CustomEvent(
                     "disconnect", { detail:
-                                    { clean: this._rfb_clean_disconnect } }));
+                                    { clean: this._rfbCleanDisconnect } }));
                 break;
         }
     }
@@ -750,7 +750,7 @@ export default class RFB extends EventTargetMixin {
      * should be logged but not sent to the user interface.
      */
     _fail(details) {
-        switch (this._rfb_connection_state) {
+        switch (this._rfbConnectionState) {
             case 'disconnecting':
                 Log.Error("Failed when disconnecting: " + details);
                 break;
@@ -764,7 +764,7 @@ export default class RFB extends EventTargetMixin {
                 Log.Error("RFB failure: " + details);
                 break;
         }
-        this._rfb_clean_disconnect = false; //This is sent to the UI
+        this._rfbCleanDisconnect = false; //This is sent to the UI
 
         // Transition to disconnected without waiting for socket to close
         this._updateConnectionState('disconnecting');
@@ -779,13 +779,13 @@ export default class RFB extends EventTargetMixin {
                                            { detail: { capabilities: this._capabilities } }));
     }
 
-    _handle_message() {
+    _handleMessage() {
         if (this._sock.rQlen === 0) {
-            Log.Warn("handle_message called on an empty receive queue");
+            Log.Warn("handleMessage called on an empty receive queue");
             return;
         }
 
-        switch (this._rfb_connection_state) {
+        switch (this._rfbConnectionState) {
             case 'disconnected':
                 Log.Error("Got data while disconnected");
                 break;
@@ -794,7 +794,7 @@ export default class RFB extends EventTargetMixin {
                     if (this._flushing) {
                         break;
                     }
-                    if (!this._normal_msg()) {
+                    if (!this._normalMsg()) {
                         break;
                     }
                     if (this._sock.rQlen === 0) {
@@ -803,7 +803,7 @@ export default class RFB extends EventTargetMixin {
                 }
                 break;
             default:
-                this._init_msg();
+                this._initMsg();
                 break;
         }
     }
@@ -814,9 +814,9 @@ export default class RFB extends EventTargetMixin {
 
     _handleMouseButton(x, y, down, bmask) {
         if (down) {
-            this._mouse_buttonMask |= bmask;
+            this._mouseButtonMask |= bmask;
         } else {
-            this._mouse_buttonMask &= ~bmask;
+            this._mouseButtonMask &= ~bmask;
         }
 
         if (this.dragViewport) {
@@ -848,8 +848,8 @@ export default class RFB extends EventTargetMixin {
 
         if (this._viewOnly) { return; } // View only, skip mouse events
 
-        if (this._rfb_connection_state !== 'connected') { return; }
-        RFB.messages.pointerEvent(this._sock, this._display.absX(x), this._display.absY(y), this._mouse_buttonMask);
+        if (this._rfbConnectionState !== 'connected') { return; }
+        RFB.messages.pointerEvent(this._sock, this._display.absX(x), this._display.absY(y), this._mouseButtonMask);
     }
 
     _handleMouseMove(x, y) {
@@ -871,43 +871,43 @@ export default class RFB extends EventTargetMixin {
 
         if (this._viewOnly) { return; } // View only, skip mouse events
 
-        if (this._rfb_connection_state !== 'connected') { return; }
-        RFB.messages.pointerEvent(this._sock, this._display.absX(x), this._display.absY(y), this._mouse_buttonMask);
+        if (this._rfbConnectionState !== 'connected') { return; }
+        RFB.messages.pointerEvent(this._sock, this._display.absX(x), this._display.absY(y), this._mouseButtonMask);
     }
 
     // Message Handlers
 
-    _negotiate_protocol_version() {
+    _negotiateProtocolVersion() {
         if (this._sock.rQwait("version", 12)) {
             return false;
         }
 
         const sversion = this._sock.rQshiftStr(12).substr(4, 7);
         Log.Info("Server ProtocolVersion: " + sversion);
-        let is_repeater = 0;
+        let isRepeater = 0;
         switch (sversion) {
             case "000.000":  // UltraVNC repeater
-                is_repeater = 1;
+                isRepeater = 1;
                 break;
             case "003.003":
             case "003.006":  // UltraVNC
             case "003.889":  // Apple Remote Desktop
-                this._rfb_version = 3.3;
+                this._rfbVersion = 3.3;
                 break;
             case "003.007":
-                this._rfb_version = 3.7;
+                this._rfbVersion = 3.7;
                 break;
             case "003.008":
             case "004.000":  // Intel AMT KVM
             case "004.001":  // RealVNC 4.6
             case "005.000":  // RealVNC 5.3
-                this._rfb_version = 3.8;
+                this._rfbVersion = 3.8;
                 break;
             default:
                 return this._fail("Invalid server version " + sversion);
         }
 
-        if (is_repeater) {
+        if (isRepeater) {
             let repeaterID = "ID:" + this._repeaterID;
             while (repeaterID.length < 250) {
                 repeaterID += "\0";
@@ -916,19 +916,19 @@ export default class RFB extends EventTargetMixin {
             return true;
         }
 
-        if (this._rfb_version > this._rfb_max_version) {
-            this._rfb_version = this._rfb_max_version;
+        if (this._rfbVersion > this._rfbMaxVersion) {
+            this._rfbVersion = this._rfbMaxVersion;
         }
 
-        const cversion = "00" + parseInt(this._rfb_version, 10) +
-                       ".00" + ((this._rfb_version * 10) % 10);
+        const cversion = "00" + parseInt(this._rfbVersion, 10) +
+                       ".00" + ((this._rfbVersion * 10) % 10);
         this._sock.send_string("RFB " + cversion + "\n");
         Log.Debug('Sent ProtocolVersion: ' + cversion);
 
-        this._rfb_init_state = 'Security';
+        this._rfbInitState = 'Security';
     }
 
-    _negotiate_security() {
+    _negotiateSecurity() {
         // Polyfill since IE and PhantomJS doesn't have
         // TypedArray.includes()
         function includes(item, array) {
@@ -940,57 +940,57 @@ export default class RFB extends EventTargetMixin {
             return false;
         }
 
-        if (this._rfb_version >= 3.7) {
+        if (this._rfbVersion >= 3.7) {
             // Server sends supported list, client decides
-            const num_types = this._sock.rQshift8();
-            if (this._sock.rQwait("security type", num_types, 1)) { return false; }
+            const numTypes = this._sock.rQshift8();
+            if (this._sock.rQwait("security type", numTypes, 1)) { return false; }
 
-            if (num_types === 0) {
-                this._rfb_init_state = "SecurityReason";
-                this._security_context = "no security types";
-                this._security_status = 1;
-                return this._init_msg();
+            if (numTypes === 0) {
+                this._rfbInitState = "SecurityReason";
+                this._securityContext = "no security types";
+                this._securityStatus = 1;
+                return this._initMsg();
             }
 
-            const types = this._sock.rQshiftBytes(num_types);
+            const types = this._sock.rQshiftBytes(numTypes);
             Log.Debug("Server security types: " + types);
 
             // Look for each auth in preferred order
             if (includes(1, types)) {
-                this._rfb_auth_scheme = 1; // None
+                this._rfbAuthScheme = 1; // None
             } else if (includes(22, types)) {
-                this._rfb_auth_scheme = 22; // XVP
+                this._rfbAuthScheme = 22; // XVP
             } else if (includes(16, types)) {
-                this._rfb_auth_scheme = 16; // Tight
+                this._rfbAuthScheme = 16; // Tight
             } else if (includes(2, types)) {
-                this._rfb_auth_scheme = 2; // VNC Auth
+                this._rfbAuthScheme = 2; // VNC Auth
             } else if (includes(19, types)) {
-                this._rfb_auth_scheme = 19; // VeNCrypt Auth
+                this._rfbAuthScheme = 19; // VeNCrypt Auth
             } else {
                 return this._fail("Unsupported security types (types: " + types + ")");
             }
 
-            this._sock.send([this._rfb_auth_scheme]);
+            this._sock.send([this._rfbAuthScheme]);
         } else {
             // Server decides
             if (this._sock.rQwait("security scheme", 4)) { return false; }
-            this._rfb_auth_scheme = this._sock.rQshift32();
+            this._rfbAuthScheme = this._sock.rQshift32();
 
-            if (this._rfb_auth_scheme == 0) {
-                this._rfb_init_state = "SecurityReason";
-                this._security_context = "authentication scheme";
-                this._security_status = 1;
-                return this._init_msg();
+            if (this._rfbAuthScheme == 0) {
+                this._rfbInitState = "SecurityReason";
+                this._securityContext = "authentication scheme";
+                this._securityStatus = 1;
+                return this._initMsg();
             }
         }
 
-        this._rfb_init_state = 'Authentication';
-        Log.Debug('Authenticating using scheme: ' + this._rfb_auth_scheme);
+        this._rfbInitState = 'Authentication';
+        Log.Debug('Authenticating using scheme: ' + this._rfbAuthScheme);
 
-        return this._init_msg(); // jump to authentication
+        return this._initMsg(); // jump to authentication
     }
 
-    _handle_security_reason() {
+    _handleSecurityReason() {
         if (this._sock.rQwait("reason length", 4)) {
             return false;
         }
@@ -1005,47 +1005,47 @@ export default class RFB extends EventTargetMixin {
         if (reason !== "") {
             this.dispatchEvent(new CustomEvent(
                 "securityfailure",
-                { detail: { status: this._security_status,
+                { detail: { status: this._securityStatus,
                             reason: reason } }));
 
             return this._fail("Security negotiation failed on " +
-                              this._security_context +
+                              this._securityContext +
                               " (reason: " + reason + ")");
         } else {
             this.dispatchEvent(new CustomEvent(
                 "securityfailure",
-                { detail: { status: this._security_status } }));
+                { detail: { status: this._securityStatus } }));
 
             return this._fail("Security negotiation failed on " +
-                              this._security_context);
+                              this._securityContext);
         }
     }
 
     // authentication
-    _negotiate_xvp_auth() {
-        if (this._rfb_credentials.username === undefined ||
-            this._rfb_credentials.password === undefined ||
-            this._rfb_credentials.target === undefined) {
+    _negotiateXvpAuth() {
+        if (this._rfbCredentials.username === undefined ||
+            this._rfbCredentials.password === undefined ||
+            this._rfbCredentials.target === undefined) {
             this.dispatchEvent(new CustomEvent(
                 "credentialsrequired",
                 { detail: { types: ["username", "password", "target"] } }));
             return false;
         }
 
-        const xvp_auth_str = String.fromCharCode(this._rfb_credentials.username.length) +
-                           String.fromCharCode(this._rfb_credentials.target.length) +
-                           this._rfb_credentials.username +
-                           this._rfb_credentials.target;
-        this._sock.send_string(xvp_auth_str);
-        this._rfb_auth_scheme = 2;
-        return this._negotiate_authentication();
+        const xvpAuthStr = String.fromCharCode(this._rfbCredentials.username.length) +
+                           String.fromCharCode(this._rfbCredentials.target.length) +
+                           this._rfbCredentials.username +
+                           this._rfbCredentials.target;
+        this._sock.send_string(xvpAuthStr);
+        this._rfbAuthScheme = 2;
+        return this._negotiateAuthentication();
     }
 
     // VeNCrypt authentication, currently only supports version 0.2 and only Plain subtype
-    _negotiate_vencrypt_auth() {
+    _negotiateVeNCryptAuth() {
 
         // waiting for VeNCrypt version
-        if (this._rfb_vencrypt_state == 0) {
+        if (this._rfbVeNCryptState == 0) {
             if (this._sock.rQwait("vencrypt version", 2)) { return false; }
 
             const major = this._sock.rQshift8();
@@ -1056,11 +1056,11 @@ export default class RFB extends EventTargetMixin {
             }
 
             this._sock.send([0, 2]);
-            this._rfb_vencrypt_state = 1;
+            this._rfbVeNCryptState = 1;
         }
 
         // waiting for ACK
-        if (this._rfb_vencrypt_state == 1) {
+        if (this._rfbVeNCryptState == 1) {
             if (this._sock.rQwait("vencrypt ack", 1)) { return false; }
 
             const res = this._sock.rQshift8();
@@ -1069,29 +1069,29 @@ export default class RFB extends EventTargetMixin {
                 return this._fail("VeNCrypt failure " + res);
             }
 
-            this._rfb_vencrypt_state = 2;
+            this._rfbVeNCryptState = 2;
         }
         // must fall through here (i.e. no "else if"), beacause we may have already received
         // the subtypes length and won't be called again
 
-        if (this._rfb_vencrypt_state == 2) { // waiting for subtypes length
+        if (this._rfbVeNCryptState == 2) { // waiting for subtypes length
             if (this._sock.rQwait("vencrypt subtypes length", 1)) { return false; }
 
-            const subtypes_length = this._sock.rQshift8();
-            if (subtypes_length < 1) {
+            const subtypesLength = this._sock.rQshift8();
+            if (subtypesLength < 1) {
                 return this._fail("VeNCrypt subtypes empty");
             }
 
-            this._rfb_vencrypt_subtypes_length = subtypes_length;
-            this._rfb_vencrypt_state = 3;
+            this._rfbVeNCryptSubtypesLength = subtypesLength;
+            this._rfbVeNCryptState = 3;
         }
 
         // waiting for subtypes list
-        if (this._rfb_vencrypt_state == 3) {
-            if (this._sock.rQwait("vencrypt subtypes", 4 * this._rfb_vencrypt_subtypes_length)) { return false; }
+        if (this._rfbVeNCryptState == 3) {
+            if (this._sock.rQwait("vencrypt subtypes", 4 * this._rfbVeNCryptSubtypesLength)) { return false; }
 
             const subtypes = [];
-            for (let i = 0; i < this._rfb_vencrypt_subtypes_length; i++) {
+            for (let i = 0; i < this._rfbVeNCryptSubtypesLength; i++) {
                 subtypes.push(this._sock.rQshift32());
             }
 
@@ -1099,24 +1099,24 @@ export default class RFB extends EventTargetMixin {
             if (subtypes.indexOf(256) != -1) {
                 // 0x100 = 256
                 this._sock.send([0, 0, 1, 0]);
-                this._rfb_vencrypt_state = 4;
+                this._rfbVeNCryptState = 4;
             } else {
                 return this._fail("VeNCrypt Plain subtype not offered by server");
             }
         }
 
         // negotiated Plain subtype, server waits for password
-        if (this._rfb_vencrypt_state == 4) {
-            if (!this._rfb_credentials.username ||
-                !this._rfb_credentials.password) {
+        if (this._rfbVeNCryptState == 4) {
+            if (!this._rfbCredentials.username ||
+                !this._rfbCredentials.password) {
                 this.dispatchEvent(new CustomEvent(
                     "credentialsrequired",
                     { detail: { types: ["username", "password"] } }));
                 return false;
             }
 
-            const user = encodeUTF8(this._rfb_credentials.username);
-            const pass = encodeUTF8(this._rfb_credentials.password);
+            const user = encodeUTF8(this._rfbCredentials.username);
+            const pass = encodeUTF8(this._rfbCredentials.password);
 
             // XXX we assume lengths are <= 255 (should not be an issue in the real world)
             this._sock.send([0, 0, 0, user.length]);
@@ -1124,15 +1124,15 @@ export default class RFB extends EventTargetMixin {
             this._sock.send_string(user);
             this._sock.send_string(pass);
 
-            this._rfb_init_state = "SecurityResult";
+            this._rfbInitState = "SecurityResult";
             return true;
         }
     }
 
-    _negotiate_std_vnc_auth() {
+    _negotiateStdVNCAuth() {
         if (this._sock.rQwait("auth challenge", 16)) { return false; }
 
-        if (this._rfb_credentials.password === undefined) {
+        if (this._rfbCredentials.password === undefined) {
             this.dispatchEvent(new CustomEvent(
                 "credentialsrequired",
                 { detail: { types: ["password"] } }));
@@ -1141,40 +1141,40 @@ export default class RFB extends EventTargetMixin {
 
         // TODO(directxman12): make genDES not require an Array
         const challenge = Array.prototype.slice.call(this._sock.rQshiftBytes(16));
-        const response = RFB.genDES(this._rfb_credentials.password, challenge);
+        const response = RFB.genDES(this._rfbCredentials.password, challenge);
         this._sock.send(response);
-        this._rfb_init_state = "SecurityResult";
+        this._rfbInitState = "SecurityResult";
         return true;
     }
 
-    _negotiate_tight_unix_auth() {
-        if (this._rfb_credentials.username === undefined ||
-            this._rfb_credentials.password === undefined) {
+    _negotiateTightUnixAuth() {
+        if (this._rfbCredentials.username === undefined ||
+            this._rfbCredentials.password === undefined) {
             this.dispatchEvent(new CustomEvent(
                 "credentialsrequired",
                 { detail: { types: ["username", "password"] } }));
             return false;
         }
 
-        this._sock.send([0, 0, 0, this._rfb_credentials.username.length]);
-        this._sock.send([0, 0, 0, this._rfb_credentials.password.length]);
-        this._sock.send_string(this._rfb_credentials.username);
-        this._sock.send_string(this._rfb_credentials.password);
-        this._rfb_init_state = "SecurityResult";
+        this._sock.send([0, 0, 0, this._rfbCredentials.username.length]);
+        this._sock.send([0, 0, 0, this._rfbCredentials.password.length]);
+        this._sock.send_string(this._rfbCredentials.username);
+        this._sock.send_string(this._rfbCredentials.password);
+        this._rfbInitState = "SecurityResult";
         return true;
     }
 
-    _negotiate_tight_tunnels(numTunnels) {
+    _negotiateTightTunnels(numTunnels) {
         const clientSupportedTunnelTypes = {
             0: { vendor: 'TGHT', signature: 'NOTUNNEL' }
         };
         const serverSupportedTunnelTypes = {};
         // receive tunnel capabilities
         for (let i = 0; i < numTunnels; i++) {
-            const cap_code = this._sock.rQshift32();
-            const cap_vendor = this._sock.rQshiftStr(4);
-            const cap_signature = this._sock.rQshiftStr(8);
-            serverSupportedTunnelTypes[cap_code] = { vendor: cap_vendor, signature: cap_signature };
+            const capCode = this._sock.rQshift32();
+            const capVendor = this._sock.rQshiftStr(4);
+            const capSignature = this._sock.rQshiftStr(8);
+            serverSupportedTunnelTypes[capCode] = { vendor: capVendor, signature: capSignature };
         }
 
         Log.Debug("Server Tight tunnel types: " + serverSupportedTunnelTypes);
@@ -1205,16 +1205,16 @@ export default class RFB extends EventTargetMixin {
         }
     }
 
-    _negotiate_tight_auth() {
-        if (!this._rfb_tightvnc) {  // first pass, do the tunnel negotiation
+    _negotiateTightAuth() {
+        if (!this._rfbTightVNC) {  // first pass, do the tunnel negotiation
             if (this._sock.rQwait("num tunnels", 4)) { return false; }
             const numTunnels = this._sock.rQshift32();
             if (numTunnels > 0 && this._sock.rQwait("tunnel capabilities", 16 * numTunnels, 4)) { return false; }
 
-            this._rfb_tightvnc = true;
+            this._rfbTightVNC = true;
 
             if (numTunnels > 0) {
-                this._negotiate_tight_tunnels(numTunnels);
+                this._negotiateTightTunnels(numTunnels);
                 return false;  // wait until we receive the sub auth to continue
             }
         }
@@ -1223,7 +1223,7 @@ export default class RFB extends EventTargetMixin {
         if (this._sock.rQwait("sub auth count", 4)) { return false; }
         const subAuthCount = this._sock.rQshift32();
         if (subAuthCount === 0) {  // empty sub-auth list received means 'no auth' subtype selected
-            this._rfb_init_state = 'SecurityResult';
+            this._rfbInitState = 'SecurityResult';
             return true;
         }
 
@@ -1252,14 +1252,14 @@ export default class RFB extends EventTargetMixin {
 
                 switch (authType) {
                     case 'STDVNOAUTH__':  // no auth
-                        this._rfb_init_state = 'SecurityResult';
+                        this._rfbInitState = 'SecurityResult';
                         return true;
                     case 'STDVVNCAUTH_': // VNC auth
-                        this._rfb_auth_scheme = 2;
-                        return this._init_msg();
+                        this._rfbAuthScheme = 2;
+                        return this._initMsg();
                     case 'TGHTULGNAUTH': // UNIX auth
-                        this._rfb_auth_scheme = 129;
-                        return this._init_msg();
+                        this._rfbAuthScheme = 129;
+                        return this._initMsg();
                     default:
                         return this._fail("Unsupported tiny auth scheme " +
                                           "(scheme: " + authType + ")");
@@ -1270,52 +1270,52 @@ export default class RFB extends EventTargetMixin {
         return this._fail("No supported sub-auth types!");
     }
 
-    _negotiate_authentication() {
-        switch (this._rfb_auth_scheme) {
+    _negotiateAuthentication() {
+        switch (this._rfbAuthScheme) {
             case 1:  // no auth
-                if (this._rfb_version >= 3.8) {
-                    this._rfb_init_state = 'SecurityResult';
+                if (this._rfbVersion >= 3.8) {
+                    this._rfbInitState = 'SecurityResult';
                     return true;
                 }
-                this._rfb_init_state = 'ClientInitialisation';
-                return this._init_msg();
+                this._rfbInitState = 'ClientInitialisation';
+                return this._initMsg();
 
             case 22:  // XVP auth
-                return this._negotiate_xvp_auth();
+                return this._negotiateXvpAuth();
 
             case 2:  // VNC authentication
-                return this._negotiate_std_vnc_auth();
+                return this._negotiateStdVNCAuth();
 
             case 16:  // TightVNC Security Type
-                return this._negotiate_tight_auth();
+                return this._negotiateTightAuth();
 
             case 19:  // VeNCrypt Security Type
-                return this._negotiate_vencrypt_auth();
+                return this._negotiateVeNCryptAuth();
 
             case 129:  // TightVNC UNIX Security Type
-                return this._negotiate_tight_unix_auth();
+                return this._negotiateTightUnixAuth();
 
             default:
                 return this._fail("Unsupported auth scheme (scheme: " +
-                                  this._rfb_auth_scheme + ")");
+                                  this._rfbAuthScheme + ")");
         }
     }
 
-    _handle_security_result() {
+    _handleSecurityResult() {
         if (this._sock.rQwait('VNC auth response ', 4)) { return false; }
 
         const status = this._sock.rQshift32();
 
         if (status === 0) { // OK
-            this._rfb_init_state = 'ClientInitialisation';
+            this._rfbInitState = 'ClientInitialisation';
             Log.Debug('Authentication OK');
-            return this._init_msg();
+            return this._initMsg();
         } else {
-            if (this._rfb_version >= 3.8) {
-                this._rfb_init_state = "SecurityReason";
-                this._security_context = "security result";
-                this._security_status = status;
-                return this._init_msg();
+            if (this._rfbVersion >= 3.8) {
+                this._rfbInitState = "SecurityReason";
+                this._securityContext = "security result";
+                this._securityStatus = status;
+                return this._initMsg();
             } else {
                 this.dispatchEvent(new CustomEvent(
                     "securityfailure",
@@ -1326,7 +1326,7 @@ export default class RFB extends EventTargetMixin {
         }
     }
 
-    _negotiate_server_init() {
+    _negotiateServerInit() {
         if (this._sock.rQwait("server initialization", 24)) { return false; }
 
         /* Screen size */
@@ -1336,28 +1336,28 @@ export default class RFB extends EventTargetMixin {
         /* PIXEL_FORMAT */
         const bpp         = this._sock.rQshift8();
         const depth       = this._sock.rQshift8();
-        const big_endian  = this._sock.rQshift8();
-        const true_color  = this._sock.rQshift8();
+        const bigEndian  = this._sock.rQshift8();
+        const trueColor  = this._sock.rQshift8();
 
-        const red_max     = this._sock.rQshift16();
-        const green_max   = this._sock.rQshift16();
-        const blue_max    = this._sock.rQshift16();
-        const red_shift   = this._sock.rQshift8();
-        const green_shift = this._sock.rQshift8();
-        const blue_shift  = this._sock.rQshift8();
+        const redMax     = this._sock.rQshift16();
+        const greenMax   = this._sock.rQshift16();
+        const blueMax    = this._sock.rQshift16();
+        const redShift   = this._sock.rQshift8();
+        const greenShift = this._sock.rQshift8();
+        const blueShift  = this._sock.rQshift8();
         this._sock.rQskipBytes(3);  // padding
 
         // NB(directxman12): we don't want to call any callbacks or print messages until
         //                   *after* we're past the point where we could backtrack
 
         /* Connection name/title */
-        const name_length = this._sock.rQshift32();
-        if (this._sock.rQwait('server init name', name_length, 24)) { return false; }
-        let name = this._sock.rQshiftStr(name_length);
+        const nameLength = this._sock.rQshift32();
+        if (this._sock.rQwait('server init name', nameLength, 24)) { return false; }
+        let name = this._sock.rQshiftStr(nameLength);
         name = decodeUTF8(name, true);
 
-        if (this._rfb_tightvnc) {
-            if (this._sock.rQwait('TightVNC extended server init header', 8, 24 + name_length)) { return false; }
+        if (this._rfbTightVNC) {
+            if (this._sock.rQwait('TightVNC extended server init header', 8, 24 + nameLength)) { return false; }
             // In TightVNC mode, ServerInit message is extended
             const numServerMessages = this._sock.rQshift16();
             const numClientMessages = this._sock.rQshift16();
@@ -1365,7 +1365,7 @@ export default class RFB extends EventTargetMixin {
             this._sock.rQskipBytes(2);  // padding
 
             const totalMessagesLength = (numServerMessages + numClientMessages + numEncodings) * 16;
-            if (this._sock.rQwait('TightVNC extended server init header', totalMessagesLength, 32 + name_length)) { return false; }
+            if (this._sock.rQwait('TightVNC extended server init header', totalMessagesLength, 32 + nameLength)) { return false; }
 
             // we don't actually do anything with the capability information that TIGHT sends,
             // so we just skip the all of this.
@@ -1384,14 +1384,14 @@ export default class RFB extends EventTargetMixin {
         //                   if we backtrack
         Log.Info("Screen: " + width + "x" + height +
                   ", bpp: " + bpp + ", depth: " + depth +
-                  ", big_endian: " + big_endian +
-                  ", true_color: " + true_color +
-                  ", red_max: " + red_max +
-                  ", green_max: " + green_max +
-                  ", blue_max: " + blue_max +
-                  ", red_shift: " + red_shift +
-                  ", green_shift: " + green_shift +
-                  ", blue_shift: " + blue_shift);
+                  ", bigEndian: " + bigEndian +
+                  ", trueColor: " + trueColor +
+                  ", redMax: " + redMax +
+                  ", greenMax: " + greenMax +
+                  ", blueMax: " + blueMax +
+                  ", redShift: " + redShift +
+                  ", greenShift: " + greenShift +
+                  ", blueShift: " + blueShift);
 
         // we're past the point where we could backtrack, so it's safe to call this
         this._setDesktopName(name);
@@ -1400,16 +1400,16 @@ export default class RFB extends EventTargetMixin {
         if (!this._viewOnly) { this._keyboard.grab(); }
         if (!this._viewOnly) { this._mouse.grab(); }
 
-        this._fb_depth = 24;
+        this._fbDepth = 24;
 
-        if (this._fb_name === "Intel(r) AMT KVM") {
+        if (this._fbName === "Intel(r) AMT KVM") {
             Log.Warn("Intel AMT KVM only supports 8/16 bit depths. Using low color mode.");
-            this._fb_depth = 8;
+            this._fbDepth = 8;
         }
 
-        RFB.messages.pixelFormat(this._sock, this._fb_depth, true);
+        RFB.messages.pixelFormat(this._sock, this._fbDepth, true);
         this._sendEncodings();
-        RFB.messages.fbUpdateRequest(this._sock, false, 0, 0, this._fb_width, this._fb_height);
+        RFB.messages.fbUpdateRequest(this._sock, false, 0, 0, this._fbWidth, this._fbHeight);
 
         this._updateConnectionState('connected');
         return true;
@@ -1421,7 +1421,7 @@ export default class RFB extends EventTargetMixin {
         // In preference order
         encs.push(encodings.encodingCopyRect);
         // Only supported with full depth support
-        if (this._fb_depth == 24) {
+        if (this._fbDepth == 24) {
             encs.push(encodings.encodingTight);
             encs.push(encodings.encodingTightPNG);
             encs.push(encodings.encodingHextile);
@@ -1443,7 +1443,7 @@ export default class RFB extends EventTargetMixin {
         encs.push(encodings.pseudoEncodingDesktopName);
         encs.push(encodings.pseudoEncodingExtendedClipboard);
 
-        if (this._fb_depth == 24) {
+        if (this._fbDepth == 24) {
             encs.push(encodings.pseudoEncodingVMwareCursor);
             encs.push(encodings.pseudoEncodingCursor);
         }
@@ -1459,44 +1459,44 @@ export default class RFB extends EventTargetMixin {
      *   ClientInitialization - not triggered by server message
      *   ServerInitialization
      */
-    _init_msg() {
-        switch (this._rfb_init_state) {
+    _initMsg() {
+        switch (this._rfbInitState) {
             case 'ProtocolVersion':
-                return this._negotiate_protocol_version();
+                return this._negotiateProtocolVersion();
 
             case 'Security':
-                return this._negotiate_security();
+                return this._negotiateSecurity();
 
             case 'Authentication':
-                return this._negotiate_authentication();
+                return this._negotiateAuthentication();
 
             case 'SecurityResult':
-                return this._handle_security_result();
+                return this._handleSecurityResult();
 
             case 'SecurityReason':
-                return this._handle_security_reason();
+                return this._handleSecurityReason();
 
             case 'ClientInitialisation':
                 this._sock.send([this._shared ? 1 : 0]); // ClientInitialisation
-                this._rfb_init_state = 'ServerInitialisation';
+                this._rfbInitState = 'ServerInitialisation';
                 return true;
 
             case 'ServerInitialisation':
-                return this._negotiate_server_init();
+                return this._negotiateServerInit();
 
             default:
                 return this._fail("Unknown init state (state: " +
-                                  this._rfb_init_state + ")");
+                                  this._rfbInitState + ")");
         }
     }
 
-    _handle_set_colour_map_msg() {
+    _handleSetColourMapMsg() {
         Log.Debug("SetColorMapEntries");
 
         return this._fail("Unexpected SetColorMapEntries message");
     }
 
-    _handle_server_cut_text() {
+    _handleServerCutText() {
         Log.Debug("ServerCutText");
 
         if (this._sock.rQwait("ServerCutText header", 7, 1)) { return false; }
@@ -1664,7 +1664,7 @@ export default class RFB extends EventTargetMixin {
         return true;
     }
 
-    _handle_server_fence_msg() {
+    _handleServerFenceMsg() {
         if (this._sock.rQwait("ServerFence header", 8, 1)) { return false; }
         this._sock.rQskipBytes(3); // Padding
         let flags = this._sock.rQshift32();
@@ -1706,49 +1706,49 @@ export default class RFB extends EventTargetMixin {
         return true;
     }
 
-    _handle_xvp_msg() {
+    _handleXvpMsg() {
         if (this._sock.rQwait("XVP version and message", 3, 1)) { return false; }
         this._sock.rQskipBytes(1);  // Padding
-        const xvp_ver = this._sock.rQshift8();
-        const xvp_msg = this._sock.rQshift8();
+        const xvpVer = this._sock.rQshift8();
+        const xvpMsg = this._sock.rQshift8();
 
-        switch (xvp_msg) {
+        switch (xvpMsg) {
             case 0:  // XVP_FAIL
                 Log.Error("XVP Operation Failed");
                 break;
             case 1:  // XVP_INIT
-                this._rfb_xvp_ver = xvp_ver;
-                Log.Info("XVP extensions enabled (version " + this._rfb_xvp_ver + ")");
+                this._rfbXvpVer = xvpVer;
+                Log.Info("XVP extensions enabled (version " + this._rfbXvpVer + ")");
                 this._setCapability("power", true);
                 break;
             default:
-                this._fail("Illegal server XVP message (msg: " + xvp_msg + ")");
+                this._fail("Illegal server XVP message (msg: " + xvpMsg + ")");
                 break;
         }
 
         return true;
     }
 
-    _normal_msg() {
-        let msg_type;
+    _normalMsg() {
+        let msgType;
         if (this._FBU.rects > 0) {
-            msg_type = 0;
+            msgType = 0;
         } else {
-            msg_type = this._sock.rQshift8();
+            msgType = this._sock.rQshift8();
         }
 
         let first, ret;
-        switch (msg_type) {
+        switch (msgType) {
             case 0:  // FramebufferUpdate
                 ret = this._framebufferUpdate();
                 if (ret && !this._enabledContinuousUpdates) {
                     RFB.messages.fbUpdateRequest(this._sock, true, 0, 0,
-                                                 this._fb_width, this._fb_height);
+                                                 this._fbWidth, this._fbHeight);
                 }
                 return ret;
 
             case 1:  // SetColorMapEntries
-                return this._handle_set_colour_map_msg();
+                return this._handleSetColourMapMsg();
 
             case 2:  // Bell
                 Log.Debug("Bell");
@@ -1758,7 +1758,7 @@ export default class RFB extends EventTargetMixin {
                 return true;
 
             case 3:  // ServerCutText
-                return this._handle_server_cut_text();
+                return this._handleServerCutText();
 
             case 150: // EndOfContinuousUpdates
                 first = !this._supportsContinuousUpdates;
@@ -1775,13 +1775,13 @@ export default class RFB extends EventTargetMixin {
                 return true;
 
             case 248: // ServerFence
-                return this._handle_server_fence_msg();
+                return this._handleServerFenceMsg();
 
             case 250:  // XVP
-                return this._handle_xvp_msg();
+                return this._handleXvpMsg();
 
             default:
-                this._fail("Unexpected server message (type " + msg_type + ")");
+                this._fail("Unexpected server message (type " + msgType + ")");
                 Log.Debug("sock.rQslice(0, 30): " + this._sock.rQslice(0, 30));
                 return true;
         }
@@ -1791,7 +1791,7 @@ export default class RFB extends EventTargetMixin {
         this._flushing = false;
         // Resume processing
         if (this._sock.rQlen > 0) {
-            this._handle_message();
+            this._handleMessage();
         }
     }
 
@@ -1885,7 +1885,7 @@ export default class RFB extends EventTargetMixin {
             return false;
         }
 
-        const cursor_type = this._sock.rQshift8();
+        const cursorType = this._sock.rQshift8();
 
         this._sock.rQshift8(); //Padding
 
@@ -1893,7 +1893,7 @@ export default class RFB extends EventTargetMixin {
         const bytesPerPixel = 4;
 
         //Classic cursor
-        if (cursor_type == 0) {
+        if (cursorType == 0) {
             //Used to filter away unimportant bits.
             //OR is used for correct conversion in js.
             const PIXEL_MASK = 0xffffff00 | 0;
@@ -1904,20 +1904,20 @@ export default class RFB extends EventTargetMixin {
                 return false;
             }
 
-            let and_mask = new Array(w * h);
+            let andMask = new Array(w * h);
             for (let pixel = 0; pixel < (w * h); pixel++) {
-                and_mask[pixel] = this._sock.rQshift32();
+                andMask[pixel] = this._sock.rQshift32();
             }
 
-            let xor_mask = new Array(w * h);
+            let xorMask = new Array(w * h);
             for (let pixel = 0; pixel < (w * h); pixel++) {
-                xor_mask[pixel] = this._sock.rQshift32();
+                xorMask[pixel] = this._sock.rQshift32();
             }
 
             for (let pixel = 0; pixel < (w * h); pixel++) {
-                if (and_mask[pixel] == 0) {
+                if (andMask[pixel] == 0) {
                     //Fully opaque pixel
-                    let bgr = xor_mask[pixel];
+                    let bgr = xorMask[pixel];
                     let r   = bgr >> 8  & 0xff;
                     let g   = bgr >> 16 & 0xff;
                     let b   = bgr >> 24 & 0xff;
@@ -1927,17 +1927,17 @@ export default class RFB extends EventTargetMixin {
                     rgba[(pixel * bytesPerPixel) + 2 ] = b;    //b
                     rgba[(pixel * bytesPerPixel) + 3 ] = 0xff; //a
 
-                } else if ((and_mask[pixel] & PIXEL_MASK) ==
+                } else if ((andMask[pixel] & PIXEL_MASK) ==
                            PIXEL_MASK) {
                     //Only screen value matters, no mouse colouring
-                    if (xor_mask[pixel] == 0) {
+                    if (xorMask[pixel] == 0) {
                         //Transparent pixel
                         rgba[(pixel * bytesPerPixel)     ] = 0x00;
                         rgba[(pixel * bytesPerPixel) + 1 ] = 0x00;
                         rgba[(pixel * bytesPerPixel) + 2 ] = 0x00;
                         rgba[(pixel * bytesPerPixel) + 3 ] = 0x00;
 
-                    } else if ((xor_mask[pixel] & PIXEL_MASK) ==
+                    } else if ((xorMask[pixel] & PIXEL_MASK) ==
                                PIXEL_MASK) {
                         //Inverted pixel, not supported in browsers.
                         //Fully opaque instead.
@@ -1947,7 +1947,7 @@ export default class RFB extends EventTargetMixin {
                         rgba[(pixel * bytesPerPixel) + 3 ] = 0xff;
 
                     } else {
-                        //Unhandled xor_mask
+                        //Unhandled xorMask
                         rgba[(pixel * bytesPerPixel)     ] = 0x00;
                         rgba[(pixel * bytesPerPixel) + 1 ] = 0x00;
                         rgba[(pixel * bytesPerPixel) + 2 ] = 0x00;
@@ -1955,7 +1955,7 @@ export default class RFB extends EventTargetMixin {
                     }
 
                 } else {
-                    //Unhandled and_mask
+                    //Unhandled andMask
                     rgba[(pixel * bytesPerPixel)     ] = 0x00;
                     rgba[(pixel * bytesPerPixel) + 1 ] = 0x00;
                     rgba[(pixel * bytesPerPixel) + 2 ] = 0x00;
@@ -1964,7 +1964,7 @@ export default class RFB extends EventTargetMixin {
             }
 
         //Alpha cursor.
-        } else if (cursor_type == 1) {
+        } else if (cursorType == 1) {
             if (this._sock.rQwait("VMware cursor alpha encoding",
                                   (w * h * 4), 2)) {
                 return false;
@@ -1983,7 +1983,7 @@ export default class RFB extends EventTargetMixin {
 
         } else {
             Log.Warn("The given cursor type is not supported: "
-                      + cursor_type + " given.");
+                      + cursorType + " given.");
             return false;
         }
 
@@ -2011,16 +2011,16 @@ export default class RFB extends EventTargetMixin {
         const mask = this._sock.rQshiftBytes(masklength);
         let rgba = new Uint8Array(w * h * 4);
 
-        let pix_idx = 0;
+        let pixIdx = 0;
         for (let y = 0; y < h; y++) {
             for (let x = 0; x < w; x++) {
-                let mask_idx = y * Math.ceil(w / 8) + Math.floor(x / 8);
-                let alpha = (mask[mask_idx] << (x % 8)) & 0x80 ? 255 : 0;
-                rgba[pix_idx    ] = pixels[pix_idx + 2];
-                rgba[pix_idx + 1] = pixels[pix_idx + 1];
-                rgba[pix_idx + 2] = pixels[pix_idx];
-                rgba[pix_idx + 3] = alpha;
-                pix_idx += 4;
+                let maskIdx = y * Math.ceil(w / 8) + Math.floor(x / 8);
+                let alpha = (mask[maskIdx] << (x % 8)) & 0x80 ? 255 : 0;
+                rgba[pixIdx    ] = pixels[pixIdx + 2];
+                rgba[pixIdx + 1] = pixels[pixIdx + 1];
+                rgba[pixIdx + 2] = pixels[pixIdx];
+                rgba[pixIdx + 3] = alpha;
+                pixIdx += 4;
             }
         }
 
@@ -2053,9 +2053,9 @@ export default class RFB extends EventTargetMixin {
             return false;
         }
 
-        const number_of_screens = this._sock.rQpeek8();
+        const numberOfScreens = this._sock.rQpeek8();
 
-        let bytes = 4 + (number_of_screens * 16);
+        let bytes = 4 + (numberOfScreens * 16);
         if (this._sock.rQwait("ExtendedDesktopSize", bytes)) {
             return false;
         }
@@ -2074,15 +2074,15 @@ export default class RFB extends EventTargetMixin {
         this._sock.rQskipBytes(1);  // number-of-screens
         this._sock.rQskipBytes(3);  // padding
 
-        for (let i = 0; i < number_of_screens; i += 1) {
+        for (let i = 0; i < numberOfScreens; i += 1) {
             // Save the id and flags of the first screen
             if (i === 0) {
-                this._screen_id = this._sock.rQshiftBytes(4);    // id
+                this._screenID = this._sock.rQshiftBytes(4);    // id
                 this._sock.rQskipBytes(2);                       // x-position
                 this._sock.rQskipBytes(2);                       // y-position
                 this._sock.rQskipBytes(2);                       // width
                 this._sock.rQskipBytes(2);                       // height
-                this._screen_flags = this._sock.rQshiftBytes(4); // flags
+                this._screenFlags = this._sock.rQshiftBytes(4); // flags
             } else {
                 this._sock.rQskipBytes(16);
             }
@@ -2135,7 +2135,7 @@ export default class RFB extends EventTargetMixin {
             return decoder.decodeRect(this._FBU.x, this._FBU.y,
                                       this._FBU.width, this._FBU.height,
                                       this._sock, this._display,
-                                      this._fb_depth);
+                                      this._fbDepth);
         } catch (err) {
             this._fail("Error decoding rect: " + err);
             return false;
@@ -2146,14 +2146,14 @@ export default class RFB extends EventTargetMixin {
         if (!this._enabledContinuousUpdates) { return; }
 
         RFB.messages.enableContinuousUpdates(this._sock, true, 0, 0,
-                                             this._fb_width, this._fb_height);
+                                             this._fbWidth, this._fbHeight);
     }
 
     _resize(width, height) {
-        this._fb_width = width;
-        this._fb_height = height;
+        this._fbWidth = width;
+        this._fbHeight = height;
 
-        this._display.resize(this._fb_width, this._fb_height);
+        this._display.resize(this._fbWidth, this._fbHeight);
 
         // Adjust the visible viewport based on the new dimensions
         this._updateClip();
@@ -2163,7 +2163,7 @@ export default class RFB extends EventTargetMixin {
     }
 
     _xvpOp(ver, op) {
-        if (this._rfb_xvp_ver < ver) { return; }
+        if (this._rfbXvpVer < ver) { return; }
         Log.Info("Sending XVP operation " + op + " (version " + ver + ")");
         RFB.messages.xvpOp(this._sock, ver, op);
     }
@@ -2199,8 +2199,8 @@ export default class RFB extends EventTargetMixin {
     }
 
     _refreshCursor() {
-        if (this._rfb_connection_state !== "connecting" &&
-            this._rfb_connection_state !== "connected") {
+        if (this._rfbConnectionState !== "connecting" &&
+            this._rfbConnectionState !== "connected") {
             return;
         }
         const image = this._shouldShowDotCursor() ? RFB.cursors.dot : this._cursorImage;
@@ -2238,13 +2238,13 @@ RFB.messages = {
     },
 
     QEMUExtendedKeyEvent(sock, keysym, down, keycode) {
-        function getRFBkeycode(xt_scancode) {
+        function getRFBkeycode(xtScanCode) {
             const upperByte = (keycode >> 8);
             const lowerByte = (keycode & 0x00ff);
             if (upperByte === 0xe0 && lowerByte < 0x7f) {
                 return lowerByte | 0x80;
             }
-            return xt_scancode;
+            return xtScanCode;
         }
 
         const buff = sock._sQ;
@@ -2513,7 +2513,7 @@ RFB.messages = {
         sock.flush();
     },
 
-    pixelFormat(sock, depth, true_color) {
+    pixelFormat(sock, depth, trueColor) {
         const buff = sock._sQ;
         const offset = sock._sQlen;
 
@@ -2538,7 +2538,7 @@ RFB.messages = {
         buff[offset + 4] = bpp;                 // bits-per-pixel
         buff[offset + 5] = depth;               // depth
         buff[offset + 6] = 0;                   // little-endian
-        buff[offset + 7] = true_color ? 1 : 0;  // true-color
+        buff[offset + 7] = trueColor ? 1 : 0;  // true-color
 
         buff[offset + 8] = 0;    // red-max
         buff[offset + 9] = (1 << bits) - 1;  // red-max

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -134,7 +134,6 @@ export default class RFB extends EventTargetMixin {
 
         // Mouse state
         this._mouse_buttonMask = 0;
-        this._mouse_arr = [];
         this._viewportDragging = false;
         this._viewportDragPos = {};
         this._viewportHasMoved = false;

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -912,7 +912,7 @@ export default class RFB extends EventTargetMixin {
             while (repeaterID.length < 250) {
                 repeaterID += "\0";
             }
-            this._sock.send_string(repeaterID);
+            this._sock.sendString(repeaterID);
             return true;
         }
 
@@ -922,7 +922,7 @@ export default class RFB extends EventTargetMixin {
 
         const cversion = "00" + parseInt(this._rfbVersion, 10) +
                        ".00" + ((this._rfbVersion * 10) % 10);
-        this._sock.send_string("RFB " + cversion + "\n");
+        this._sock.sendString("RFB " + cversion + "\n");
         Log.Debug('Sent ProtocolVersion: ' + cversion);
 
         this._rfbInitState = 'Security';
@@ -1036,7 +1036,7 @@ export default class RFB extends EventTargetMixin {
                            String.fromCharCode(this._rfbCredentials.target.length) +
                            this._rfbCredentials.username +
                            this._rfbCredentials.target;
-        this._sock.send_string(xvpAuthStr);
+        this._sock.sendString(xvpAuthStr);
         this._rfbAuthScheme = 2;
         return this._negotiateAuthentication();
     }
@@ -1121,8 +1121,8 @@ export default class RFB extends EventTargetMixin {
             // XXX we assume lengths are <= 255 (should not be an issue in the real world)
             this._sock.send([0, 0, 0, user.length]);
             this._sock.send([0, 0, 0, pass.length]);
-            this._sock.send_string(user);
-            this._sock.send_string(pass);
+            this._sock.sendString(user);
+            this._sock.sendString(pass);
 
             this._rfbInitState = "SecurityResult";
             return true;
@@ -1158,8 +1158,8 @@ export default class RFB extends EventTargetMixin {
 
         this._sock.send([0, 0, 0, this._rfbCredentials.username.length]);
         this._sock.send([0, 0, 0, this._rfbCredentials.password.length]);
-        this._sock.send_string(this._rfbCredentials.username);
-        this._sock.send_string(this._rfbCredentials.password);
+        this._sock.sendString(this._rfbCredentials.username);
+        this._sock.sendString(this._rfbCredentials.password);
         this._rfbInitState = "SecurityResult";
         return true;
     }

--- a/core/util/logging.js
+++ b/core/util/logging.js
@@ -10,18 +10,18 @@
  * Logging/debug routines
  */
 
-let _log_level = 'warn';
+let _logLevel = 'warn';
 
 let Debug = () => {};
 let Info = () => {};
 let Warn = () => {};
 let Error = () => {};
 
-export function init_logging(level) {
+export function initLogging(level) {
     if (typeof level === 'undefined') {
-        level = _log_level;
+        level = _logLevel;
     } else {
-        _log_level = level;
+        _logLevel = level;
     }
 
     Debug = Info = Warn = Error = () => {};
@@ -46,11 +46,11 @@ export function init_logging(level) {
     }
 }
 
-export function get_logging() {
-    return _log_level;
+export function getLogging() {
+    return _logLevel;
 }
 
 export { Debug, Info, Warn, Error };
 
 // Initialize logging level
-init_logging();
+initLogging();

--- a/core/websock.js
+++ b/core/websock.js
@@ -144,7 +144,7 @@ export default class Websock {
 
     flush() {
         if (this._sQlen > 0 && this._websocket.readyState === WebSocket.OPEN) {
-            this._websocket.send(this._encode_message());
+            this._websocket.send(this._encodeMessage());
             this._sQlen = 0;
         }
     }
@@ -155,7 +155,7 @@ export default class Websock {
         this.flush();
     }
 
-    send_string(str) {
+    sendString(str) {
         this.send(str.split('').map(chr => chr.charCodeAt(0)));
     }
 
@@ -168,13 +168,13 @@ export default class Websock {
         this._eventHandlers[evt] = handler;
     }
 
-    _allocate_buffers() {
+    _allocateBuffers() {
         this._rQ = new Uint8Array(this._rQbufferSize);
         this._sQ = new Uint8Array(this._sQbufferSize);
     }
 
     init() {
-        this._allocate_buffers();
+        this._allocateBuffers();
         this._rQi = 0;
         this._websocket = null;
     }
@@ -185,7 +185,7 @@ export default class Websock {
         this._websocket = new WebSocket(uri, protocols);
         this._websocket.binaryType = 'arraybuffer';
 
-        this._websocket.onmessage = this._recv_message.bind(this);
+        this._websocket.onmessage = this._recvMessage.bind(this);
         this._websocket.onopen = () => {
             Log.Debug('>> WebSock.onopen');
             if (this._websocket.protocol) {
@@ -220,7 +220,7 @@ export default class Websock {
     }
 
     // private methods
-    _encode_message() {
+    _encodeMessage() {
         // Put in a binary arraybuffer
         // according to the spec, you can send ArrayBufferViews with the send method
         return new Uint8Array(this._sQ.buffer, 0, this._sQlen);
@@ -231,30 +231,30 @@ export default class Websock {
     // The function also expands the receive que if needed, and for
     // performance reasons we combine these two actions to avoid
     // unneccessary copying.
-    _expand_compact_rQ(min_fit) {
+    _expandCompactRQ(minFit) {
         // if we're using less than 1/8th of the buffer even with the incoming bytes, compact in place
         // instead of resizing
-        const required_buffer_size =  (this._rQlen - this._rQi + min_fit) * 8;
-        const resizeNeeded = this._rQbufferSize < required_buffer_size;
+        const requiredBufferSize =  (this._rQlen - this._rQi + minFit) * 8;
+        const resizeNeeded = this._rQbufferSize < requiredBufferSize;
 
         if (resizeNeeded) {
             // Make sure we always *at least* double the buffer size, and have at least space for 8x
             // the current amount of data
-            this._rQbufferSize = Math.max(this._rQbufferSize * 2, required_buffer_size);
+            this._rQbufferSize = Math.max(this._rQbufferSize * 2, requiredBufferSize);
         }
 
         // we don't want to grow unboundedly
         if (this._rQbufferSize > MAX_RQ_GROW_SIZE) {
             this._rQbufferSize = MAX_RQ_GROW_SIZE;
-            if (this._rQbufferSize - this.rQlen < min_fit) {
+            if (this._rQbufferSize - this.rQlen < minFit) {
                 throw new Error("Receive Queue buffer exceeded " + MAX_RQ_GROW_SIZE + " bytes, and the new message could not fit");
             }
         }
 
         if (resizeNeeded) {
-            const old_rQbuffer = this._rQ.buffer;
+            const oldRQbuffer = this._rQ.buffer;
             this._rQ = new Uint8Array(this._rQbufferSize);
-            this._rQ.set(new Uint8Array(old_rQbuffer, this._rQi, this._rQlen - this._rQi));
+            this._rQ.set(new Uint8Array(oldRQbuffer, this._rQi, this._rQlen - this._rQi));
         } else {
             if (ENABLE_COPYWITHIN) {
                 this._rQ.copyWithin(0, this._rQi, this._rQlen);
@@ -268,17 +268,17 @@ export default class Websock {
     }
 
     // push arraybuffer values onto the end of the receive que
-    _decode_message(data) {
+    _DecodeMessage(data) {
         const u8 = new Uint8Array(data);
         if (u8.length > this._rQbufferSize - this._rQlen) {
-            this._expand_compact_rQ(u8.length);
+            this._expandCompactRQ(u8.length);
         }
         this._rQ.set(u8, this._rQlen);
         this._rQlen += u8.length;
     }
 
-    _recv_message(e) {
-        this._decode_message(e.data);
+    _recvMessage(e) {
+        this._DecodeMessage(e.data);
         if (this.rQlen > 0) {
             this._eventHandlers.message();
             if (this._rQlen == this._rQi) {

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -1,32 +1,32 @@
 // noVNC specific assertions
 chai.use(function (_chai, utils) {
-    _chai.Assertion.addMethod('displayed', function (target_data) {
+    _chai.Assertion.addMethod('displayed', function (targetData) {
         const obj = this._obj;
         const ctx = obj._target.getContext('2d');
-        const data_cl = ctx.getImageData(0, 0, obj._target.width, obj._target.height).data;
+        const dataCl = ctx.getImageData(0, 0, obj._target.width, obj._target.height).data;
         // NB(directxman12): PhantomJS 1.x doesn't implement Uint8ClampedArray, so work around that
-        const data = new Uint8Array(data_cl);
-        const len = data_cl.length;
-        new chai.Assertion(len).to.be.equal(target_data.length, "unexpected display size");
+        const data = new Uint8Array(dataCl);
+        const len = dataCl.length;
+        new chai.Assertion(len).to.be.equal(targetData.length, "unexpected display size");
         let same = true;
         for (let i = 0; i < len; i++) {
-            if (data[i] != target_data[i]) {
+            if (data[i] != targetData[i]) {
                 same = false;
                 break;
             }
         }
         if (!same) {
             // eslint-disable-next-line no-console
-            console.log("expected data: %o, actual data: %o", target_data, data);
+            console.log("expected data: %o, actual data: %o", targetData, data);
         }
         this.assert(same,
                     "expected #{this} to have displayed the image #{exp}, but instead it displayed #{act}",
                     "expected #{this} not to have displayed the image #{act}",
-                    target_data,
+                    targetData,
                     data);
     });
 
-    _chai.Assertion.addMethod('sent', function (target_data) {
+    _chai.Assertion.addMethod('sent', function (targetData) {
         const obj = this._obj;
         obj.inspect = () => {
             const res = { _websocket: obj._websocket, rQi: obj._rQi, _rQ: new Uint8Array(obj._rQ.buffer, 0, obj._rQlen),
@@ -34,13 +34,13 @@ chai.use(function (_chai, utils) {
             res.prototype = obj;
             return res;
         };
-        const data = obj._websocket._get_sent_data();
+        const data = obj._websocket._getSentData();
         let same = true;
-        if (data.length != target_data.length) {
+        if (data.length != targetData.length) {
             same = false;
         } else {
             for (let i = 0; i < data.length; i++) {
-                if (data[i] != target_data[i]) {
+                if (data[i] != targetData[i]) {
                     same = false;
                     break;
                 }
@@ -48,12 +48,12 @@ chai.use(function (_chai, utils) {
         }
         if (!same) {
             // eslint-disable-next-line no-console
-            console.log("expected data: %o, actual data: %o", target_data, data);
+            console.log("expected data: %o, actual data: %o", targetData, data);
         }
         this.assert(same,
                     "expected #{this} to have sent the data #{exp}, but it actually sent #{act}",
                     "expected #{this} not to have sent the data #{act}",
-                    Array.prototype.slice.call(target_data),
+                    Array.prototype.slice.call(targetData),
                     Array.prototype.slice.call(data));
     });
 

--- a/tests/fake.websocket.js
+++ b/tests/fake.websocket.js
@@ -1,7 +1,7 @@
 import Base64 from '../core/base64.js';
 
 // PhantomJS can't create Event objects directly, so we need to use this
-function make_event(name, props) {
+function makeEvent(name, props) {
     const evt = document.createEvent('Event');
     evt.initEvent(name, true, true);
     if (props) {
@@ -24,18 +24,18 @@ export default class FakeWebSocket {
             this.protocol = protocols[0];
         }
 
-        this._send_queue = new Uint8Array(20000);
+        this._sendQueue = new Uint8Array(20000);
 
         this.readyState = FakeWebSocket.CONNECTING;
         this.bufferedAmount = 0;
 
-        this.__is_fake = true;
+        this._isFake = true;
     }
 
     close(code, reason) {
         this.readyState = FakeWebSocket.CLOSED;
         if (this.onclose) {
-            this.onclose(make_event("close", { 'code': code, 'reason': reason, 'wasClean': true }));
+            this.onclose(makeEvent("close", { 'code': code, 'reason': reason, 'wasClean': true }));
         }
     }
 
@@ -45,12 +45,12 @@ export default class FakeWebSocket {
         } else {
             data = new Uint8Array(data);
         }
-        this._send_queue.set(data, this.bufferedAmount);
+        this._sendQueue.set(data, this.bufferedAmount);
         this.bufferedAmount += data.length;
     }
 
-    _get_sent_data() {
-        const res = new Uint8Array(this._send_queue.buffer, 0, this.bufferedAmount);
+    _getSentData() {
+        const res = new Uint8Array(this._sendQueue.buffer, 0, this.bufferedAmount);
         this.bufferedAmount = 0;
         return res;
     }
@@ -58,16 +58,16 @@ export default class FakeWebSocket {
     _open() {
         this.readyState = FakeWebSocket.OPEN;
         if (this.onopen) {
-            this.onopen(make_event('open'));
+            this.onopen(makeEvent('open'));
         }
     }
 
-    _receive_data(data) {
+    _receiveData(data) {
         // Break apart the data to expose bugs where we assume data is
         // neatly packaged
         for (let i = 0;i < data.length;i++) {
             let buf = data.subarray(i, i+1);
-            this.onmessage(make_event("message", { 'data': buf }));
+            this.onmessage(makeEvent("message", { 'data': buf }));
         }
     }
 }
@@ -77,20 +77,20 @@ FakeWebSocket.CONNECTING = WebSocket.CONNECTING;
 FakeWebSocket.CLOSING = WebSocket.CLOSING;
 FakeWebSocket.CLOSED = WebSocket.CLOSED;
 
-FakeWebSocket.__is_fake = true;
+FakeWebSocket._isFake = true;
 
 FakeWebSocket.replace = () => {
-    if (!WebSocket.__is_fake) {
-        const real_version = WebSocket;
+    if (!WebSocket._isFake) {
+        const realVersion = WebSocket;
         // eslint-disable-next-line no-global-assign
         WebSocket = FakeWebSocket;
-        FakeWebSocket.__real_version = real_version;
+        FakeWebSocket._realVersion = realVersion;
     }
 };
 
 FakeWebSocket.restore = () => {
-    if (WebSocket.__is_fake) {
+    if (WebSocket._isFake) {
         // eslint-disable-next-line no-global-assign
-        WebSocket = WebSocket.__real_version;
+        WebSocket = WebSocket._realVersion;
     }
 };

--- a/tests/playback-ui.js
+++ b/tests/playback-ui.js
@@ -1,4 +1,4 @@
-/* global VNC_frame_data, VNC_frame_encoding */
+/* global vncFrameData, vncFrameEncoding */
 
 import * as WebUtil from '../app/webutil.js';
 import RecordingPlayer from './playback.js';
@@ -41,7 +41,7 @@ function enableUI() {
         document.getElementById('mode1').checked = true;
     }
 
-    message("Loaded " + VNC_frame_data.length + " frames");
+    message("Loaded " + vncFrameData.length + " frames");
 
     const startButton = document.getElementById('startButton');
     startButton.disabled = false;
@@ -49,12 +49,12 @@ function enableUI() {
 
     message("Converting...");
 
-    frames = VNC_frame_data;
+    frames = vncFrameData;
 
     let encoding;
     // Only present in older recordings
-    if (window.VNC_frame_encoding) {
-        encoding = VNC_frame_encoding;
+    if (window.vncFrameEncoding) {
+        encoding = vncFrameEncoding;
     } else {
         let frame = frames[0];
         let start = frame.indexOf('{', 1) + 1;
@@ -102,7 +102,7 @@ class IterationPlayer {
         this._iteration = undefined;
         this._player = undefined;
 
-        this._start_time = undefined;
+        this._startTime = undefined;
 
         this._frames = frames;
 
@@ -115,7 +115,7 @@ class IterationPlayer {
 
     start(realtime) {
         this._iteration = 0;
-        this._start_time = (new Date()).getTime();
+        this._startTime = (new Date()).getTime();
 
         this._realtime = realtime;
 
@@ -139,7 +139,7 @@ class IterationPlayer {
 
     _finish() {
         const endTime = (new Date()).getTime();
-        const totalDuration = endTime - this._start_time;
+        const totalDuration = endTime - this._startTime;
 
         const evt = new CustomEvent('finish',
                                     { detail:

--- a/tests/playback.js
+++ b/tests/playback.js
@@ -49,10 +49,10 @@ export default class RecordingPlayer {
         this._disconnected = disconnected;
 
         this._rfb = undefined;
-        this._frame_length = this._frames.length;
+        this._frameLength = this._frames.length;
 
-        this._frame_index = 0;
-        this._start_time = undefined;
+        this._frameIndex = 0;
+        this._startTime = undefined;
         this._realtime = true;
         this._trafficManagement = true;
 
@@ -72,8 +72,8 @@ export default class RecordingPlayer {
         this._enablePlaybackMode();
 
         // reset the frame index and timer
-        this._frame_index = 0;
-        this._start_time = (new Date()).getTime();
+        this._frameIndex = 0;
+        this._startTime = (new Date()).getTime();
 
         this._realtime = realtime;
         this._trafficManagement = (trafficManagement === undefined) ? !realtime : trafficManagement;
@@ -97,22 +97,22 @@ export default class RecordingPlayer {
     _queueNextPacket() {
         if (!this._running) { return; }
 
-        let frame = this._frames[this._frame_index];
+        let frame = this._frames[this._frameIndex];
 
         // skip send frames
-        while (this._frame_index < this._frame_length && frame.fromClient) {
-            this._frame_index++;
-            frame = this._frames[this._frame_index];
+        while (this._frameIndex < this._frameLength && frame.fromClient) {
+            this._frameIndex++;
+            frame = this._frames[this._frameIndex];
         }
 
-        if (this._frame_index >= this._frame_length) {
+        if (this._frameIndex >= this._frameLength) {
             Log.Debug('Finished, no more frames');
             this._finish();
             return;
         }
 
         if (this._realtime) {
-            const toffset = (new Date()).getTime() - this._start_time;
+            const toffset = (new Date()).getTime() - this._startTime;
             let delay = frame.timestamp - toffset;
             if (delay < 1) delay = 1;
 
@@ -134,10 +134,10 @@ export default class RecordingPlayer {
             return;
         }
 
-        const frame = this._frames[this._frame_index];
+        const frame = this._frames[this._frameIndex];
 
         this._rfb._sock._recv_message({'data': frame.data});
-        this._frame_index++;
+        this._frameIndex++;
 
         this._queueNextPacket();
     }
@@ -155,13 +155,13 @@ export default class RecordingPlayer {
             this._running = false;
             this._rfb._sock._eventHandlers.close({code: 1000, reason: ""});
             delete this._rfb;
-            this.onfinish((new Date()).getTime() - this._start_time);
+            this.onfinish((new Date()).getTime() - this._startTime);
         }
     }
 
     _handleDisconnect(evt) {
         this._running = false;
-        this._disconnected(evt.detail.clean, this._frame_index);
+        this._disconnected(evt.detail.clean, this._frameIndex);
     }
 
     _handleCredentials(evt) {

--- a/tests/test.deflator.js
+++ b/tests/test.deflator.js
@@ -17,12 +17,14 @@ function _inflator(compText, expected) {
         strm.output = new Uint8Array(chunkSize);
     }
 
+    /* eslint-disable camelcase */
     strm.input = compText;
     strm.avail_in = strm.input.length;
     strm.next_in = 0;
 
     strm.next_out = 0;
     strm.avail_out = expected.length;
+    /* eslint-enable camelcase */
 
     let ret = inflate(strm, 0);
 

--- a/tests/test.display.js
+++ b/tests/test.display.js
@@ -385,10 +385,6 @@ describe('Display/Canvas Helper', function () {
             sinon.spy(display, '_scan_renderQ');
         });
 
-        afterEach(function () {
-            window.requestAnimationFrame = this.old_requestAnimationFrame;
-        });
-
         it('should try to process an item when it is pushed on, if nothing else is on the queue', function () {
             display._renderQ_push({ type: 'noop' });  // does nothing
             expect(display._scan_renderQ).to.have.been.calledOnce;

--- a/tests/test.display.js
+++ b/tests/test.display.js
@@ -4,28 +4,28 @@ import Base64 from '../core/base64.js';
 import Display from '../core/display.js';
 
 describe('Display/Canvas Helper', function () {
-    const checked_data = new Uint8Array([
+    const checkedData = new Uint8Array([
         0x00, 0x00, 0xff, 255, 0x00, 0x00, 0xff, 255, 0x00, 0xff, 0x00, 255, 0x00, 0xff, 0x00, 255,
         0x00, 0x00, 0xff, 255, 0x00, 0x00, 0xff, 255, 0x00, 0xff, 0x00, 255, 0x00, 0xff, 0x00, 255,
         0x00, 0xff, 0x00, 255, 0x00, 0xff, 0x00, 255, 0x00, 0x00, 0xff, 255, 0x00, 0x00, 0xff, 255,
         0x00, 0xff, 0x00, 255, 0x00, 0xff, 0x00, 255, 0x00, 0x00, 0xff, 255, 0x00, 0x00, 0xff, 255
     ]);
 
-    const basic_data = new Uint8Array([0xff, 0x00, 0x00, 255, 0x00, 0xff, 0x00, 255, 0x00, 0x00, 0xff, 255, 0xff, 0xff, 0xff, 255]);
+    const basicData = new Uint8Array([0xff, 0x00, 0x00, 255, 0x00, 0xff, 0x00, 255, 0x00, 0x00, 0xff, 255, 0xff, 0xff, 0xff, 255]);
 
-    function make_image_canvas(input_data) {
+    function makeImageCanvas(inputData) {
         const canvas = document.createElement('canvas');
         canvas.width = 4;
         canvas.height = 4;
         const ctx = canvas.getContext('2d');
         const data = ctx.createImageData(4, 4);
-        for (let i = 0; i < checked_data.length; i++) { data.data[i] = input_data[i]; }
+        for (let i = 0; i < checkedData.length; i++) { data.data[i] = inputData[i]; }
         ctx.putImageData(data, 0, 0);
         return canvas;
     }
 
-    function make_image_png(input_data) {
-        const canvas = make_image_canvas(input_data);
+    function makeImagePng(inputData) {
+        const canvas = makeImageCanvas(inputData);
         const url = canvas.toDataURL();
         const data = url.split(",")[1];
         return Base64.decode(data);
@@ -44,11 +44,11 @@ describe('Display/Canvas Helper', function () {
         it('should take viewport location into consideration when drawing images', function () {
             display.resize(4, 4);
             display.viewportChangeSize(2, 2);
-            display.drawImage(make_image_canvas(basic_data), 1, 1);
+            display.drawImage(makeImageCanvas(basicData), 1, 1);
             display.flip();
 
             const expected = new Uint8Array(16);
-            for (let i = 0; i < 8; i++) { expected[i] = basic_data[i]; }
+            for (let i = 0; i < 8; i++) { expected[i] = basicData[i]; }
             for (let i = 8; i < 16; i++) { expected[i] = 0; }
             expect(display).to.have.displayed(expected);
         });
@@ -123,8 +123,8 @@ describe('Display/Canvas Helper', function () {
 
         it('should change the size of the logical canvas', function () {
             display.resize(5, 7);
-            expect(display._fb_width).to.equal(5);
-            expect(display._fb_height).to.equal(7);
+            expect(display._fbWidth).to.equal(5);
+            expect(display._fbHeight).to.equal(7);
         });
 
         it('should keep the framebuffer data', function () {
@@ -275,7 +275,7 @@ describe('Display/Canvas Helper', function () {
             display.flip();
             display.fillRect(0, 0, 4, 4, [0, 0xff, 0]);
             const expected = [];
-            for (let i = 0; i < 4 * display._fb_width * display._fb_height; i += 4) {
+            for (let i = 0; i < 4 * display._fbWidth * display._fbHeight; i += 4) {
                 expected[i] = 0xff;
                 expected[i+1] = expected[i+2] = 0;
                 expected[i+3] = 0xff;
@@ -288,7 +288,7 @@ describe('Display/Canvas Helper', function () {
             display.fillRect(0, 0, 2, 2, [0xff, 0, 0]);
             display.fillRect(2, 2, 2, 2, [0xff, 0, 0]);
             display.flip();
-            expect(display).to.have.displayed(checked_data);
+            expect(display).to.have.displayed(checkedData);
         });
 
         it('should support copying an portion of the canvas via #copyImage', function () {
@@ -296,14 +296,14 @@ describe('Display/Canvas Helper', function () {
             display.fillRect(0, 0, 2, 2, [0xff, 0, 0x00]);
             display.copyImage(0, 0, 2, 2, 2, 2);
             display.flip();
-            expect(display).to.have.displayed(checked_data);
+            expect(display).to.have.displayed(checkedData);
         });
 
         it('should support drawing images via #imageRect', function (done) {
-            display.imageRect(0, 0, 4, 4, "image/png", make_image_png(checked_data));
+            display.imageRect(0, 0, 4, 4, "image/png", makeImagePng(checkedData));
             display.flip();
             display.onflush = () => {
-                expect(display).to.have.displayed(checked_data);
+                expect(display).to.have.displayed(checkedData);
                 done();
             };
             display.flush();
@@ -315,12 +315,12 @@ describe('Display/Canvas Helper', function () {
             display.subTile(2, 2, 2, 2, [0xff, 0, 0]);
             display.finishTile();
             display.flip();
-            expect(display).to.have.displayed(checked_data);
+            expect(display).to.have.displayed(checkedData);
         });
 
         // We have a special cache for 16x16 tiles that we need to test
         it('should support drawing a 16x16 tile', function () {
-            const large_checked_data = new Uint8Array(16*16*4);
+            const largeCheckedData = new Uint8Array(16*16*4);
             display.resize(16, 16);
 
             for (let y = 0;y < 16;y++) {
@@ -328,11 +328,11 @@ describe('Display/Canvas Helper', function () {
                     let pixel;
                     if ((x < 4) && (y < 4)) {
                         // NB: of course IE11 doesn't support #slice on ArrayBufferViews...
-                        pixel = Array.prototype.slice.call(checked_data, (y*4+x)*4, (y*4+x+1)*4);
+                        pixel = Array.prototype.slice.call(checkedData, (y*4+x)*4, (y*4+x+1)*4);
                     } else {
                         pixel = [0, 0xff, 0, 255];
                     }
-                    large_checked_data.set(pixel, (y*16+x)*4);
+                    largeCheckedData.set(pixel, (y*16+x)*4);
                 }
             }
 
@@ -341,39 +341,39 @@ describe('Display/Canvas Helper', function () {
             display.subTile(2, 2, 2, 2, [0xff, 0, 0]);
             display.finishTile();
             display.flip();
-            expect(display).to.have.displayed(large_checked_data);
+            expect(display).to.have.displayed(largeCheckedData);
         });
 
         it('should support drawing BGRX blit images with true color via #blitImage', function () {
             const data = [];
             for (let i = 0; i < 16; i++) {
-                data[i * 4] = checked_data[i * 4 + 2];
-                data[i * 4 + 1] = checked_data[i * 4 + 1];
-                data[i * 4 + 2] = checked_data[i * 4];
-                data[i * 4 + 3] = checked_data[i * 4 + 3];
+                data[i * 4] = checkedData[i * 4 + 2];
+                data[i * 4 + 1] = checkedData[i * 4 + 1];
+                data[i * 4 + 2] = checkedData[i * 4];
+                data[i * 4 + 3] = checkedData[i * 4 + 3];
             }
             display.blitImage(0, 0, 4, 4, data, 0);
             display.flip();
-            expect(display).to.have.displayed(checked_data);
+            expect(display).to.have.displayed(checkedData);
         });
 
         it('should support drawing RGB blit images with true color via #blitRgbImage', function () {
             const data = [];
             for (let i = 0; i < 16; i++) {
-                data[i * 3] = checked_data[i * 4];
-                data[i * 3 + 1] = checked_data[i * 4 + 1];
-                data[i * 3 + 2] = checked_data[i * 4 + 2];
+                data[i * 3] = checkedData[i * 4];
+                data[i * 3 + 1] = checkedData[i * 4 + 1];
+                data[i * 3 + 2] = checkedData[i * 4 + 2];
             }
             display.blitRgbImage(0, 0, 4, 4, data, 0);
             display.flip();
-            expect(display).to.have.displayed(checked_data);
+            expect(display).to.have.displayed(checkedData);
         });
 
         it('should support drawing an image object via #drawImage', function () {
-            const img = make_image_canvas(checked_data);
+            const img = makeImageCanvas(checkedData);
             display.drawImage(img, 0, 0);
             display.flip();
-            expect(display).to.have.displayed(checked_data);
+            expect(display).to.have.displayed(checkedData);
         });
     });
 
@@ -382,18 +382,18 @@ describe('Display/Canvas Helper', function () {
         beforeEach(function () {
             display = new Display(document.createElement('canvas'));
             display.resize(4, 4);
-            sinon.spy(display, '_scan_renderQ');
+            sinon.spy(display, '_scanRenderQ');
         });
 
         it('should try to process an item when it is pushed on, if nothing else is on the queue', function () {
-            display._renderQ_push({ type: 'noop' });  // does nothing
-            expect(display._scan_renderQ).to.have.been.calledOnce;
+            display._renderQPush({ type: 'noop' });  // does nothing
+            expect(display._scanRenderQ).to.have.been.calledOnce;
         });
 
         it('should not try to process an item when it is pushed on if we are waiting for other items', function () {
             display._renderQ.length = 2;
-            display._renderQ_push({ type: 'noop' });
-            expect(display._scan_renderQ).to.not.have.been.called;
+            display._renderQPush({ type: 'noop' });
+            expect(display._scanRenderQ).to.not.have.been.called;
         });
 
         it('should wait until an image is loaded to attempt to draw it and the rest of the queue', function () {
@@ -403,13 +403,13 @@ describe('Display/Canvas Helper', function () {
             display.drawImage = sinon.spy();
             display.fillRect = sinon.spy();
 
-            display._scan_renderQ();
+            display._scanRenderQ();
             expect(display.drawImage).to.not.have.been.called;
             expect(display.fillRect).to.not.have.been.called;
             expect(img.addEventListener).to.have.been.calledOnce;
 
             display._renderQ[0].img.complete = true;
-            display._scan_renderQ();
+            display._scanRenderQ();
             expect(display.drawImage).to.have.been.calledOnce;
             expect(display.fillRect).to.have.been.calledOnce;
             expect(img.addEventListener).to.have.been.calledOnce;
@@ -422,7 +422,7 @@ describe('Display/Canvas Helper', function () {
             display.drawImage = sinon.spy();
             display.fillRect = sinon.spy();
 
-            display._scan_renderQ();
+            display._scanRenderQ();
             expect(display.drawImage).to.not.have.been.called;
             expect(display.fillRect).to.not.have.been.called;
             expect(img.addEventListener).to.have.been.calledOnce;
@@ -430,7 +430,7 @@ describe('Display/Canvas Helper', function () {
             display._renderQ[0].img.complete = true;
             display._renderQ[0].img.width = 4;
             display._renderQ[0].img.height = 4;
-            display._scan_renderQ();
+            display._scanRenderQ();
             expect(display.drawImage).to.have.been.calledOnce;
             expect(display.fillRect).to.have.been.calledOnce;
             expect(img.addEventListener).to.have.been.calledOnce;
@@ -446,35 +446,35 @@ describe('Display/Canvas Helper', function () {
 
         it('should draw a blit image on type "blit"', function () {
             display.blitImage = sinon.spy();
-            display._renderQ_push({ type: 'blit', x: 3, y: 4, width: 5, height: 6, data: [7, 8, 9] });
+            display._renderQPush({ type: 'blit', x: 3, y: 4, width: 5, height: 6, data: [7, 8, 9] });
             expect(display.blitImage).to.have.been.calledOnce;
             expect(display.blitImage).to.have.been.calledWith(3, 4, 5, 6, [7, 8, 9], 0);
         });
 
         it('should draw a blit RGB image on type "blitRgb"', function () {
             display.blitRgbImage = sinon.spy();
-            display._renderQ_push({ type: 'blitRgb', x: 3, y: 4, width: 5, height: 6, data: [7, 8, 9] });
+            display._renderQPush({ type: 'blitRgb', x: 3, y: 4, width: 5, height: 6, data: [7, 8, 9] });
             expect(display.blitRgbImage).to.have.been.calledOnce;
             expect(display.blitRgbImage).to.have.been.calledWith(3, 4, 5, 6, [7, 8, 9], 0);
         });
 
         it('should copy a region on type "copy"', function () {
             display.copyImage = sinon.spy();
-            display._renderQ_push({ type: 'copy', x: 3, y: 4, width: 5, height: 6, old_x: 7, old_y: 8 });
+            display._renderQPush({ type: 'copy', x: 3, y: 4, width: 5, height: 6, oldX: 7, oldY: 8 });
             expect(display.copyImage).to.have.been.calledOnce;
             expect(display.copyImage).to.have.been.calledWith(7, 8, 3, 4, 5, 6);
         });
 
         it('should fill a rect with a given color on type "fill"', function () {
             display.fillRect = sinon.spy();
-            display._renderQ_push({ type: 'fill', x: 3, y: 4, width: 5, height: 6, color: [7, 8, 9]});
+            display._renderQPush({ type: 'fill', x: 3, y: 4, width: 5, height: 6, color: [7, 8, 9]});
             expect(display.fillRect).to.have.been.calledOnce;
             expect(display.fillRect).to.have.been.calledWith(3, 4, 5, 6, [7, 8, 9]);
         });
 
         it('should draw an image from an image object on type "img" (if complete)', function () {
             display.drawImage = sinon.spy();
-            display._renderQ_push({ type: 'img', x: 3, y: 4, img: { complete: true } });
+            display._renderQPush({ type: 'img', x: 3, y: 4, img: { complete: true } });
             expect(display.drawImage).to.have.been.calledOnce;
             expect(display.drawImage).to.have.been.calledWith({ complete: true }, 3, 4);
         });

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -352,7 +352,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                     push32(data, toUnsigned32bit(-8));
                     data = data.concat(flags);
                     data = data.concat(fileSizes);
-                    client._sock._websocket._receive_data(new Uint8Array(data));
+                    client._sock._websocket._receiveData(new Uint8Array(data));
 
                     client.clipboardPasteFrom('extended test');
                     expect(RFB.messages.extendedClipboardNotify).to.have.been.calledOnce;
@@ -450,7 +450,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             sinon.spy(client._display, "viewportChangeSize");
 
-            client._sock._websocket._receive_data(new Uint8Array(incoming));
+            client._sock._websocket._receiveData(new Uint8Array(incoming));
 
             // FIXME: Display implicitly calls viewportChangeSize() when
             //        resizing the framebuffer, hence calledTwice.
@@ -640,7 +640,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             sinon.spy(client._display, "autoscale");
 
-            client._sock._websocket._receive_data(new Uint8Array(incoming));
+            client._sock._websocket._receiveData(new Uint8Array(incoming));
 
             expect(client._display.autoscale).to.have.been.calledOnce;
             expect(client._display.autoscale).to.have.been.calledWith(70, 80);
@@ -695,7 +695,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             client._supportsSetDesktopSize = false;
 
-            client._sock._websocket._receive_data(new Uint8Array(incoming));
+            client._sock._websocket._receiveData(new Uint8Array(incoming));
 
             expect(RFB.messages.setDesktopSize).to.have.been.calledOnce;
             expect(RFB.messages.setDesktopSize).to.have.been.calledWith(sinon.match.object, 70, 80, 0, 0);
@@ -704,7 +704,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             // Second message should not trigger a resize
 
-            client._sock._websocket._receive_data(new Uint8Array(incoming));
+            client._sock._websocket._receiveData(new Uint8Array(incoming));
 
             expect(RFB.messages.setDesktopSize).to.not.have.been.called;
         });
@@ -787,7 +787,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                                0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x04,
                                0x00, 0x00, 0x00, 0x00 ];
 
-            client._sock._websocket._receive_data(new Uint8Array(incoming));
+            client._sock._websocket._receiveData(new Uint8Array(incoming));
 
             expect(RFB.messages.setDesktopSize).to.not.have.been.called;
         });
@@ -1005,7 +1005,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 }
                 arr[0] = 'R'; arr[1] = 'F'; arr[2] = 'B'; arr[3] = ' ';
                 arr[11] = '\n';
-                client._sock._websocket._receive_data(arr);
+                client._sock._websocket._receiveData(arr);
             }
 
             describe('version parsing', function () {
@@ -1083,7 +1083,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                     sendVer('000.000', client);
                     expect(client._rfbVersion).to.equal(0);
 
-                    const sentData = client._sock._websocket._get_sent_data();
+                    const sentData = client._sock._websocket._getSentData();
                     expect(new Uint8Array(sentData.buffer, 0, 9)).to.array.equal(new Uint8Array([73, 68, 58, 49, 50, 51, 52, 53, 0]));
                     expect(sentData).to.have.length(250);
                 });
@@ -1106,14 +1106,14 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 const authSchemeRaw = [1, 2, 3, 4];
                 const authScheme = (authSchemeRaw[0] << 24) + (authSchemeRaw[1] << 16) +
                                   (authSchemeRaw[2] << 8) + authSchemeRaw[3];
-                client._sock._websocket._receive_data(new Uint8Array(authSchemeRaw));
+                client._sock._websocket._receiveData(new Uint8Array(authSchemeRaw));
                 expect(client._rfbAuthScheme).to.equal(authScheme);
             });
 
             it('should prefer no authentication is possible', function () {
                 client._rfbVersion = 3.7;
                 const authSchemes = [2, 1, 3];
-                client._sock._websocket._receive_data(new Uint8Array(authSchemes));
+                client._sock._websocket._receiveData(new Uint8Array(authSchemes));
                 expect(client._rfbAuthScheme).to.equal(1);
                 expect(client._sock).to.have.sent(new Uint8Array([1, 1]));
             });
@@ -1121,7 +1121,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should choose for the most prefered scheme possible for versions >= 3.7', function () {
                 client._rfbVersion = 3.7;
                 const authSchemes = [2, 22, 16];
-                client._sock._websocket._receive_data(new Uint8Array(authSchemes));
+                client._sock._websocket._receiveData(new Uint8Array(authSchemes));
                 expect(client._rfbAuthScheme).to.equal(22);
                 expect(client._sock).to.have.sent(new Uint8Array([22]));
             });
@@ -1130,7 +1130,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 sinon.spy(client, "_fail");
                 client._rfbVersion = 3.7;
                 const authSchemes = [1, 32];
-                client._sock._websocket._receive_data(new Uint8Array(authSchemes));
+                client._sock._websocket._receiveData(new Uint8Array(authSchemes));
                 expect(client._fail).to.have.been.calledOnce;
             });
 
@@ -1138,7 +1138,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 client._rfbVersion = 3.7;
                 const failureData = [0, 0, 0, 0, 6, 119, 104, 111, 111, 112, 115];
                 sinon.spy(client, '_fail');
-                client._sock._websocket._receive_data(new Uint8Array(failureData));
+                client._sock._websocket._receiveData(new Uint8Array(failureData));
 
                 expect(client._fail).to.have.been.calledOnce;
                 expect(client._fail).to.have.been.calledWith(
@@ -1149,7 +1149,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 client._rfbVersion = 3.7;
                 const authSchemes = [1, 1];
                 client._negotiateAuthentication = sinon.spy();
-                client._sock._websocket._receive_data(new Uint8Array(authSchemes));
+                client._sock._websocket._receiveData(new Uint8Array(authSchemes));
                 expect(client._rfbInitState).to.equal('Authentication');
                 expect(client._negotiateAuthentication).to.have.been.calledOnce;
             });
@@ -1161,7 +1161,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
             });
 
             function sendSecurity(type, cl) {
-                cl._sock._websocket._receive_data(new Uint8Array([1, type]));
+                cl._sock._websocket._receiveData(new Uint8Array([1, type]));
             }
 
             it('should fail on auth scheme 0 (pre 3.7) with the given message', function () {
@@ -1175,7 +1175,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 }
 
                 sinon.spy(client, '_fail');
-                client._sock._websocket._receive_data(new Uint8Array(data));
+                client._sock._websocket._receiveData(new Uint8Array(data));
                 expect(client._fail).to.have.been.calledWith(
                     'Security negotiation failed on authentication scheme (reason: Whoopsies)');
             });
@@ -1212,7 +1212,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
                     const challenge = [];
                     for (let i = 0; i < 16; i++) { challenge[i] = i; }
-                    client._sock._websocket._receive_data(new Uint8Array(challenge));
+                    client._sock._websocket._receiveData(new Uint8Array(challenge));
 
                     expect(client._rfbCredentials).to.be.empty;
                     expect(spy).to.have.been.calledOnce;
@@ -1222,11 +1222,11 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 it('should encrypt the password with DES and then send it back', function () {
                     client._rfbCredentials = { password: 'passwd' };
                     sendSecurity(2, client);
-                    client._sock._websocket._get_sent_data(); // skip the choice of auth reply
+                    client._sock._websocket._getSentData(); // skip the choice of auth reply
 
                     const challenge = [];
                     for (let i = 0; i < 16; i++) { challenge[i] = i; }
-                    client._sock._websocket._receive_data(new Uint8Array(challenge));
+                    client._sock._websocket._receiveData(new Uint8Array(challenge));
 
                     const desPass = RFB.genDES('passwd', challenge);
                     expect(client._sock).to.have.sent(new Uint8Array(desPass));
@@ -1238,7 +1238,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
                     const challenge = [];
                     for (let i = 0; i < 16; i++) { challenge[i] = i; }
-                    client._sock._websocket._receive_data(new Uint8Array(challenge));
+                    client._sock._websocket._receiveData(new Uint8Array(challenge));
 
                     expect(client._rfbInitState).to.equal('SecurityResult');
                 });
@@ -1301,7 +1301,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                     client._rfbInitState = 'Security';
                     client._rfbVersion = 3.8;
                     sendSecurity(16, client);
-                    client._sock._websocket._get_sent_data();  // skip the security reply
+                    client._sock._websocket._getSentData();  // skip the security reply
                 });
 
                 function sendNumStrPairs(pairs, client) {
@@ -1318,11 +1318,11 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         }
                     }
 
-                    client._sock._websocket._receive_data(new Uint8Array(data));
+                    client._sock._websocket._receiveData(new Uint8Array(data));
                 }
 
                 it('should skip tunnel negotiation if no tunnels are requested', function () {
-                    client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 0]));
+                    client._sock._websocket._receiveData(new Uint8Array([0, 0, 0, 0]));
                     expect(client._rfbTightVNC).to.be.true;
                 });
 
@@ -1344,7 +1344,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
                 it('should continue to sub-auth negotiation after tunnel negotiation', function () {
                     sendNumStrPairs([[0, 'TGHT', 'NOTUNNEL']], client);
-                    client._sock._websocket._get_sent_data();  // skip the tunnel choice here
+                    client._sock._websocket._getSentData();  // skip the tunnel choice here
                     sendNumStrPairs([[1, 'STDV', 'NOAUTH__']], client);
                     expect(client._sock).to.have.sent(new Uint8Array([0, 0, 0, 1]));
                     expect(client._rfbInitState).to.equal('SecurityResult');
@@ -1390,7 +1390,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
             });
 
             it('should fall through to ServerInitialisation on a response code of 0', function () {
-                client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 0]));
+                client._sock._websocket._receiveData(new Uint8Array([0, 0, 0, 0]));
                 expect(client._rfbInitState).to.equal('ServerInitialisation');
             });
 
@@ -1398,7 +1398,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 client._rfbVersion = 3.8;
                 sinon.spy(client, '_fail');
                 const failureData = [0, 0, 0, 1, 0, 0, 0, 6, 119, 104, 111, 111, 112, 115];
-                client._sock._websocket._receive_data(new Uint8Array(failureData));
+                client._sock._websocket._receiveData(new Uint8Array(failureData));
                 expect(client._fail).to.have.been.calledWith(
                     'Security negotiation failed on security result (reason: whoops)');
             });
@@ -1406,7 +1406,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should fail on an error code of 1 with a standard message for version < 3.8', function () {
                 sinon.spy(client, '_fail');
                 client._rfbVersion = 3.7;
-                client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 1]));
+                client._sock._websocket._receiveData(new Uint8Array([0, 0, 0, 1]));
                 expect(client._fail).to.have.been.calledWith(
                     'Security handshake failed');
             });
@@ -1414,7 +1414,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should result in securityfailure event when receiving a non zero status', function () {
                 const spy = sinon.spy();
                 client.addEventListener("securityfailure", spy);
-                client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 2]));
+                client._sock._websocket._receiveData(new Uint8Array([0, 0, 0, 2]));
                 expect(spy).to.have.been.calledOnce;
                 expect(spy.args[0][0].detail.status).to.equal(2);
             });
@@ -1425,7 +1425,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 client.addEventListener("securityfailure", spy);
                 const failureData = [0, 0, 0, 1, 0, 0, 0, 12, 115, 117, 99, 104,
                                      32, 102, 97, 105, 108, 117, 114, 101];
-                client._sock._websocket._receive_data(new Uint8Array(failureData));
+                client._sock._websocket._receiveData(new Uint8Array(failureData));
                 expect(spy.args[0][0].detail.status).to.equal(1);
                 expect(spy.args[0][0].detail.reason).to.equal('such failure');
             });
@@ -1435,7 +1435,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 const spy = sinon.spy();
                 client.addEventListener("securityfailure", spy);
                 const failureData = [0, 0, 0, 1, 0, 0, 0, 0];
-                client._sock._websocket._receive_data(new Uint8Array(failureData));
+                client._sock._websocket._receiveData(new Uint8Array(failureData));
                 expect(spy.args[0][0].detail.status).to.equal(1);
                 expect('reason' in spy.args[0][0].detail).to.be.false;
             });
@@ -1444,7 +1444,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 client._rfbVersion = 3.6;
                 const spy = sinon.spy();
                 client.addEventListener("securityfailure", spy);
-                client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 2]));
+                client._sock._websocket._receiveData(new Uint8Array([0, 0, 0, 2]));
                 expect(spy.args[0][0].detail.status).to.equal(2);
                 expect('reason' in spy.args[0][0].detail).to.be.false;
             });
@@ -1455,7 +1455,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 const client = makeRFB();
                 client._rfbConnectionState = 'connecting';
                 client._rfbInitState = 'SecurityResult';
-                client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 0]));
+                client._sock._websocket._receiveData(new Uint8Array([0, 0, 0, 0]));
                 expect(client._rfbInitState).to.equal('ServerInitialisation');
             });
 
@@ -1463,7 +1463,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 const client = makeRFB('wss://host:8675', { shared: true });
                 client._rfbConnectionState = 'connecting';
                 client._rfbInitState = 'SecurityResult';
-                client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 0]));
+                client._sock._websocket._receiveData(new Uint8Array([0, 0, 0, 0]));
                 expect(client._sock).to.have.sent(new Uint8Array([1]));
             });
 
@@ -1471,7 +1471,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 const client = makeRFB('wss://host:8675', { shared: false });
                 client._rfbConnectionState = 'connecting';
                 client._rfbInitState = 'SecurityResult';
-                client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 0]));
+                client._sock._websocket._receiveData(new Uint8Array([0, 0, 0, 0]));
                 expect(client._sock).to.have.sent(new Uint8Array([0]));
             });
         });
@@ -1510,15 +1510,15 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 push8(data, 0);
                 push8(data, 0);
 
-                client._sock._websocket._receive_data(new Uint8Array(data));
+                client._sock._websocket._receiveData(new Uint8Array(data));
 
                 const nameData = [];
                 let nameLen = [];
                 pushString(nameData, fullOpts.name);
                 push32(nameLen, nameData.length);
 
-                client._sock._websocket._receive_data(new Uint8Array(nameLen));
-                client._sock._websocket._receive_data(new Uint8Array(nameData));
+                client._sock._websocket._receiveData(new Uint8Array(nameLen));
+                client._sock._websocket._receiveData(new Uint8Array(nameData));
             }
 
             it('should set the framebuffer width and height', function () {
@@ -1553,7 +1553,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 for (let i = 0; i < 16 + 32 + 48; i++) {
                     tightData.push(i);
                 }
-                client._sock._websocket._receive_data(new Uint8Array(tightData));
+                client._sock._websocket._receiveData(new Uint8Array(tightData));
 
                 expect(client._rfbConnectionState).to.equal('connected');
             });
@@ -1677,7 +1677,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                     data = data.concat(rectData[i]);
                 }
 
-                client._sock._websocket._receive_data(new Uint8Array(data));
+                client._sock._websocket._receiveData(new Uint8Array(data));
             }
 
             it('should send an update request if there is sufficient data', function () {
@@ -1685,14 +1685,14 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 RFB.messages.fbUpdateRequest(expectedMsg, true, 0, 0, 640, 20);
 
                 client._framebufferUpdate = () => true;
-                client._sock._websocket._receive_data(new Uint8Array([0]));
+                client._sock._websocket._receiveData(new Uint8Array([0]));
 
                 expect(client._sock).to.have.sent(expectedMsg._sQ);
             });
 
             it('should not send an update request if we need more data', function () {
-                client._sock._websocket._receive_data(new Uint8Array([0]));
-                expect(client._sock._websocket._get_sent_data()).to.have.length(0);
+                client._sock._websocket._receiveData(new Uint8Array([0]));
+                expect(client._sock._websocket._getSentData()).to.have.length(0);
             });
 
             it('should resume receiving an update if we previously did not have enough data', function () {
@@ -1700,21 +1700,21 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 RFB.messages.fbUpdateRequest(expectedMsg, true, 0, 0, 640, 20);
 
                 // just enough to set FBU.rects
-                client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 3]));
-                expect(client._sock._websocket._get_sent_data()).to.have.length(0);
+                client._sock._websocket._receiveData(new Uint8Array([0, 0, 0, 3]));
+                expect(client._sock._websocket._getSentData()).to.have.length(0);
 
                 client._framebufferUpdate = function () { this._sock.rQskipBytes(1); return true; };  // we magically have enough data
                 // 247 should *not* be used as the message type here
-                client._sock._websocket._receive_data(new Uint8Array([247]));
+                client._sock._websocket._receiveData(new Uint8Array([247]));
                 expect(client._sock).to.have.sent(expectedMsg._sQ);
             });
 
             it('should not send a request in continuous updates mode', function () {
                 client._enabledContinuousUpdates = true;
                 client._framebufferUpdate = () => true;
-                client._sock._websocket._receive_data(new Uint8Array([0]));
+                client._sock._websocket._receiveData(new Uint8Array([0]));
 
-                expect(client._sock._websocket._get_sent_data()).to.have.length(0);
+                expect(client._sock._websocket._getSentData()).to.have.length(0);
             });
 
             it('should fail on an unsupported encoding', function () {
@@ -2381,7 +2381,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should set the XVP version and fire the callback with the version on XVP_INIT', function () {
                 const spy = sinon.spy();
                 client.addEventListener("capabilities", spy);
-                client._sock._websocket._receive_data(new Uint8Array([250, 0, 10, 1]));
+                client._sock._websocket._receiveData(new Uint8Array([250, 0, 10, 1]));
                 expect(client._rfbXvpVer).to.equal(10);
                 expect(spy).to.have.been.calledOnce;
                 expect(spy.args[0][0].detail.capabilities.power).to.be.true;
@@ -2390,7 +2390,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             it('should fail on unknown XVP message types', function () {
                 sinon.spy(client, "_fail");
-                client._sock._websocket._receive_data(new Uint8Array([250, 0, 10, 237]));
+                client._sock._websocket._receiveData(new Uint8Array([250, 0, 10, 237]));
                 expect(client._fail).to.have.been.calledOnce;
             });
         });
@@ -2404,7 +2404,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 const spy = sinon.spy();
                 client.addEventListener("clipboard", spy);
 
-                client._sock._websocket._receive_data(new Uint8Array(data));
+                client._sock._websocket._receiveData(new Uint8Array(data));
                 expect(spy).to.have.been.calledOnce;
                 expect(spy.args[0][0].detail.text).to.equal(expectedStr);
             });
@@ -2430,7 +2430,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                     push32(data, toUnsigned32bit(-12));
                     data = data.concat(flags);
                     data = data.concat(fileSizes);
-                    client._sock._websocket._receive_data(new Uint8Array(data));
+                    client._sock._websocket._receiveData(new Uint8Array(data));
 
                     // Check that we give an response caps when we receive one
                     expect(RFB.messages.extendedClipboardCaps).to.have.been.calledOnce;
@@ -2456,7 +2456,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                     push32(data, toUnsigned32bit(-8));
                     data = data.concat(flags);
                     data = data.concat(fileSizes);
-                    client._sock._websocket._receive_data(new Uint8Array(data));
+                    client._sock._websocket._receiveData(new Uint8Array(data));
                 });
 
                 describe('Handle Provide', function () {
@@ -2480,7 +2480,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         const spy = sinon.spy();
                         client.addEventListener("clipboard", spy);
 
-                        client._sock._websocket._receive_data(new Uint8Array(data));
+                        client._sock._websocket._receiveData(new Uint8Array(data));
                         expect(spy).to.have.been.calledOnce;
                         expect(spy.args[0][0].detail.text).to.equal(expectedData);
                         client.removeEventListener("clipboard", spy);
@@ -2507,7 +2507,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         const spy = sinon.spy();
                         client.addEventListener("clipboard", spy);
 
-                        client._sock._websocket._receive_data(sendData);
+                        client._sock._websocket._receiveData(sendData);
                         expect(spy).to.have.been.calledOnce;
                         expect(spy.args[0][0].detail.text).to.equal(expectedData);
                         client.removeEventListener("clipboard", spy);
@@ -2539,7 +2539,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         const spy = sinon.spy();
                         client.addEventListener("clipboard", spy);
 
-                        client._sock._websocket._receive_data(sendData);
+                        client._sock._websocket._receiveData(sendData);
                         expect(spy).to.have.been.calledOnce;
                         expect(spy.args[0][0].detail.text).to.equal(expectedData);
                         client.removeEventListener("clipboard", spy);
@@ -2563,7 +2563,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         data = data.concat(flags);
                         let expectedData = [0x01];
 
-                        client._sock._websocket._receive_data(new Uint8Array(data));
+                        client._sock._websocket._receiveData(new Uint8Array(data));
 
                         expect(RFB.messages.extendedClipboardRequest).to.have.been.calledOnce;
                         expect(RFB.messages.extendedClipboardRequest).to.have.been.calledWith(client._sock, expectedData);
@@ -2586,7 +2586,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         data = data.concat(flags);
                         let expectedData = [];
 
-                        client._sock._websocket._receive_data(new Uint8Array(data));
+                        client._sock._websocket._receiveData(new Uint8Array(data));
 
                         expect(RFB.messages.extendedClipboardNotify).to.have.been.calledOnce;
                         expect(RFB.messages.extendedClipboardNotify).to.have.been.calledWith(client._sock, expectedData);
@@ -2604,7 +2604,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         client.clipboardPasteFrom("HejHej");
                         RFB.messages.extendedClipboardNotify.resetHistory();
 
-                        client._sock._websocket._receive_data(new Uint8Array(data));
+                        client._sock._websocket._receiveData(new Uint8Array(data));
 
                         expect(RFB.messages.extendedClipboardNotify).to.have.been.calledOnce;
                         expect(RFB.messages.extendedClipboardNotify).to.have.been.calledWith(client._sock, expectedData);
@@ -2630,7 +2630,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         client.clipboardPasteFrom("HejHej");
                         expect(RFB.messages.extendedClipboardProvide).to.not.have.been.called;
 
-                        client._sock._websocket._receive_data(new Uint8Array(data));
+                        client._sock._websocket._receiveData(new Uint8Array(data));
 
                         expect(RFB.messages.extendedClipboardProvide).to.have.been.calledOnce;
                         expect(RFB.messages.extendedClipboardProvide).to.have.been.calledWith(client._sock, expectedData, ["HejHej"]);
@@ -2643,7 +2643,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
         it('should fire the bell callback on Bell', function () {
             const spy = sinon.spy();
             client.addEventListener("bell", spy);
-            client._sock._websocket._receive_data(new Uint8Array([2]));
+            client._sock._websocket._receiveData(new Uint8Array([2]));
             expect(spy).to.have.been.calledOnce;
         });
 
@@ -2657,7 +2657,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
             RFB.messages.clientFence(expectedMsg, (1<<0) | (1<<1), payload);
             RFB.messages.clientFence(incomingMsg, 0xffffffff, payload);
 
-            client._sock._websocket._receive_data(incomingMsg._sQ);
+            client._sock._websocket._receiveData(incomingMsg._sQ);
 
             expect(client._sock).to.have.sent(expectedMsg._sQ);
 
@@ -2667,7 +2667,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
             RFB.messages.clientFence(expectedMsg, (1<<0), payload);
             RFB.messages.clientFence(incomingMsg, (1<<0) | (1<<31), payload);
 
-            client._sock._websocket._receive_data(incomingMsg._sQ);
+            client._sock._websocket._receiveData(incomingMsg._sQ);
 
             expect(client._sock).to.have.sent(expectedMsg._sQ);
         });
@@ -2679,7 +2679,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             expect(client._enabledContinuousUpdates).to.be.false;
 
-            client._sock._websocket._receive_data(new Uint8Array([150]));
+            client._sock._websocket._receiveData(new Uint8Array([150]));
 
             expect(client._enabledContinuousUpdates).to.be.true;
             expect(client._sock).to.have.sent(expectedMsg._sQ);
@@ -2689,7 +2689,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
             client._enabledContinuousUpdates = true;
             client._supportsContinuousUpdates = true;
 
-            client._sock._websocket._receive_data(new Uint8Array([150]));
+            client._sock._websocket._receiveData(new Uint8Array([150]));
 
             expect(client._enabledContinuousUpdates).to.be.false;
         });
@@ -2700,7 +2700,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             client._resize(450, 160);
 
-            expect(client._sock._websocket._get_sent_data()).to.have.length(0);
+            expect(client._sock._websocket._getSentData()).to.have.length(0);
 
             client._enabledContinuousUpdates = true;
 
@@ -2711,7 +2711,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
         it('should fail on an unknown message type', function () {
             sinon.spy(client, "_fail");
-            client._sock._websocket._receive_data(new Uint8Array([87]));
+            client._sock._websocket._receiveData(new Uint8Array([87]));
             expect(client._fail).to.have.been.calledOnce;
         });
     });
@@ -2796,13 +2796,13 @@ describe('Remote Frame Buffer Protocol Client', function () {
             // message events
             it('should do nothing if we receive an empty message and have nothing in the queue', function () {
                 client._normalMsg = sinon.spy();
-                client._sock._websocket._receive_data(new Uint8Array([]));
+                client._sock._websocket._receiveData(new Uint8Array([]));
                 expect(client._normalMsg).to.not.have.been.called;
             });
 
             it('should handle a message in the connected state as a normal message', function () {
                 client._normalMsg = sinon.spy();
-                client._sock._websocket._receive_data(new Uint8Array([1, 2, 3]));
+                client._sock._websocket._receiveData(new Uint8Array([1, 2, 3]));
                 expect(client._normalMsg).to.have.been.called;
             });
 
@@ -2810,14 +2810,14 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 client._rfbConnectionState = 'connecting';
                 client._rfbInitState = 'ProtocolVersion';
                 client._initMsg = sinon.spy();
-                client._sock._websocket._receive_data(new Uint8Array([1, 2, 3]));
+                client._sock._websocket._receiveData(new Uint8Array([1, 2, 3]));
                 expect(client._initMsg).to.have.been.called;
             });
 
             it('should process all normal messages directly', function () {
                 const spy = sinon.spy();
                 client.addEventListener("bell", spy);
-                client._sock._websocket._receive_data(new Uint8Array([0x02, 0x02]));
+                client._sock._websocket._receiveData(new Uint8Array([0x02, 0x02]));
                 expect(spy).to.have.been.calledTwice;
             });
 

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -70,11 +70,13 @@ function deflateWithSize(data) {
     strm.output = new Uint8Array(chunkSize);
     deflateInit(strm, 5);
 
+    /* eslint-disable camelcase */
     strm.input = unCompData;
     strm.avail_in = strm.input.length;
     strm.next_in = 0;
     strm.next_out = 0;
     strm.avail_out = chunkSize;
+    /* eslint-enable camelcase */
 
     deflate(strm, 3);
 

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -139,12 +139,12 @@ describe('Remote Frame Buffer Protocol Client', function () {
         container = null;
     });
 
-    function make_rfb(url, options) {
+    function makeRFB(url, options) {
         url = url || 'wss://host:8675';
         const rfb = new RFB(container, url, options);
         clock.tick();
         rfb._sock._websocket._open();
-        rfb._rfb_connection_state = 'connected';
+        rfb._rfbConnectionState = 'connected';
         sinon.spy(rfb, "_disconnect");
         rfbs.push(rfb);
         return rfb;
@@ -154,9 +154,9 @@ describe('Remote Frame Buffer Protocol Client', function () {
         describe('#RFB', function () {
             it('should set the current state to "connecting"', function () {
                 const client = new RFB(document.createElement('div'), 'wss://host:8675');
-                client._rfb_connection_state = '';
+                client._rfbConnectionState = '';
                 this.clock.tick();
-                expect(client._rfb_connection_state).to.equal('connecting');
+                expect(client._rfbConnectionState).to.equal('connecting');
             });
 
             it('should actually connect to the websocket', function () {
@@ -171,7 +171,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
         describe('#disconnect', function () {
             let client;
             beforeEach(function () {
-                client = make_rfb();
+                client = makeRFB();
             });
 
             it('should go to state "disconnecting" before "disconnected"', function () {
@@ -182,7 +182,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                     .to.equal('disconnecting');
                 expect(client._updateConnectionState.getCall(1).args[0])
                     .to.equal('disconnected');
-                expect(client._rfb_connection_state).to.equal('disconnected');
+                expect(client._rfbConnectionState).to.equal('disconnected');
             });
 
             it('should unregister error event handler', function () {
@@ -207,20 +207,20 @@ describe('Remote Frame Buffer Protocol Client', function () {
         describe('#sendCredentials', function () {
             let client;
             beforeEach(function () {
-                client = make_rfb();
-                client._rfb_connection_state = 'connecting';
+                client = makeRFB();
+                client._rfbConnectionState = 'connecting';
             });
 
             it('should set the rfb credentials properly"', function () {
                 client.sendCredentials({ password: 'pass' });
-                expect(client._rfb_credentials).to.deep.equal({ password: 'pass' });
+                expect(client._rfbCredentials).to.deep.equal({ password: 'pass' });
             });
 
-            it('should call init_msg "soon"', function () {
-                client._init_msg = sinon.spy();
+            it('should call initMsg "soon"', function () {
+                client._initMsg = sinon.spy();
                 client.sendCredentials({ password: 'pass' });
                 this.clock.tick(5);
-                expect(client._init_msg).to.have.been.calledOnce;
+                expect(client._initMsg).to.have.been.calledOnce;
             });
         });
     });
@@ -228,7 +228,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
     describe('Public API Basic Behavior', function () {
         let client;
         beforeEach(function () {
-            client = make_rfb();
+            client = makeRFB();
         });
 
         describe('#sendCtrlAlDel', function () {
@@ -247,7 +247,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             it('should not send the keys if we are not in a normal state', function () {
                 sinon.spy(client._sock, 'flush');
-                client._rfb_connection_state = "connecting";
+                client._rfbConnectionState = "connecting";
                 client.sendCtrlAltDel();
                 expect(client._sock.flush).to.not.have.been.called;
             });
@@ -278,7 +278,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             it('should not send the key if we are not in a normal state', function () {
                 sinon.spy(client._sock, 'flush');
-                client._rfb_connection_state = "connecting";
+                client._rfbConnectionState = "connecting";
                 client.sendKey(123, 'Key123');
                 expect(client._sock.flush).to.not.have.been.called;
             });
@@ -361,17 +361,17 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             it('should flush multiple times for large clipboards', function () {
                 sinon.spy(client._sock, 'flush');
-                let long_text = "";
+                let longText = "";
                 for (let i = 0; i < client._sock._sQbufferSize + 100; i++) {
-                    long_text += 'a';
+                    longText += 'a';
                 }
-                client.clipboardPasteFrom(long_text);
+                client.clipboardPasteFrom(longText);
                 expect(client._sock.flush).to.have.been.calledTwice;
             });
 
             it('should not send the text if we are not in a normal state', function () {
                 sinon.spy(client._sock, 'flush');
-                client._rfb_connection_state = "connecting";
+                client._rfbConnectionState = "connecting";
                 client.clipboardPasteFrom('abc');
                 expect(client._sock.flush).to.not.have.been.called;
             });
@@ -379,7 +379,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
         describe("XVP operations", function () {
             beforeEach(function () {
-                client._rfb_xvp_ver = 1;
+                client._rfbXvpVer = 1;
             });
 
             it('should send the shutdown signal on #machineShutdown', function () {
@@ -408,7 +408,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
     describe('Clipping', function () {
         let client;
         beforeEach(function () {
-            client = make_rfb();
+            client = makeRFB();
             container.style.width = '70px';
             container.style.height = '80px';
             client.clipViewport = true;
@@ -581,7 +581,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
     describe('Scaling', function () {
         let client;
         beforeEach(function () {
-            client = make_rfb();
+            client = makeRFB();
             container.style.width = '70px';
             container.style.height = '80px';
             client.scaleViewport = true;
@@ -664,7 +664,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
     describe('Remote resize', function () {
         let client;
         beforeEach(function () {
-            client = make_rfb();
+            client = makeRFB();
             client._supportsSetDesktopSize = true;
             client.resizeSession = true;
             container.style.width = '70px';
@@ -797,37 +797,37 @@ describe('Remote Frame Buffer Protocol Client', function () {
         describe('#_updateConnectionState', function () {
             let client;
             beforeEach(function () {
-                client = make_rfb();
+                client = makeRFB();
             });
 
             it('should clear the disconnect timer if the state is not "disconnecting"', function () {
                 const spy = sinon.spy();
                 client._disconnTimer = setTimeout(spy, 50);
-                client._rfb_connection_state = 'connecting';
+                client._rfbConnectionState = 'connecting';
                 client._updateConnectionState('connected');
                 this.clock.tick(51);
                 expect(spy).to.not.have.been.called;
                 expect(client._disconnTimer).to.be.null;
             });
 
-            it('should set the rfb_connection_state', function () {
-                client._rfb_connection_state = 'connecting';
+            it('should set the rfbConnectionState', function () {
+                client._rfbConnectionState = 'connecting';
                 client._updateConnectionState('connected');
-                expect(client._rfb_connection_state).to.equal('connected');
+                expect(client._rfbConnectionState).to.equal('connected');
             });
 
             it('should not change the state when we are disconnected', function () {
                 client.disconnect();
-                expect(client._rfb_connection_state).to.equal('disconnected');
+                expect(client._rfbConnectionState).to.equal('disconnected');
                 client._updateConnectionState('connecting');
-                expect(client._rfb_connection_state).to.not.equal('connecting');
+                expect(client._rfbConnectionState).to.not.equal('connecting');
             });
 
             it('should ignore state changes to the same state', function () {
                 const connectSpy = sinon.spy();
                 client.addEventListener("connect", connectSpy);
 
-                expect(client._rfb_connection_state).to.equal('connected');
+                expect(client._rfbConnectionState).to.equal('connected');
                 client._updateConnectionState('connected');
                 expect(connectSpy).to.not.have.been.called;
 
@@ -836,7 +836,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 const disconnectSpy = sinon.spy();
                 client.addEventListener("disconnect", disconnectSpy);
 
-                expect(client._rfb_connection_state).to.equal('disconnected');
+                expect(client._rfbConnectionState).to.equal('disconnected');
                 client._updateConnectionState('disconnected');
                 expect(disconnectSpy).to.not.have.been.called;
             });
@@ -845,7 +845,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 const spy = sinon.spy();
                 client.addEventListener("disconnect", spy);
                 client._updateConnectionState('disconnected');
-                expect(client._rfb_connection_state).to.not.equal('disconnected');
+                expect(client._rfbConnectionState).to.not.equal('disconnected');
                 expect(spy).to.not.have.been.called;
             });
         });
@@ -853,7 +853,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
         describe('#_fail', function () {
             let client;
             beforeEach(function () {
-                client = make_rfb();
+                client = makeRFB();
             });
 
             it('should close the WebSocket connection', function () {
@@ -867,18 +867,18 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 client._fail();
                 this.clock.tick(2000);
                 expect(client._updateConnectionState).to.have.been.called;
-                expect(client._rfb_connection_state).to.equal('disconnected');
+                expect(client._rfbConnectionState).to.equal('disconnected');
             });
 
             it('should set clean_disconnect variable', function () {
-                client._rfb_clean_disconnect = true;
-                client._rfb_connection_state = 'connected';
+                client._rfbCleanDisconnect = true;
+                client._rfbConnectionState = 'connected';
                 client._fail();
-                expect(client._rfb_clean_disconnect).to.be.false;
+                expect(client._rfbCleanDisconnect).to.be.false;
             });
 
             it('should result in disconnect event with clean set to false', function () {
-                client._rfb_connection_state = 'connected';
+                client._rfbConnectionState = 'connected';
                 const spy = sinon.spy();
                 client.addEventListener("disconnect", spy);
                 client._fail();
@@ -904,13 +904,13 @@ describe('Remote Frame Buffer Protocol Client', function () {
         describe('connected', function () {
             let client;
             beforeEach(function () {
-                client = make_rfb();
+                client = makeRFB();
             });
 
             it('should result in a connect event if state becomes connected', function () {
                 const spy = sinon.spy();
                 client.addEventListener("connect", spy);
-                client._rfb_connection_state = 'connecting';
+                client._rfbConnectionState = 'connecting';
                 client._updateConnectionState('connected');
                 expect(spy).to.have.been.calledOnce;
             });
@@ -927,7 +927,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
         describe('disconnecting', function () {
             let client;
             beforeEach(function () {
-                client = make_rfb();
+                client = makeRFB();
             });
 
             it('should force disconnect if we do not call Websock.onclose within the disconnection timeout', function () {
@@ -936,8 +936,8 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 client._updateConnectionState('disconnecting');
                 this.clock.tick(3 * 1000);
                 expect(client._updateConnectionState).to.have.been.calledTwice;
-                expect(client._rfb_disconnect_reason).to.not.equal("");
-                expect(client._rfb_connection_state).to.equal("disconnected");
+                expect(client._rfbDisconnectReason).to.not.equal("");
+                expect(client._rfbConnectionState).to.equal("disconnected");
             });
 
             it('should not fail if Websock.onclose gets called within the disconnection timeout', function () {
@@ -945,7 +945,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 this.clock.tick(3 * 1000 / 2);
                 client._sock._websocket.close();
                 this.clock.tick(3 * 1000 / 2 + 1);
-                expect(client._rfb_connection_state).to.equal('disconnected');
+                expect(client._rfbConnectionState).to.equal('disconnected');
             });
 
             it('should close the WebSocket connection', function () {
@@ -972,7 +972,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should result in a disconnect event if state becomes "disconnected"', function () {
                 const spy = sinon.spy();
                 client.addEventListener("disconnect", spy);
-                client._rfb_connection_state = 'disconnecting';
+                client._rfbConnectionState = 'disconnecting';
                 client._updateConnectionState('disconnected');
                 expect(spy).to.have.been.calledOnce;
                 expect(spy.args[0][0].detail.clean).to.be.true;
@@ -981,8 +981,8 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should result in a disconnect event without msg when no reason given', function () {
                 const spy = sinon.spy();
                 client.addEventListener("disconnect", spy);
-                client._rfb_connection_state = 'disconnecting';
-                client._rfb_disconnect_reason = "";
+                client._rfbConnectionState = 'disconnecting';
+                client._rfbDisconnectReason = "";
                 client._updateConnectionState('disconnected');
                 expect(spy).to.have.been.calledOnce;
                 expect(spy.args[0].length).to.equal(1);
@@ -993,12 +993,12 @@ describe('Remote Frame Buffer Protocol Client', function () {
     describe('Protocol Initialization States', function () {
         let client;
         beforeEach(function () {
-            client = make_rfb();
-            client._rfb_connection_state = 'connecting';
+            client = makeRFB();
+            client._rfbConnectionState = 'connecting';
         });
 
         describe('ProtocolVersion', function () {
-            function send_ver(ver, client) {
+            function sendVer(ver, client) {
                 const arr = new Uint8Array(12);
                 for (let i = 0; i < ver.length; i++) {
                     arr[i+4] = ver.charCodeAt(i);
@@ -1010,135 +1010,135 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             describe('version parsing', function () {
                 it('should interpret version 003.003 as version 3.3', function () {
-                    send_ver('003.003', client);
-                    expect(client._rfb_version).to.equal(3.3);
+                    sendVer('003.003', client);
+                    expect(client._rfbVersion).to.equal(3.3);
                 });
 
                 it('should interpret version 003.006 as version 3.3', function () {
-                    send_ver('003.006', client);
-                    expect(client._rfb_version).to.equal(3.3);
+                    sendVer('003.006', client);
+                    expect(client._rfbVersion).to.equal(3.3);
                 });
 
                 it('should interpret version 003.889 as version 3.3', function () {
-                    send_ver('003.889', client);
-                    expect(client._rfb_version).to.equal(3.3);
+                    sendVer('003.889', client);
+                    expect(client._rfbVersion).to.equal(3.3);
                 });
 
                 it('should interpret version 003.007 as version 3.7', function () {
-                    send_ver('003.007', client);
-                    expect(client._rfb_version).to.equal(3.7);
+                    sendVer('003.007', client);
+                    expect(client._rfbVersion).to.equal(3.7);
                 });
 
                 it('should interpret version 003.008 as version 3.8', function () {
-                    send_ver('003.008', client);
-                    expect(client._rfb_version).to.equal(3.8);
+                    sendVer('003.008', client);
+                    expect(client._rfbVersion).to.equal(3.8);
                 });
 
                 it('should interpret version 004.000 as version 3.8', function () {
-                    send_ver('004.000', client);
-                    expect(client._rfb_version).to.equal(3.8);
+                    sendVer('004.000', client);
+                    expect(client._rfbVersion).to.equal(3.8);
                 });
 
                 it('should interpret version 004.001 as version 3.8', function () {
-                    send_ver('004.001', client);
-                    expect(client._rfb_version).to.equal(3.8);
+                    sendVer('004.001', client);
+                    expect(client._rfbVersion).to.equal(3.8);
                 });
 
                 it('should interpret version 005.000 as version 3.8', function () {
-                    send_ver('005.000', client);
-                    expect(client._rfb_version).to.equal(3.8);
+                    sendVer('005.000', client);
+                    expect(client._rfbVersion).to.equal(3.8);
                 });
 
                 it('should fail on an invalid version', function () {
                     sinon.spy(client, "_fail");
-                    send_ver('002.000', client);
+                    sendVer('002.000', client);
                     expect(client._fail).to.have.been.calledOnce;
                 });
             });
 
             it('should send back the interpreted version', function () {
-                send_ver('004.000', client);
+                sendVer('004.000', client);
 
-                const expected_str = 'RFB 003.008\n';
+                const expectedStr = 'RFB 003.008\n';
                 const expected = [];
-                for (let i = 0; i < expected_str.length; i++) {
-                    expected[i] = expected_str.charCodeAt(i);
+                for (let i = 0; i < expectedStr.length; i++) {
+                    expected[i] = expectedStr.charCodeAt(i);
                 }
 
                 expect(client._sock).to.have.sent(new Uint8Array(expected));
             });
 
             it('should transition to the Security state on successful negotiation', function () {
-                send_ver('003.008', client);
-                expect(client._rfb_init_state).to.equal('Security');
+                sendVer('003.008', client);
+                expect(client._rfbInitState).to.equal('Security');
             });
 
             describe('Repeater', function () {
                 beforeEach(function () {
-                    client = make_rfb('wss://host:8675', { repeaterID: "12345" });
-                    client._rfb_connection_state = 'connecting';
+                    client = makeRFB('wss://host:8675', { repeaterID: "12345" });
+                    client._rfbConnectionState = 'connecting';
                 });
 
                 it('should interpret version 000.000 as a repeater', function () {
-                    send_ver('000.000', client);
-                    expect(client._rfb_version).to.equal(0);
+                    sendVer('000.000', client);
+                    expect(client._rfbVersion).to.equal(0);
 
-                    const sent_data = client._sock._websocket._get_sent_data();
-                    expect(new Uint8Array(sent_data.buffer, 0, 9)).to.array.equal(new Uint8Array([73, 68, 58, 49, 50, 51, 52, 53, 0]));
-                    expect(sent_data).to.have.length(250);
+                    const sentData = client._sock._websocket._get_sent_data();
+                    expect(new Uint8Array(sentData.buffer, 0, 9)).to.array.equal(new Uint8Array([73, 68, 58, 49, 50, 51, 52, 53, 0]));
+                    expect(sentData).to.have.length(250);
                 });
 
                 it('should handle two step repeater negotiation', function () {
-                    send_ver('000.000', client);
-                    send_ver('003.008', client);
-                    expect(client._rfb_version).to.equal(3.8);
+                    sendVer('000.000', client);
+                    sendVer('003.008', client);
+                    expect(client._rfbVersion).to.equal(3.8);
                 });
             });
         });
 
         describe('Security', function () {
             beforeEach(function () {
-                client._rfb_init_state = 'Security';
+                client._rfbInitState = 'Security';
             });
 
             it('should simply receive the auth scheme when for versions < 3.7', function () {
-                client._rfb_version = 3.6;
-                const auth_scheme_raw = [1, 2, 3, 4];
-                const auth_scheme = (auth_scheme_raw[0] << 24) + (auth_scheme_raw[1] << 16) +
-                                  (auth_scheme_raw[2] << 8) + auth_scheme_raw[3];
-                client._sock._websocket._receive_data(new Uint8Array(auth_scheme_raw));
-                expect(client._rfb_auth_scheme).to.equal(auth_scheme);
+                client._rfbVersion = 3.6;
+                const authSchemeRaw = [1, 2, 3, 4];
+                const authScheme = (authSchemeRaw[0] << 24) + (authSchemeRaw[1] << 16) +
+                                  (authSchemeRaw[2] << 8) + authSchemeRaw[3];
+                client._sock._websocket._receive_data(new Uint8Array(authSchemeRaw));
+                expect(client._rfbAuthScheme).to.equal(authScheme);
             });
 
             it('should prefer no authentication is possible', function () {
-                client._rfb_version = 3.7;
-                const auth_schemes = [2, 1, 3];
-                client._sock._websocket._receive_data(new Uint8Array(auth_schemes));
-                expect(client._rfb_auth_scheme).to.equal(1);
+                client._rfbVersion = 3.7;
+                const authSchemes = [2, 1, 3];
+                client._sock._websocket._receive_data(new Uint8Array(authSchemes));
+                expect(client._rfbAuthScheme).to.equal(1);
                 expect(client._sock).to.have.sent(new Uint8Array([1, 1]));
             });
 
             it('should choose for the most prefered scheme possible for versions >= 3.7', function () {
-                client._rfb_version = 3.7;
-                const auth_schemes = [2, 22, 16];
-                client._sock._websocket._receive_data(new Uint8Array(auth_schemes));
-                expect(client._rfb_auth_scheme).to.equal(22);
+                client._rfbVersion = 3.7;
+                const authSchemes = [2, 22, 16];
+                client._sock._websocket._receive_data(new Uint8Array(authSchemes));
+                expect(client._rfbAuthScheme).to.equal(22);
                 expect(client._sock).to.have.sent(new Uint8Array([22]));
             });
 
             it('should fail if there are no supported schemes for versions >= 3.7', function () {
                 sinon.spy(client, "_fail");
-                client._rfb_version = 3.7;
-                const auth_schemes = [1, 32];
-                client._sock._websocket._receive_data(new Uint8Array(auth_schemes));
+                client._rfbVersion = 3.7;
+                const authSchemes = [1, 32];
+                client._sock._websocket._receive_data(new Uint8Array(authSchemes));
                 expect(client._fail).to.have.been.calledOnce;
             });
 
             it('should fail with the appropriate message if no types are sent for versions >= 3.7', function () {
-                client._rfb_version = 3.7;
-                const failure_data = [0, 0, 0, 0, 6, 119, 104, 111, 111, 112, 115];
+                client._rfbVersion = 3.7;
+                const failureData = [0, 0, 0, 0, 6, 119, 104, 111, 111, 112, 115];
                 sinon.spy(client, '_fail');
-                client._sock._websocket._receive_data(new Uint8Array(failure_data));
+                client._sock._websocket._receive_data(new Uint8Array(failureData));
 
                 expect(client._fail).to.have.been.calledOnce;
                 expect(client._fail).to.have.been.calledWith(
@@ -1146,32 +1146,32 @@ describe('Remote Frame Buffer Protocol Client', function () {
             });
 
             it('should transition to the Authentication state and continue on successful negotiation', function () {
-                client._rfb_version = 3.7;
-                const auth_schemes = [1, 1];
-                client._negotiate_authentication = sinon.spy();
-                client._sock._websocket._receive_data(new Uint8Array(auth_schemes));
-                expect(client._rfb_init_state).to.equal('Authentication');
-                expect(client._negotiate_authentication).to.have.been.calledOnce;
+                client._rfbVersion = 3.7;
+                const authSchemes = [1, 1];
+                client._negotiateAuthentication = sinon.spy();
+                client._sock._websocket._receive_data(new Uint8Array(authSchemes));
+                expect(client._rfbInitState).to.equal('Authentication');
+                expect(client._negotiateAuthentication).to.have.been.calledOnce;
             });
         });
 
         describe('Authentication', function () {
             beforeEach(function () {
-                client._rfb_init_state = 'Security';
+                client._rfbInitState = 'Security';
             });
 
-            function send_security(type, cl) {
+            function sendSecurity(type, cl) {
                 cl._sock._websocket._receive_data(new Uint8Array([1, type]));
             }
 
             it('should fail on auth scheme 0 (pre 3.7) with the given message', function () {
-                client._rfb_version = 3.6;
-                const err_msg = "Whoopsies";
+                client._rfbVersion = 3.6;
+                const errMsg = "Whoopsies";
                 const data = [0, 0, 0, 0];
-                const err_len = err_msg.length;
-                push32(data, err_len);
-                for (let i = 0; i < err_len; i++) {
-                    data.push(err_msg.charCodeAt(i));
+                const errLen = errMsg.length;
+                push32(data, errLen);
+                for (let i = 0; i < errLen; i++) {
+                    data.push(errMsg.charCodeAt(i));
                 }
 
                 sinon.spy(client, '_fail');
@@ -1181,91 +1181,91 @@ describe('Remote Frame Buffer Protocol Client', function () {
             });
 
             it('should transition straight to SecurityResult on "no auth" (1) for versions >= 3.8', function () {
-                client._rfb_version = 3.8;
-                send_security(1, client);
-                expect(client._rfb_init_state).to.equal('SecurityResult');
+                client._rfbVersion = 3.8;
+                sendSecurity(1, client);
+                expect(client._rfbInitState).to.equal('SecurityResult');
             });
 
             it('should transition straight to ServerInitialisation on "no auth" for versions < 3.8', function () {
-                client._rfb_version = 3.7;
-                send_security(1, client);
-                expect(client._rfb_init_state).to.equal('ServerInitialisation');
+                client._rfbVersion = 3.7;
+                sendSecurity(1, client);
+                expect(client._rfbInitState).to.equal('ServerInitialisation');
             });
 
             it('should fail on an unknown auth scheme', function () {
                 sinon.spy(client, "_fail");
-                client._rfb_version = 3.8;
-                send_security(57, client);
+                client._rfbVersion = 3.8;
+                sendSecurity(57, client);
                 expect(client._fail).to.have.been.calledOnce;
             });
 
             describe('VNC Authentication (type 2) Handler', function () {
                 beforeEach(function () {
-                    client._rfb_init_state = 'Security';
-                    client._rfb_version = 3.8;
+                    client._rfbInitState = 'Security';
+                    client._rfbVersion = 3.8;
                 });
 
                 it('should fire the credentialsrequired event if missing a password', function () {
                     const spy = sinon.spy();
                     client.addEventListener("credentialsrequired", spy);
-                    send_security(2, client);
+                    sendSecurity(2, client);
 
                     const challenge = [];
                     for (let i = 0; i < 16; i++) { challenge[i] = i; }
                     client._sock._websocket._receive_data(new Uint8Array(challenge));
 
-                    expect(client._rfb_credentials).to.be.empty;
+                    expect(client._rfbCredentials).to.be.empty;
                     expect(spy).to.have.been.calledOnce;
                     expect(spy.args[0][0].detail.types).to.have.members(["password"]);
                 });
 
                 it('should encrypt the password with DES and then send it back', function () {
-                    client._rfb_credentials = { password: 'passwd' };
-                    send_security(2, client);
+                    client._rfbCredentials = { password: 'passwd' };
+                    sendSecurity(2, client);
                     client._sock._websocket._get_sent_data(); // skip the choice of auth reply
 
                     const challenge = [];
                     for (let i = 0; i < 16; i++) { challenge[i] = i; }
                     client._sock._websocket._receive_data(new Uint8Array(challenge));
 
-                    const des_pass = RFB.genDES('passwd', challenge);
-                    expect(client._sock).to.have.sent(new Uint8Array(des_pass));
+                    const desPass = RFB.genDES('passwd', challenge);
+                    expect(client._sock).to.have.sent(new Uint8Array(desPass));
                 });
 
                 it('should transition to SecurityResult immediately after sending the password', function () {
-                    client._rfb_credentials = { password: 'passwd' };
-                    send_security(2, client);
+                    client._rfbCredentials = { password: 'passwd' };
+                    sendSecurity(2, client);
 
                     const challenge = [];
                     for (let i = 0; i < 16; i++) { challenge[i] = i; }
                     client._sock._websocket._receive_data(new Uint8Array(challenge));
 
-                    expect(client._rfb_init_state).to.equal('SecurityResult');
+                    expect(client._rfbInitState).to.equal('SecurityResult');
                 });
             });
 
             describe('XVP Authentication (type 22) Handler', function () {
                 beforeEach(function () {
-                    client._rfb_init_state = 'Security';
-                    client._rfb_version = 3.8;
+                    client._rfbInitState = 'Security';
+                    client._rfbVersion = 3.8;
                 });
 
                 it('should fall through to standard VNC authentication upon completion', function () {
-                    client._rfb_credentials = { username: 'user',
-                                                target: 'target',
-                                                password: 'password' };
-                    client._negotiate_std_vnc_auth = sinon.spy();
-                    send_security(22, client);
-                    expect(client._negotiate_std_vnc_auth).to.have.been.calledOnce;
+                    client._rfbCredentials = { username: 'user',
+                                               target: 'target',
+                                               password: 'password' };
+                    client._negotiateStdVNCAuth = sinon.spy();
+                    sendSecurity(22, client);
+                    expect(client._negotiateStdVNCAuth).to.have.been.calledOnce;
                 });
 
                 it('should fire the credentialsrequired event if all credentials are missing', function () {
                     const spy = sinon.spy();
                     client.addEventListener("credentialsrequired", spy);
-                    client._rfb_credentials = {};
-                    send_security(22, client);
+                    client._rfbCredentials = {};
+                    sendSecurity(22, client);
 
-                    expect(client._rfb_credentials).to.be.empty;
+                    expect(client._rfbCredentials).to.be.empty;
                     expect(spy).to.have.been.calledOnce;
                     expect(spy.args[0][0].detail.types).to.have.members(["username", "password", "target"]);
                 });
@@ -1273,21 +1273,21 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 it('should fire the credentialsrequired event if some credentials are missing', function () {
                     const spy = sinon.spy();
                     client.addEventListener("credentialsrequired", spy);
-                    client._rfb_credentials = { username: 'user',
-                                                target: 'target' };
-                    send_security(22, client);
+                    client._rfbCredentials = { username: 'user',
+                                               target: 'target' };
+                    sendSecurity(22, client);
 
                     expect(spy).to.have.been.calledOnce;
                     expect(spy.args[0][0].detail.types).to.have.members(["username", "password", "target"]);
                 });
 
                 it('should send user and target separately', function () {
-                    client._rfb_credentials = { username: 'user',
-                                                target: 'target',
-                                                password: 'password' };
-                    client._negotiate_std_vnc_auth = sinon.spy();
+                    client._rfbCredentials = { username: 'user',
+                                               target: 'target',
+                                               password: 'password' };
+                    client._negotiateStdVNCAuth = sinon.spy();
 
-                    send_security(22, client);
+                    sendSecurity(22, client);
 
                     const expected = [22, 4, 6]; // auth selection, len user, len target
                     for (let i = 0; i < 10; i++) { expected[i+3] = 'usertarget'.charCodeAt(i); }
@@ -1298,13 +1298,13 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             describe('TightVNC Authentication (type 16) Handler', function () {
                 beforeEach(function () {
-                    client._rfb_init_state = 'Security';
-                    client._rfb_version = 3.8;
-                    send_security(16, client);
+                    client._rfbInitState = 'Security';
+                    client._rfbVersion = 3.8;
+                    sendSecurity(16, client);
                     client._sock._websocket._get_sent_data();  // skip the security reply
                 });
 
-                function send_num_str_pairs(pairs, client) {
+                function sendNumStrPairs(pairs, client) {
                     const data = [];
                     push32(data, pairs.length);
 
@@ -1323,62 +1323,62 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
                 it('should skip tunnel negotiation if no tunnels are requested', function () {
                     client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 0]));
-                    expect(client._rfb_tightvnc).to.be.true;
+                    expect(client._rfbTightVNC).to.be.true;
                 });
 
                 it('should fail if no supported tunnels are listed', function () {
                     sinon.spy(client, "_fail");
-                    send_num_str_pairs([[123, 'OTHR', 'SOMETHNG']], client);
+                    sendNumStrPairs([[123, 'OTHR', 'SOMETHNG']], client);
                     expect(client._fail).to.have.been.calledOnce;
                 });
 
                 it('should choose the notunnel tunnel type', function () {
-                    send_num_str_pairs([[0, 'TGHT', 'NOTUNNEL'], [123, 'OTHR', 'SOMETHNG']], client);
+                    sendNumStrPairs([[0, 'TGHT', 'NOTUNNEL'], [123, 'OTHR', 'SOMETHNG']], client);
                     expect(client._sock).to.have.sent(new Uint8Array([0, 0, 0, 0]));
                 });
 
                 it('should choose the notunnel tunnel type for Siemens devices', function () {
-                    send_num_str_pairs([[1, 'SICR', 'SCHANNEL'], [2, 'SICR', 'SCHANLPW']], client);
+                    sendNumStrPairs([[1, 'SICR', 'SCHANNEL'], [2, 'SICR', 'SCHANLPW']], client);
                     expect(client._sock).to.have.sent(new Uint8Array([0, 0, 0, 0]));
                 });
 
                 it('should continue to sub-auth negotiation after tunnel negotiation', function () {
-                    send_num_str_pairs([[0, 'TGHT', 'NOTUNNEL']], client);
+                    sendNumStrPairs([[0, 'TGHT', 'NOTUNNEL']], client);
                     client._sock._websocket._get_sent_data();  // skip the tunnel choice here
-                    send_num_str_pairs([[1, 'STDV', 'NOAUTH__']], client);
+                    sendNumStrPairs([[1, 'STDV', 'NOAUTH__']], client);
                     expect(client._sock).to.have.sent(new Uint8Array([0, 0, 0, 1]));
-                    expect(client._rfb_init_state).to.equal('SecurityResult');
+                    expect(client._rfbInitState).to.equal('SecurityResult');
                 });
 
                 /*it('should attempt to use VNC auth over no auth when possible', function () {
-                    client._rfb_tightvnc = true;
-                    client._negotiate_std_vnc_auth = sinon.spy();
-                    send_num_str_pairs([[1, 'STDV', 'NOAUTH__'], [2, 'STDV', 'VNCAUTH_']], client);
+                    client._rfbTightVNC = true;
+                    client._negotiateStdVNCAuth = sinon.spy();
+                    sendNumStrPairs([[1, 'STDV', 'NOAUTH__'], [2, 'STDV', 'VNCAUTH_']], client);
                     expect(client._sock).to.have.sent([0, 0, 0, 1]);
-                    expect(client._negotiate_std_vnc_auth).to.have.been.calledOnce;
-                    expect(client._rfb_auth_scheme).to.equal(2);
+                    expect(client._negotiateStdVNCAuth).to.have.been.calledOnce;
+                    expect(client._rfbAuthScheme).to.equal(2);
                 });*/ // while this would make sense, the original code doesn't actually do this
 
                 it('should accept the "no auth" auth type and transition to SecurityResult', function () {
-                    client._rfb_tightvnc = true;
-                    send_num_str_pairs([[1, 'STDV', 'NOAUTH__']], client);
+                    client._rfbTightVNC = true;
+                    sendNumStrPairs([[1, 'STDV', 'NOAUTH__']], client);
                     expect(client._sock).to.have.sent(new Uint8Array([0, 0, 0, 1]));
-                    expect(client._rfb_init_state).to.equal('SecurityResult');
+                    expect(client._rfbInitState).to.equal('SecurityResult');
                 });
 
                 it('should accept VNC authentication and transition to that', function () {
-                    client._rfb_tightvnc = true;
-                    client._negotiate_std_vnc_auth = sinon.spy();
-                    send_num_str_pairs([[2, 'STDV', 'VNCAUTH__']], client);
+                    client._rfbTightVNC = true;
+                    client._negotiateStdVNCAuth = sinon.spy();
+                    sendNumStrPairs([[2, 'STDV', 'VNCAUTH__']], client);
                     expect(client._sock).to.have.sent(new Uint8Array([0, 0, 0, 2]));
-                    expect(client._negotiate_std_vnc_auth).to.have.been.calledOnce;
-                    expect(client._rfb_auth_scheme).to.equal(2);
+                    expect(client._negotiateStdVNCAuth).to.have.been.calledOnce;
+                    expect(client._rfbAuthScheme).to.equal(2);
                 });
 
                 it('should fail if there are no supported auth types', function () {
                     sinon.spy(client, "_fail");
-                    client._rfb_tightvnc = true;
-                    send_num_str_pairs([[23, 'stdv', 'badval__']], client);
+                    client._rfbTightVNC = true;
+                    sendNumStrPairs([[23, 'stdv', 'badval__']], client);
                     expect(client._fail).to.have.been.calledOnce;
                 });
             });
@@ -1386,26 +1386,26 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
         describe('SecurityResult', function () {
             beforeEach(function () {
-                client._rfb_init_state = 'SecurityResult';
+                client._rfbInitState = 'SecurityResult';
             });
 
             it('should fall through to ServerInitialisation on a response code of 0', function () {
                 client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 0]));
-                expect(client._rfb_init_state).to.equal('ServerInitialisation');
+                expect(client._rfbInitState).to.equal('ServerInitialisation');
             });
 
             it('should fail on an error code of 1 with the given message for versions >= 3.8', function () {
-                client._rfb_version = 3.8;
+                client._rfbVersion = 3.8;
                 sinon.spy(client, '_fail');
-                const failure_data = [0, 0, 0, 1, 0, 0, 0, 6, 119, 104, 111, 111, 112, 115];
-                client._sock._websocket._receive_data(new Uint8Array(failure_data));
+                const failureData = [0, 0, 0, 1, 0, 0, 0, 6, 119, 104, 111, 111, 112, 115];
+                client._sock._websocket._receive_data(new Uint8Array(failureData));
                 expect(client._fail).to.have.been.calledWith(
                     'Security negotiation failed on security result (reason: whoops)');
             });
 
             it('should fail on an error code of 1 with a standard message for version < 3.8', function () {
                 sinon.spy(client, '_fail');
-                client._rfb_version = 3.7;
+                client._rfbVersion = 3.7;
                 client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 1]));
                 expect(client._fail).to.have.been.calledWith(
                     'Security handshake failed');
@@ -1420,28 +1420,28 @@ describe('Remote Frame Buffer Protocol Client', function () {
             });
 
             it('should include reason when provided in securityfailure event', function () {
-                client._rfb_version = 3.8;
+                client._rfbVersion = 3.8;
                 const spy = sinon.spy();
                 client.addEventListener("securityfailure", spy);
-                const failure_data = [0, 0, 0, 1, 0, 0, 0, 12, 115, 117, 99, 104,
-                                      32, 102, 97, 105, 108, 117, 114, 101];
-                client._sock._websocket._receive_data(new Uint8Array(failure_data));
+                const failureData = [0, 0, 0, 1, 0, 0, 0, 12, 115, 117, 99, 104,
+                                     32, 102, 97, 105, 108, 117, 114, 101];
+                client._sock._websocket._receive_data(new Uint8Array(failureData));
                 expect(spy.args[0][0].detail.status).to.equal(1);
                 expect(spy.args[0][0].detail.reason).to.equal('such failure');
             });
 
             it('should not include reason when length is zero in securityfailure event', function () {
-                client._rfb_version = 3.9;
+                client._rfbVersion = 3.9;
                 const spy = sinon.spy();
                 client.addEventListener("securityfailure", spy);
-                const failure_data = [0, 0, 0, 1, 0, 0, 0, 0];
-                client._sock._websocket._receive_data(new Uint8Array(failure_data));
+                const failureData = [0, 0, 0, 1, 0, 0, 0, 0];
+                client._sock._websocket._receive_data(new Uint8Array(failureData));
                 expect(spy.args[0][0].detail.status).to.equal(1);
                 expect('reason' in spy.args[0][0].detail).to.be.false;
             });
 
             it('should not include reason in securityfailure event for version < 3.8', function () {
-                client._rfb_version = 3.6;
+                client._rfbVersion = 3.6;
                 const spy = sinon.spy();
                 client.addEventListener("securityfailure", spy);
                 client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 2]));
@@ -1452,25 +1452,25 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
         describe('ClientInitialisation', function () {
             it('should transition to the ServerInitialisation state', function () {
-                const client = make_rfb();
-                client._rfb_connection_state = 'connecting';
-                client._rfb_init_state = 'SecurityResult';
+                const client = makeRFB();
+                client._rfbConnectionState = 'connecting';
+                client._rfbInitState = 'SecurityResult';
                 client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 0]));
-                expect(client._rfb_init_state).to.equal('ServerInitialisation');
+                expect(client._rfbInitState).to.equal('ServerInitialisation');
             });
 
             it('should send 1 if we are in shared mode', function () {
-                const client = make_rfb('wss://host:8675', { shared: true });
-                client._rfb_connection_state = 'connecting';
-                client._rfb_init_state = 'SecurityResult';
+                const client = makeRFB('wss://host:8675', { shared: true });
+                client._rfbConnectionState = 'connecting';
+                client._rfbInitState = 'SecurityResult';
                 client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 0]));
                 expect(client._sock).to.have.sent(new Uint8Array([1]));
             });
 
             it('should send 0 if we are not in shared mode', function () {
-                const client = make_rfb('wss://host:8675', { shared: false });
-                client._rfb_connection_state = 'connecting';
-                client._rfb_init_state = 'SecurityResult';
+                const client = makeRFB('wss://host:8675', { shared: false });
+                client._rfbConnectionState = 'connecting';
+                client._rfbInitState = 'SecurityResult';
                 client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 0]));
                 expect(client._sock).to.have.sent(new Uint8Array([0]));
             });
@@ -1478,32 +1478,32 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
         describe('ServerInitialisation', function () {
             beforeEach(function () {
-                client._rfb_init_state = 'ServerInitialisation';
+                client._rfbInitState = 'ServerInitialisation';
             });
 
-            function send_server_init(opts, client) {
-                const full_opts = { width: 10, height: 12, bpp: 24, depth: 24, big_endian: 0,
-                                    true_color: 1, red_max: 255, green_max: 255, blue_max: 255,
-                                    red_shift: 16, green_shift: 8, blue_shift: 0, name: 'a name' };
+            function sendServerInit(opts, client) {
+                const fullOpts = { width: 10, height: 12, bpp: 24, depth: 24, bigEndian: 0,
+                                   trueColor: 1, redMax: 255, greenMax: 255, blueMax: 255,
+                                   redShift: 16, greenShift: 8, blueShift: 0, name: 'a name' };
                 for (let opt in opts) {
-                    full_opts[opt] = opts[opt];
+                    fullOpts[opt] = opts[opt];
                 }
                 const data = [];
 
-                push16(data, full_opts.width);
-                push16(data, full_opts.height);
+                push16(data, fullOpts.width);
+                push16(data, fullOpts.height);
 
-                data.push(full_opts.bpp);
-                data.push(full_opts.depth);
-                data.push(full_opts.big_endian);
-                data.push(full_opts.true_color);
+                data.push(fullOpts.bpp);
+                data.push(fullOpts.depth);
+                data.push(fullOpts.bigEndian);
+                data.push(fullOpts.trueColor);
 
-                push16(data, full_opts.red_max);
-                push16(data, full_opts.green_max);
-                push16(data, full_opts.blue_max);
-                push8(data, full_opts.red_shift);
-                push8(data, full_opts.green_shift);
-                push8(data, full_opts.blue_shift);
+                push16(data, fullOpts.redMax);
+                push16(data, fullOpts.greenMax);
+                push16(data, fullOpts.blueMax);
+                push8(data, fullOpts.redShift);
+                push8(data, fullOpts.greenShift);
+                push8(data, fullOpts.blueShift);
 
                 // padding
                 push8(data, 0);
@@ -1512,19 +1512,19 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
                 client._sock._websocket._receive_data(new Uint8Array(data));
 
-                const name_data = [];
-                let name_len = [];
-                pushString(name_data, full_opts.name);
-                push32(name_len, name_data.length);
+                const nameData = [];
+                let nameLen = [];
+                pushString(nameData, fullOpts.name);
+                push32(nameLen, nameData.length);
 
-                client._sock._websocket._receive_data(new Uint8Array(name_len));
-                client._sock._websocket._receive_data(new Uint8Array(name_data));
+                client._sock._websocket._receive_data(new Uint8Array(nameLen));
+                client._sock._websocket._receive_data(new Uint8Array(nameData));
             }
 
             it('should set the framebuffer width and height', function () {
-                send_server_init({ width: 32, height: 84 }, client);
-                expect(client._fb_width).to.equal(32);
-                expect(client._fb_height).to.equal(84);
+                sendServerInit({ width: 32, height: 84 }, client);
+                expect(client._fbWidth).to.equal(32);
+                expect(client._fbHeight).to.equal(84);
             });
 
             // NB(sross): we just warn, not fail, for endian-ness and shifts, so we don't test them
@@ -1532,9 +1532,9 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should set the framebuffer name and call the callback', function () {
                 const spy = sinon.spy();
                 client.addEventListener("desktopname", spy);
-                send_server_init({ name: 'som€ nam€' }, client);
+                sendServerInit({ name: 'som€ nam€' }, client);
 
-                expect(client._fb_name).to.equal('som€ nam€');
+                expect(client._fbName).to.equal('som€ nam€');
                 expect(spy).to.have.been.calledOnce;
                 expect(spy.args[0][0].detail.name).to.equal('som€ nam€');
             });
@@ -1542,25 +1542,25 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should handle the extended init message of the tight encoding', function () {
                 // NB(sross): we don't actually do anything with it, so just test that we can
                 //            read it w/o throwing an error
-                client._rfb_tightvnc = true;
-                send_server_init({}, client);
+                client._rfbTightVNC = true;
+                sendServerInit({}, client);
 
-                const tight_data = [];
-                push16(tight_data, 1);
-                push16(tight_data, 2);
-                push16(tight_data, 3);
-                push16(tight_data, 0);
+                const tightData = [];
+                push16(tightData, 1);
+                push16(tightData, 2);
+                push16(tightData, 3);
+                push16(tightData, 0);
                 for (let i = 0; i < 16 + 32 + 48; i++) {
-                    tight_data.push(i);
+                    tightData.push(i);
                 }
-                client._sock._websocket._receive_data(new Uint8Array(tight_data));
+                client._sock._websocket._receive_data(new Uint8Array(tightData));
 
-                expect(client._rfb_connection_state).to.equal('connected');
+                expect(client._rfbConnectionState).to.equal('connected');
             });
 
             it('should resize the display', function () {
                 sinon.spy(client._display, 'resize');
-                send_server_init({ width: 27, height: 32 }, client);
+                sendServerInit({ width: 27, height: 32 }, client);
 
                 expect(client._display.resize).to.have.been.calledOnce;
                 expect(client._display.resize).to.have.been.calledWith(27, 32);
@@ -1569,7 +1569,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
             it('should grab the mouse and keyboard', function () {
                 sinon.spy(client._keyboard, 'grab');
                 sinon.spy(client._mouse, 'grab');
-                send_server_init({}, client);
+                sendServerInit({}, client);
                 expect(client._keyboard.grab).to.have.been.calledOnce;
                 expect(client._mouse.grab).to.have.been.calledOnce;
             });
@@ -1589,7 +1589,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
                 // TODO(directxman12): test the various options in this configuration matrix
                 it('should reply with the pixel format, client encodings, and initial update request', function () {
-                    send_server_init({ width: 27, height: 32 }, client);
+                    sendServerInit({ width: 27, height: 32 }, client);
 
                     expect(RFB.messages.pixelFormat).to.have.been.calledOnce;
                     expect(RFB.messages.pixelFormat).to.have.been.calledWith(client._sock, 24, true);
@@ -1602,7 +1602,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 });
 
                 it('should reply with restricted settings for Intel AMT servers', function () {
-                    send_server_init({ width: 27, height: 32, name: "Intel(r) AMT KVM"}, client);
+                    sendServerInit({ width: 27, height: 32, name: "Intel(r) AMT KVM"}, client);
 
                     expect(RFB.messages.pixelFormat).to.have.been.calledOnce;
                     expect(RFB.messages.pixelFormat).to.have.been.calledWith(client._sock, 8, true);
@@ -1617,8 +1617,8 @@ describe('Remote Frame Buffer Protocol Client', function () {
             });
 
             it('should transition to the "connected" state', function () {
-                send_server_init({}, client);
-                expect(client._rfb_connection_state).to.equal('connected');
+                sendServerInit({}, client);
+                expect(client._rfbConnectionState).to.equal('connected');
             });
         });
     });
@@ -1627,67 +1627,67 @@ describe('Remote Frame Buffer Protocol Client', function () {
         let client;
 
         beforeEach(function () {
-            client = make_rfb();
-            client._fb_name = 'some device';
-            client._fb_width = 640;
-            client._fb_height = 20;
+            client = makeRFB();
+            client._fbName = 'some device';
+            client._fbWidth = 640;
+            client._fbHeight = 20;
         });
 
         describe('Framebuffer Update Handling', function () {
-            const target_data_arr = [
+            const targetDataArr = [
                 0xff, 0x00, 0x00, 255, 0x00, 0xff, 0x00, 255, 0x00, 0x00, 0xff, 255, 0x00, 0x00, 0xff, 255,
                 0x00, 0xff, 0x00, 255, 0xff, 0x00, 0x00, 255, 0x00, 0x00, 0xff, 255, 0x00, 0x00, 0xff, 255,
                 0xee, 0x00, 0xff, 255, 0x00, 0xee, 0xff, 255, 0xaa, 0xee, 0xff, 255, 0xab, 0xee, 0xff, 255,
                 0xee, 0x00, 0xff, 255, 0x00, 0xee, 0xff, 255, 0xaa, 0xee, 0xff, 255, 0xab, 0xee, 0xff, 255
             ];
-            let target_data;
+            let targetData;
 
-            const target_data_check_arr = [
+            const targetDataCheckArr = [
                 0x00, 0x00, 0xff, 255, 0x00, 0x00, 0xff, 255, 0x00, 0xff, 0x00, 255, 0x00, 0xff, 0x00, 255,
                 0x00, 0x00, 0xff, 255, 0x00, 0x00, 0xff, 255, 0x00, 0xff, 0x00, 255, 0x00, 0xff, 0x00, 255,
                 0x00, 0xff, 0x00, 255, 0x00, 0xff, 0x00, 255, 0x00, 0x00, 0xff, 255, 0x00, 0x00, 0xff, 255,
                 0x00, 0xff, 0x00, 255, 0x00, 0xff, 0x00, 255, 0x00, 0x00, 0xff, 255, 0x00, 0x00, 0xff, 255
             ];
-            let target_data_check;
+            let targetDataCheck;
 
             before(function () {
                 // NB(directxman12): PhantomJS 1.x doesn't implement Uint8ClampedArray
-                target_data = new Uint8Array(target_data_arr);
-                target_data_check = new Uint8Array(target_data_check_arr);
+                targetData = new Uint8Array(targetDataArr);
+                targetDataCheck = new Uint8Array(targetDataCheckArr);
             });
 
-            function send_fbu_msg(rect_info, rect_data, client, rect_cnt) {
+            function sendFbuMsg(rectInfo, rectData, client, rectCnt) {
                 let data = [];
 
-                if (!rect_cnt || rect_cnt > -1) {
+                if (!rectCnt || rectCnt > -1) {
                     // header
                     data.push(0);  // msg type
                     data.push(0);  // padding
-                    push16(data, rect_cnt || rect_data.length);
+                    push16(data, rectCnt || rectData.length);
                 }
 
-                for (let i = 0; i < rect_data.length; i++) {
-                    if (rect_info[i]) {
-                        push16(data, rect_info[i].x);
-                        push16(data, rect_info[i].y);
-                        push16(data, rect_info[i].width);
-                        push16(data, rect_info[i].height);
-                        push32(data, rect_info[i].encoding);
+                for (let i = 0; i < rectData.length; i++) {
+                    if (rectInfo[i]) {
+                        push16(data, rectInfo[i].x);
+                        push16(data, rectInfo[i].y);
+                        push16(data, rectInfo[i].width);
+                        push16(data, rectInfo[i].height);
+                        push32(data, rectInfo[i].encoding);
                     }
-                    data = data.concat(rect_data[i]);
+                    data = data.concat(rectData[i]);
                 }
 
                 client._sock._websocket._receive_data(new Uint8Array(data));
             }
 
             it('should send an update request if there is sufficient data', function () {
-                const expected_msg = {_sQ: new Uint8Array(10), _sQlen: 0, flush: () => {}};
-                RFB.messages.fbUpdateRequest(expected_msg, true, 0, 0, 640, 20);
+                const expectedMsg = {_sQ: new Uint8Array(10), _sQlen: 0, flush: () => {}};
+                RFB.messages.fbUpdateRequest(expectedMsg, true, 0, 0, 640, 20);
 
                 client._framebufferUpdate = () => true;
                 client._sock._websocket._receive_data(new Uint8Array([0]));
 
-                expect(client._sock).to.have.sent(expected_msg._sQ);
+                expect(client._sock).to.have.sent(expectedMsg._sQ);
             });
 
             it('should not send an update request if we need more data', function () {
@@ -1696,8 +1696,8 @@ describe('Remote Frame Buffer Protocol Client', function () {
             });
 
             it('should resume receiving an update if we previously did not have enough data', function () {
-                const expected_msg = {_sQ: new Uint8Array(10), _sQlen: 0, flush: () => {}};
-                RFB.messages.fbUpdateRequest(expected_msg, true, 0, 0, 640, 20);
+                const expectedMsg = {_sQ: new Uint8Array(10), _sQlen: 0, flush: () => {}};
+                RFB.messages.fbUpdateRequest(expectedMsg, true, 0, 0, 640, 20);
 
                 // just enough to set FBU.rects
                 client._sock._websocket._receive_data(new Uint8Array([0, 0, 0, 3]));
@@ -1706,7 +1706,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 client._framebufferUpdate = function () { this._sock.rQskipBytes(1); return true; };  // we magically have enough data
                 // 247 should *not* be used as the message type here
                 client._sock._websocket._receive_data(new Uint8Array([247]));
-                expect(client._sock).to.have.sent(expected_msg._sQ);
+                expect(client._sock).to.have.sent(expectedMsg._sQ);
             });
 
             it('should not send a request in continuous updates mode', function () {
@@ -1719,33 +1719,33 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             it('should fail on an unsupported encoding', function () {
                 sinon.spy(client, "_fail");
-                const rect_info = { x: 8, y: 11, width: 27, height: 32, encoding: 234 };
-                send_fbu_msg([rect_info], [[]], client);
+                const rectInfo = { x: 8, y: 11, width: 27, height: 32, encoding: 234 };
+                sendFbuMsg([rectInfo], [[]], client);
                 expect(client._fail).to.have.been.calledOnce;
             });
 
             it('should be able to pause and resume receiving rects if not enought data', function () {
                 // seed some initial data to copy
-                client._fb_width = 4;
-                client._fb_height = 4;
+                client._fbWidth = 4;
+                client._fbHeight = 4;
                 client._display.resize(4, 4);
-                client._display.blitRgbxImage(0, 0, 4, 2, new Uint8Array(target_data_check_arr.slice(0, 32)), 0);
+                client._display.blitRgbxImage(0, 0, 4, 2, new Uint8Array(targetDataCheckArr.slice(0, 32)), 0);
 
                 const info = [{ x: 0, y: 2, width: 2, height: 2, encoding: 0x01},
                               { x: 2, y: 2, width: 2, height: 2, encoding: 0x01}];
                 // data says [{ old_x: 2, old_y: 0 }, { old_x: 0, old_y: 0 }]
                 const rects = [[0, 2, 0, 0], [0, 0, 0, 0]];
-                send_fbu_msg([info[0]], [rects[0]], client, 2);
-                send_fbu_msg([info[1]], [rects[1]], client, -1);
-                expect(client._display).to.have.displayed(target_data_check);
+                sendFbuMsg([info[0]], [rects[0]], client, 2);
+                sendFbuMsg([info[1]], [rects[1]], client, -1);
+                expect(client._display).to.have.displayed(targetDataCheck);
             });
 
             describe('Message Encoding Handlers', function () {
                 beforeEach(function () {
                     // a really small frame
-                    client._fb_width = 4;
-                    client._fb_height = 4;
-                    client._fb_depth = 24;
+                    client._fbWidth = 4;
+                    client._fbHeight = 4;
+                    client._fbDepth = 24;
                     client._display.resize(4, 4);
                 });
 
@@ -1760,8 +1760,8 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         [0xff, 0x00, 0x00, 0, 0xff, 0x00, 0x00, 0, 0xff, 0x00, 0x00, 0, 0xff, 0x00, 0x00, 0],
                         [0xff, 0x00, 0xee, 0, 0xff, 0xee, 0x00, 0, 0xff, 0xee, 0xaa, 0, 0xff, 0xee, 0xab, 0],
                         [0xff, 0x00, 0xee, 0, 0xff, 0xee, 0x00, 0, 0xff, 0xee, 0xaa, 0, 0xff, 0xee, 0xab, 0]];
-                    send_fbu_msg(info, rects, client);
-                    expect(client._display).to.have.displayed(target_data);
+                    sendFbuMsg(info, rects, client);
+                    expect(client._display).to.have.displayed(targetData);
                 });
 
                 it('should handle the RAW encoding in low colour mode', function () {
@@ -1774,21 +1774,21 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         [0x0c, 0x0c, 0x0c, 0x0c],
                         [0x0c, 0x0c, 0x03, 0x03],
                         [0x0c, 0x0c, 0x03, 0x03]];
-                    client._fb_depth = 8;
-                    send_fbu_msg(info, rects, client);
-                    expect(client._display).to.have.displayed(target_data_check);
+                    client._fbDepth = 8;
+                    sendFbuMsg(info, rects, client);
+                    expect(client._display).to.have.displayed(targetDataCheck);
                 });
 
                 it('should handle the COPYRECT encoding', function () {
                     // seed some initial data to copy
-                    client._display.blitRgbxImage(0, 0, 4, 2, new Uint8Array(target_data_check_arr.slice(0, 32)), 0);
+                    client._display.blitRgbxImage(0, 0, 4, 2, new Uint8Array(targetDataCheckArr.slice(0, 32)), 0);
 
                     const info = [{ x: 0, y: 2, width: 2, height: 2, encoding: 0x01},
                                   { x: 2, y: 2, width: 2, height: 2, encoding: 0x01}];
                     // data says [{ old_x: 0, old_y: 0 }, { old_x: 0, old_y: 0 }]
                     const rects = [[0, 2, 0, 0], [0, 0, 0, 0]];
-                    send_fbu_msg(info, rects, client);
-                    expect(client._display).to.have.displayed(target_data_check);
+                    sendFbuMsg(info, rects, client);
+                    expect(client._display).to.have.displayed(targetDataCheck);
                 });
 
                 // TODO(directxman12): for encodings with subrects, test resuming on partial send?
@@ -1815,9 +1815,8 @@ describe('Remote Frame Buffer Protocol Client', function () {
                     push16(rect, 2); // y: 2
                     push16(rect, 2); // width: 2
                     push16(rect, 2); // height: 2
-
-                    send_fbu_msg(info, [rect], client);
-                    expect(client._display).to.have.displayed(target_data_check);
+                    sendFbuMsg(info, [rect], client);
+                    expect(client._display).to.have.displayed(targetDataCheck);
                 });
 
                 describe('the HEXTILE encoding handler', function () {
@@ -1835,22 +1834,22 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         rect.push(1 | (1 << 4)); // width: 2, height: 2
                         rect.push(2 | (2 << 4)); // x: 2, y: 2
                         rect.push(1 | (1 << 4)); // width: 2, height: 2
-                        send_fbu_msg(info, [rect], client);
-                        expect(client._display).to.have.displayed(target_data_check);
+                        sendFbuMsg(info, [rect], client);
+                        expect(client._display).to.have.displayed(targetDataCheck);
                     });
 
                     it('should handle a raw tile', function () {
                         const info = [{ x: 0, y: 0, width: 4, height: 4, encoding: 0x05 }];
                         const rect = [];
                         rect.push(0x01); // raw
-                        for (let i = 0; i < target_data.length; i += 4) {
-                            rect.push(target_data[i + 2]);
-                            rect.push(target_data[i + 1]);
-                            rect.push(target_data[i]);
-                            rect.push(target_data[i + 3]);
+                        for (let i = 0; i < targetData.length; i += 4) {
+                            rect.push(targetData[i + 2]);
+                            rect.push(targetData[i + 1]);
+                            rect.push(targetData[i]);
+                            rect.push(targetData[i + 3]);
                         }
-                        send_fbu_msg(info, [rect], client);
-                        expect(client._display).to.have.displayed(target_data);
+                        sendFbuMsg(info, [rect], client);
+                        expect(client._display).to.have.displayed(targetData);
                     });
 
                     it('should handle a tile with only bg specified (solid bg)', function () {
@@ -1858,7 +1857,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         const rect = [];
                         rect.push(0x02);
                         push32(rect, 0xff00ff); // becomes 00ff00ff --> #00FF00 bg color
-                        send_fbu_msg(info, [rect], client);
+                        sendFbuMsg(info, [rect], client);
 
                         const expected = [];
                         for (let i = 0; i < 16; i++) { push32(expected, 0xff00ff); }
@@ -1867,7 +1866,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
                     it('should handle a tile with only bg specified and an empty frame afterwards', function () {
                         // set the width so we can have two tiles
-                        client._fb_width = 8;
+                        client._fbWidth = 8;
                         client._display.resize(8, 4);
 
                         const info = [{ x: 0, y: 0, width: 32, height: 4, encoding: 0x05 }];
@@ -1881,7 +1880,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         // send an empty frame
                         rect.push(0x00);
 
-                        send_fbu_msg(info, [rect], client);
+                        sendFbuMsg(info, [rect], client);
 
                         const expected = [];
                         for (let i = 0; i < 16; i++) { push32(expected, 0xff00ff); }     // rect 1: solid
@@ -1907,13 +1906,13 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         rect.push(0xff);
                         rect.push(2 | (2 << 4)); // x: 2, y: 2
                         rect.push(1 | (1 << 4)); // width: 2, height: 2
-                        send_fbu_msg(info, [rect], client);
-                        expect(client._display).to.have.displayed(target_data_check);
+                        sendFbuMsg(info, [rect], client);
+                        expect(client._display).to.have.displayed(targetDataCheck);
                     });
 
                     it('should carry over fg and bg colors from the previous tile if not specified', function () {
-                        client._fb_width = 4;
-                        client._fb_height = 17;
+                        client._fbWidth = 4;
+                        client._fbHeight = 17;
                         client._display.resize(4, 17);
 
                         const info = [{ x: 0, y: 0, width: 4, height: 17, encoding: 0x05}];
@@ -1935,11 +1934,11 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         rect.push(1); // 1 subrect
                         rect.push(0); // x: 0, y: 0
                         rect.push(1 | (1 << 4)); // width: 2, height: 2
-                        send_fbu_msg(info, [rect], client);
+                        sendFbuMsg(info, [rect], client);
 
                         let expected = [];
-                        for (let i = 0; i < 4; i++) { expected = expected.concat(target_data_check_arr); }
-                        expected = expected.concat(target_data_check_arr.slice(0, 16));
+                        for (let i = 0; i < 4; i++) { expected = expected.concat(targetDataCheckArr); }
+                        expected = expected.concat(targetDataCheckArr.slice(0, 16));
                         expect(client._display).to.have.displayed(new Uint8Array(expected));
                     });
 
@@ -1947,7 +1946,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         sinon.spy(client, "_fail");
                         const info = [{ x: 0, y: 0, width: 4, height: 4, encoding: 0x05 }];
                         const rects = [[45]];  // an invalid subencoding
-                        send_fbu_msg(info, rects, client);
+                        sendFbuMsg(info, rects, client);
                         expect(client._fail).to.have.been.calledOnce;
                     });
                 });
@@ -1962,10 +1961,10 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
                 it('should handle the DesktopSize pseduo-encoding', function () {
                     sinon.spy(client._display, 'resize');
-                    send_fbu_msg([{ x: 0, y: 0, width: 20, height: 50, encoding: -223 }], [[]], client);
+                    sendFbuMsg([{ x: 0, y: 0, width: 20, height: 50, encoding: -223 }], [[]], client);
 
-                    expect(client._fb_width).to.equal(20);
-                    expect(client._fb_height).to.equal(50);
+                    expect(client._fbWidth).to.equal(20);
+                    expect(client._fbHeight).to.equal(50);
 
                     expect(client._display.resize).to.have.been.calledOnce;
                     expect(client._display.resize).to.have.been.calledWith(20, 50);
@@ -1974,18 +1973,18 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 describe('the ExtendedDesktopSize pseudo-encoding handler', function () {
                     beforeEach(function () {
                         // a really small frame
-                        client._fb_width = 4;
-                        client._fb_height = 4;
+                        client._fbWidth = 4;
+                        client._fbHeight = 4;
                         client._display.resize(4, 4);
                         sinon.spy(client._display, 'resize');
                     });
 
-                    function make_screen_data(nr_of_screens) {
+                    function makeScreenData(nrOfScreens) {
                         const data = [];
-                        push8(data, nr_of_screens);   // number-of-screens
+                        push8(data, nrOfScreens);   // number-of-screens
                         push8(data, 0);               // padding
                         push16(data, 0);              // padding
-                        for (let i=0; i<nr_of_screens; i += 1) {
+                        for (let i=0; i<nrOfScreens; i += 1) {
                             push32(data, 0);  // id
                             push16(data, 0);  // x-position
                             push16(data, 0);  // y-position
@@ -1997,60 +1996,60 @@ describe('Remote Frame Buffer Protocol Client', function () {
                     }
 
                     it('should handle a resize requested by this client', function () {
-                        const reason_for_change = 1; // requested by this client
-                        const status_code       = 0; // No error
+                        const reasonForChange = 1; // requested by this client
+                        const statusCode      = 0; // No error
 
-                        send_fbu_msg([{ x: reason_for_change, y: status_code,
-                                        width: 20, height: 50, encoding: -308 }],
-                                     make_screen_data(1), client);
+                        sendFbuMsg([{ x: reasonForChange, y: statusCode,
+                                      width: 20, height: 50, encoding: -308 }],
+                                   makeScreenData(1), client);
 
-                        expect(client._fb_width).to.equal(20);
-                        expect(client._fb_height).to.equal(50);
+                        expect(client._fbWidth).to.equal(20);
+                        expect(client._fbHeight).to.equal(50);
 
                         expect(client._display.resize).to.have.been.calledOnce;
                         expect(client._display.resize).to.have.been.calledWith(20, 50);
                     });
 
                     it('should handle a resize requested by another client', function () {
-                        const reason_for_change = 2; // requested by another client
-                        const status_code       = 0; // No error
+                        const reasonForChange = 2; // requested by another client
+                        const statusCode      = 0; // No error
 
-                        send_fbu_msg([{ x: reason_for_change, y: status_code,
-                                        width: 20, height: 50, encoding: -308 }],
-                                     make_screen_data(1), client);
+                        sendFbuMsg([{ x: reasonForChange, y: statusCode,
+                                      width: 20, height: 50, encoding: -308 }],
+                                   makeScreenData(1), client);
 
-                        expect(client._fb_width).to.equal(20);
-                        expect(client._fb_height).to.equal(50);
+                        expect(client._fbWidth).to.equal(20);
+                        expect(client._fbHeight).to.equal(50);
 
                         expect(client._display.resize).to.have.been.calledOnce;
                         expect(client._display.resize).to.have.been.calledWith(20, 50);
                     });
 
                     it('should be able to recieve requests which contain data for multiple screens', function () {
-                        const reason_for_change = 2; // requested by another client
-                        const status_code       = 0; // No error
+                        const reasonForChange = 2; // requested by another client
+                        const statusCode      = 0; // No error
 
-                        send_fbu_msg([{ x: reason_for_change, y: status_code,
-                                        width: 60, height: 50, encoding: -308 }],
-                                     make_screen_data(3), client);
+                        sendFbuMsg([{ x: reasonForChange, y: statusCode,
+                                      width: 60, height: 50, encoding: -308 }],
+                                   makeScreenData(3), client);
 
-                        expect(client._fb_width).to.equal(60);
-                        expect(client._fb_height).to.equal(50);
+                        expect(client._fbWidth).to.equal(60);
+                        expect(client._fbHeight).to.equal(50);
 
                         expect(client._display.resize).to.have.been.calledOnce;
                         expect(client._display.resize).to.have.been.calledWith(60, 50);
                     });
 
                     it('should not handle a failed request', function () {
-                        const reason_for_change = 1; // requested by this client
-                        const status_code       = 1; // Resize is administratively prohibited
+                        const reasonForChange = 1; // requested by this client
+                        const statusCode      = 1; // Resize is administratively prohibited
 
-                        send_fbu_msg([{ x: reason_for_change, y: status_code,
-                                        width: 20, height: 50, encoding: -308 }],
-                                     make_screen_data(1), client);
+                        sendFbuMsg([{ x: reasonForChange, y: statusCode,
+                                      width: 20, height: 50, encoding: -308 }],
+                                   makeScreenData(1), client);
 
-                        expect(client._fb_width).to.equal(4);
-                        expect(client._fb_height).to.equal(4);
+                        expect(client._fbWidth).to.equal(4);
+                        expect(client._fbHeight).to.equal(4);
 
                         expect(client._display.resize).to.not.have.been.called;
                     });
@@ -2079,7 +2078,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         }
                         expected = new Uint8Array(expected);
 
-                        send_fbu_msg([info], [rect], client);
+                        sendFbuMsg([info], [rect], client);
 
                         expect(client._cursor.change).to.have.been.calledOnce;
                         expect(client._cursor.change).to.have.been.calledWith(expected, 5, 7, 4, 4);
@@ -2091,7 +2090,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                                        encoding: -239};
                         const rect = [];
 
-                        send_fbu_msg([info], [rect], client);
+                        sendFbuMsg([info], [rect], client);
 
                         expect(client._cursor.change).to.have.been.calledOnce;
                         expect(client._cursor.change).to.have.been.calledWith(new Uint8Array, 0, 0, 0, 0);
@@ -2114,7 +2113,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         }
                         expected = new Uint8Array(expected);
 
-                        send_fbu_msg([info], [rect], client);
+                        sendFbuMsg([info], [rect], client);
 
                         expect(client._cursor.change).to.have.been.calledOnce;
                         expect(client._cursor.change).to.have.been.calledWith(expected, 5, 7, 4, 4);
@@ -2145,7 +2144,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                             }
                             expected = new Uint8Array(expected);
 
-                            send_fbu_msg([info], [rect], client);
+                            sendFbuMsg([info], [rect], client);
 
                             expect(client._cursor.change).to.have.been.calledOnce;
                             expect(client._cursor.change).to.have.been.calledWith(expected, 5, 7, 4, 4);
@@ -2158,7 +2157,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                             const rect = [];
                             const dot = RFB.cursors.dot;
 
-                            send_fbu_msg([info], [rect], client);
+                            sendFbuMsg([info], [rect], client);
 
                             expect(client._cursor.change).to.have.been.calledOnce;
                             expect(client._cursor.change).to.have.been.calledWith(dot.rgbaPixels,
@@ -2180,7 +2179,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                             }
                             push32(rect, 0x00000000);
 
-                            send_fbu_msg([info], [rect], client);
+                            sendFbuMsg([info], [rect], client);
 
                             expect(client._cursor.change).to.have.been.calledOnce;
                             expect(client._cursor.change).to.have.been.calledWith(dot.rgbaPixels,
@@ -2218,9 +2217,9 @@ describe('Remote Frame Buffer Protocol Client', function () {
                             push8(rect, data[i]);
                         }
 
-                        send_fbu_msg([{ x: 0, y: 0, width: 2, height: 2,
-                                        encoding: 0x574d5664}],
-                                     [rect], client);
+                        sendFbuMsg([{ x: 0, y: 0, width: 2, height: 2,
+                                      encoding: 0x574d5664}],
+                                   [rect], client);
                         expect(client._FBU.rects).to.equal(0);
                     });
 
@@ -2246,22 +2245,22 @@ describe('Remote Frame Buffer Protocol Client', function () {
                             push8(rect, data[i]);
                         }
 
-                        send_fbu_msg([{ x: 0, y: 0, width: w, height: h,
-                                        encoding: 0x574d5664}],
-                                     [rect], client);
+                        sendFbuMsg([{ x: 0, y: 0, width: w, height: h,
+                                      encoding: 0x574d5664}],
+                                   [rect], client);
 
                         // expect one FBU to remain unhandled
                         expect(client._FBU.rects).to.equal(1);
                     });
 
                     it('should update the cursor when type is classic', function () {
-                        let and_mask =
+                        let andMask =
                             [0xff, 0xff, 0xff, 0xff,  //Transparent
                              0xff, 0xff, 0xff, 0xff,  //Transparent
                              0x00, 0x00, 0x00, 0x00,  //Opaque
                              0xff, 0xff, 0xff, 0xff]; //Inverted
 
-                        let xor_mask =
+                        let xorMask =
                             [0x00, 0x00, 0x00, 0x00,  //Transparent
                              0x00, 0x00, 0x00, 0x00,  //Transparent
                              0x11, 0x22, 0x33, 0x44,  //Opaque
@@ -2276,28 +2275,28 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         let h = 2;
 
                         //AND-mask
-                        for (let i = 0; i < and_mask.length; i++) {
-                            push8(rect, and_mask[i]);
+                        for (let i = 0; i < andMask.length; i++) {
+                            push8(rect, andMask[i]);
                         }
                         //XOR-mask
-                        for (let i = 0; i < xor_mask.length; i++) {
-                            push8(rect, xor_mask[i]);
+                        for (let i = 0; i < xorMask.length; i++) {
+                            push8(rect, xorMask[i]);
                         }
 
-                        let expected_rgba = [0x00, 0x00, 0x00, 0x00,
-                                             0x00, 0x00, 0x00, 0x00,
-                                             0x33, 0x22, 0x11, 0xff,
-                                             0x00, 0x00, 0x00, 0xff];
+                        let expectedRgba = [0x00, 0x00, 0x00, 0x00,
+                                            0x00, 0x00, 0x00, 0x00,
+                                            0x33, 0x22, 0x11, 0xff,
+                                            0x00, 0x00, 0x00, 0xff];
 
-                        send_fbu_msg([{ x: hotx, y: hoty,
-                                        width: w, height: h,
-                                        encoding: 0x574d5664}],
-                                     [rect], client);
+                        sendFbuMsg([{ x: hotx, y: hoty,
+                                      width: w, height: h,
+                                      encoding: 0x574d5664}],
+                                   [rect], client);
 
                         expect(client._cursor.change)
                             .to.have.been.calledOnce;
                         expect(client._cursor.change)
-                            .to.have.been.calledWith(expected_rgba,
+                            .to.have.been.calledWith(expectedRgba,
                                                      hotx, hoty,
                                                      w, h);
                     });
@@ -2321,22 +2320,22 @@ describe('Remote Frame Buffer Protocol Client', function () {
                             push8(rect, data[i]);
                         }
 
-                        let expected_rgba = [0xee, 0x55, 0xff, 0x00,
-                                             0x00, 0xff, 0x00, 0xff,
-                                             0x00, 0xff, 0x00, 0x22,
-                                             0x00, 0xff, 0x00, 0x22,
-                                             0x00, 0xff, 0x00, 0x22,
-                                             0x00, 0x00, 0xff, 0xee];
+                        let expectedRgba = [0xee, 0x55, 0xff, 0x00,
+                                            0x00, 0xff, 0x00, 0xff,
+                                            0x00, 0xff, 0x00, 0x22,
+                                            0x00, 0xff, 0x00, 0x22,
+                                            0x00, 0xff, 0x00, 0x22,
+                                            0x00, 0x00, 0xff, 0xee];
 
-                        send_fbu_msg([{ x: hotx, y: hoty,
-                                        width: w, height: h,
-                                        encoding: 0x574d5664}],
-                                     [rect], client);
+                        sendFbuMsg([{ x: hotx, y: hoty,
+                                      width: w, height: h,
+                                      encoding: 0x574d5664}],
+                                   [rect], client);
 
                         expect(client._cursor.change)
                             .to.have.been.calledOnce;
                         expect(client._cursor.change)
-                            .to.have.been.calledWith(expected_rgba,
+                            .to.have.been.calledWith(expectedRgba,
                                                      hotx, hoty,
                                                      w, h);
                     });
@@ -2347,9 +2346,9 @@ describe('Remote Frame Buffer Protocol Client', function () {
                         push8(rect, 0); // padding
 
                         client._cursor.change.resetHistory();
-                        send_fbu_msg([{ x: 0, y: 0, width: 2, height: 2,
-                                        encoding: 0x574d5664}],
-                                     [rect], client);
+                        sendFbuMsg([{ x: 0, y: 0, width: 2, height: 2,
+                                      encoding: 0x574d5664}],
+                                   [rect], client);
 
                         expect(client._cursor.change)
                             .to.not.have.been.called;
@@ -2357,7 +2356,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 });
 
                 it('should handle the last_rect pseudo-encoding', function () {
-                    send_fbu_msg([{ x: 0, y: 0, width: 0, height: 0, encoding: -224}], [[]], client, 100);
+                    sendFbuMsg([{ x: 0, y: 0, width: 0, height: 0, encoding: -224}], [[]], client, 100);
                     expect(client._FBU.rects).to.equal(0);
                 });
 
@@ -2369,9 +2368,9 @@ describe('Remote Frame Buffer Protocol Client', function () {
                     const spy = sinon.spy();
                     client.addEventListener("desktopname", spy);
 
-                    send_fbu_msg([{ x: 0, y: 0, width: 0, height: 0, encoding: -307 }], [data], client);
+                    sendFbuMsg([{ x: 0, y: 0, width: 0, height: 0, encoding: -307 }], [data], client);
 
-                    expect(client._fb_name).to.equal('som€ nam€');
+                    expect(client._fbName).to.equal('som€ nam€');
                     expect(spy).to.have.been.calledOnce;
                     expect(spy.args[0][0].detail.name).to.equal('som€ nam€');
                 });
@@ -2383,7 +2382,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 const spy = sinon.spy();
                 client.addEventListener("capabilities", spy);
                 client._sock._websocket._receive_data(new Uint8Array([250, 0, 10, 1]));
-                expect(client._rfb_xvp_ver).to.equal(10);
+                expect(client._rfbXvpVer).to.equal(10);
                 expect(spy).to.have.been.calledOnce;
                 expect(spy.args[0][0].detail.capabilities.power).to.be.true;
                 expect(client.capabilities.power).to.be.true;
@@ -2398,16 +2397,16 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
         describe('Normal Clipboard Handling Receive', function () {
             it('should fire the clipboard callback with the retrieved text on ServerCutText', function () {
-                const expected_str = 'cheese!';
+                const expectedStr = 'cheese!';
                 const data = [3, 0, 0, 0];
-                push32(data, expected_str.length);
-                for (let i = 0; i < expected_str.length; i++) { data.push(expected_str.charCodeAt(i)); }
+                push32(data, expectedStr.length);
+                for (let i = 0; i < expectedStr.length; i++) { data.push(expectedStr.charCodeAt(i)); }
                 const spy = sinon.spy();
                 client.addEventListener("clipboard", spy);
 
                 client._sock._websocket._receive_data(new Uint8Array(data));
                 expect(spy).to.have.been.calledOnce;
-                expect(spy.args[0][0].detail.text).to.equal(expected_str);
+                expect(spy.args[0][0].detail.text).to.equal(expectedStr);
             });
         });
 
@@ -2649,41 +2648,41 @@ describe('Remote Frame Buffer Protocol Client', function () {
         });
 
         it('should respond correctly to ServerFence', function () {
-            const expected_msg = {_sQ: new Uint8Array(16), _sQlen: 0, flush: () => {}};
-            const incoming_msg = {_sQ: new Uint8Array(16), _sQlen: 0, flush: () => {}};
+            const expectedMsg = {_sQ: new Uint8Array(16), _sQlen: 0, flush: () => {}};
+            const incomingMsg = {_sQ: new Uint8Array(16), _sQlen: 0, flush: () => {}};
 
             const payload = "foo\x00ab9";
 
             // ClientFence and ServerFence are identical in structure
-            RFB.messages.clientFence(expected_msg, (1<<0) | (1<<1), payload);
-            RFB.messages.clientFence(incoming_msg, 0xffffffff, payload);
+            RFB.messages.clientFence(expectedMsg, (1<<0) | (1<<1), payload);
+            RFB.messages.clientFence(incomingMsg, 0xffffffff, payload);
 
-            client._sock._websocket._receive_data(incoming_msg._sQ);
+            client._sock._websocket._receive_data(incomingMsg._sQ);
 
-            expect(client._sock).to.have.sent(expected_msg._sQ);
+            expect(client._sock).to.have.sent(expectedMsg._sQ);
 
-            expected_msg._sQlen = 0;
-            incoming_msg._sQlen = 0;
+            expectedMsg._sQlen = 0;
+            incomingMsg._sQlen = 0;
 
-            RFB.messages.clientFence(expected_msg, (1<<0), payload);
-            RFB.messages.clientFence(incoming_msg, (1<<0) | (1<<31), payload);
+            RFB.messages.clientFence(expectedMsg, (1<<0), payload);
+            RFB.messages.clientFence(incomingMsg, (1<<0) | (1<<31), payload);
 
-            client._sock._websocket._receive_data(incoming_msg._sQ);
+            client._sock._websocket._receive_data(incomingMsg._sQ);
 
-            expect(client._sock).to.have.sent(expected_msg._sQ);
+            expect(client._sock).to.have.sent(expectedMsg._sQ);
         });
 
         it('should enable continuous updates on first EndOfContinousUpdates', function () {
-            const expected_msg = {_sQ: new Uint8Array(10), _sQlen: 0, flush: () => {}};
+            const expectedMsg = {_sQ: new Uint8Array(10), _sQlen: 0, flush: () => {}};
 
-            RFB.messages.enableContinuousUpdates(expected_msg, true, 0, 0, 640, 20);
+            RFB.messages.enableContinuousUpdates(expectedMsg, true, 0, 0, 640, 20);
 
             expect(client._enabledContinuousUpdates).to.be.false;
 
             client._sock._websocket._receive_data(new Uint8Array([150]));
 
             expect(client._enabledContinuousUpdates).to.be.true;
-            expect(client._sock).to.have.sent(expected_msg._sQ);
+            expect(client._sock).to.have.sent(expectedMsg._sQ);
         });
 
         it('should disable continuous updates on subsequent EndOfContinousUpdates', function () {
@@ -2696,8 +2695,8 @@ describe('Remote Frame Buffer Protocol Client', function () {
         });
 
         it('should update continuous updates on resize', function () {
-            const expected_msg = {_sQ: new Uint8Array(10), _sQlen: 0, flush: () => {}};
-            RFB.messages.enableContinuousUpdates(expected_msg, true, 0, 0, 90, 700);
+            const expectedMsg = {_sQ: new Uint8Array(10), _sQlen: 0, flush: () => {}};
+            RFB.messages.enableContinuousUpdates(expectedMsg, true, 0, 0, 90, 700);
 
             client._resize(450, 160);
 
@@ -2707,7 +2706,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             client._resize(90, 700);
 
-            expect(client._sock).to.have.sent(expected_msg._sQ);
+            expect(client._sock).to.have.sent(expectedMsg._sQ);
         });
 
         it('should fail on an unknown message type', function () {
@@ -2720,7 +2719,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
     describe('Asynchronous Events', function () {
         let client;
         beforeEach(function () {
-            client = make_rfb();
+            client = makeRFB();
         });
 
         describe('Mouse event handlers', function () {
@@ -2740,49 +2739,49 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             it('should send a pointer event on mouse button presses', function () {
                 client._handleMouseButton(10, 12, 1, 0x001);
-                const pointer_msg = {_sQ: new Uint8Array(6), _sQlen: 0, flush: () => {}};
-                RFB.messages.pointerEvent(pointer_msg, 10, 12, 0x001);
-                expect(client._sock).to.have.sent(pointer_msg._sQ);
+                const pointerMsg = {_sQ: new Uint8Array(6), _sQlen: 0, flush: () => {}};
+                RFB.messages.pointerEvent(pointerMsg, 10, 12, 0x001);
+                expect(client._sock).to.have.sent(pointerMsg._sQ);
             });
 
             it('should send a mask of 1 on mousedown', function () {
                 client._handleMouseButton(10, 12, 1, 0x001);
-                const pointer_msg = {_sQ: new Uint8Array(6), _sQlen: 0, flush: () => {}};
-                RFB.messages.pointerEvent(pointer_msg, 10, 12, 0x001);
-                expect(client._sock).to.have.sent(pointer_msg._sQ);
+                const pointerMsg = {_sQ: new Uint8Array(6), _sQlen: 0, flush: () => {}};
+                RFB.messages.pointerEvent(pointerMsg, 10, 12, 0x001);
+                expect(client._sock).to.have.sent(pointerMsg._sQ);
             });
 
             it('should send a mask of 0 on mouseup', function () {
-                client._mouse_buttonMask = 0x001;
+                client._mouseButtonMask = 0x001;
                 client._handleMouseButton(10, 12, 0, 0x001);
-                const pointer_msg = {_sQ: new Uint8Array(6), _sQlen: 0, flush: () => {}};
-                RFB.messages.pointerEvent(pointer_msg, 10, 12, 0x000);
-                expect(client._sock).to.have.sent(pointer_msg._sQ);
+                const pointerMsg = {_sQ: new Uint8Array(6), _sQlen: 0, flush: () => {}};
+                RFB.messages.pointerEvent(pointerMsg, 10, 12, 0x000);
+                expect(client._sock).to.have.sent(pointerMsg._sQ);
             });
 
             it('should send a pointer event on mouse movement', function () {
                 client._handleMouseMove(10, 12);
-                const pointer_msg = {_sQ: new Uint8Array(6), _sQlen: 0, flush: () => {}};
-                RFB.messages.pointerEvent(pointer_msg, 10, 12, 0x000);
-                expect(client._sock).to.have.sent(pointer_msg._sQ);
+                const pointerMsg = {_sQ: new Uint8Array(6), _sQlen: 0, flush: () => {}};
+                RFB.messages.pointerEvent(pointerMsg, 10, 12, 0x000);
+                expect(client._sock).to.have.sent(pointerMsg._sQ);
             });
 
             it('should set the button mask so that future mouse movements use it', function () {
                 client._handleMouseButton(10, 12, 1, 0x010);
                 client._handleMouseMove(13, 9);
-                const pointer_msg = {_sQ: new Uint8Array(12), _sQlen: 0, flush: () => {}};
-                RFB.messages.pointerEvent(pointer_msg, 10, 12, 0x010);
-                RFB.messages.pointerEvent(pointer_msg, 13, 9, 0x010);
-                expect(client._sock).to.have.sent(pointer_msg._sQ);
+                const pointerMsg = {_sQ: new Uint8Array(12), _sQlen: 0, flush: () => {}};
+                RFB.messages.pointerEvent(pointerMsg, 10, 12, 0x010);
+                RFB.messages.pointerEvent(pointerMsg, 13, 9, 0x010);
+                expect(client._sock).to.have.sent(pointerMsg._sQ);
             });
         });
 
         describe('Keyboard Event Handlers', function () {
             it('should send a key message on a key press', function () {
                 client._handleKeyEvent(0x41, 'KeyA', true);
-                const key_msg = {_sQ: new Uint8Array(8), _sQlen: 0, flush: () => {}};
-                RFB.messages.keyEvent(key_msg, 0x41, 1);
-                expect(client._sock).to.have.sent(key_msg._sQ);
+                const keyMsg = {_sQ: new Uint8Array(8), _sQlen: 0, flush: () => {}};
+                RFB.messages.keyEvent(keyMsg, 0x41, 1);
+                expect(client._sock).to.have.sent(keyMsg._sQ);
             });
 
             it('should not send messages in view-only mode', function () {
@@ -2796,23 +2795,23 @@ describe('Remote Frame Buffer Protocol Client', function () {
         describe('WebSocket event handlers', function () {
             // message events
             it('should do nothing if we receive an empty message and have nothing in the queue', function () {
-                client._normal_msg = sinon.spy();
+                client._normalMsg = sinon.spy();
                 client._sock._websocket._receive_data(new Uint8Array([]));
-                expect(client._normal_msg).to.not.have.been.called;
+                expect(client._normalMsg).to.not.have.been.called;
             });
 
             it('should handle a message in the connected state as a normal message', function () {
-                client._normal_msg = sinon.spy();
+                client._normalMsg = sinon.spy();
                 client._sock._websocket._receive_data(new Uint8Array([1, 2, 3]));
-                expect(client._normal_msg).to.have.been.called;
+                expect(client._normalMsg).to.have.been.called;
             });
 
             it('should handle a message in any non-disconnected/failed state like an init message', function () {
-                client._rfb_connection_state = 'connecting';
-                client._rfb_init_state = 'ProtocolVersion';
-                client._init_msg = sinon.spy();
+                client._rfbConnectionState = 'connecting';
+                client._rfbInitState = 'ProtocolVersion';
+                client._initMsg = sinon.spy();
                 client._sock._websocket._receive_data(new Uint8Array([1, 2, 3]));
-                expect(client._init_msg).to.have.been.called;
+                expect(client._initMsg).to.have.been.called;
             });
 
             it('should process all normal messages directly', function () {
@@ -2827,12 +2826,12 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 client = new RFB(document.createElement('div'), 'wss://host:8675');
                 this.clock.tick();
                 client._sock._websocket._open();
-                expect(client._rfb_init_state).to.equal('ProtocolVersion');
+                expect(client._rfbInitState).to.equal('ProtocolVersion');
             });
 
             it('should fail if we are not currently ready to connect and we get an "open" event', function () {
                 sinon.spy(client, "_fail");
-                client._rfb_connection_state = 'connected';
+                client._rfbConnectionState = 'connected';
                 client._sock._websocket._open();
                 expect(client._fail).to.have.been.calledOnce;
             });
@@ -2842,15 +2841,15 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 const real = client._sock._websocket.close;
                 client._sock._websocket.close = () => {};
                 client.disconnect();
-                expect(client._rfb_connection_state).to.equal('disconnecting');
+                expect(client._rfbConnectionState).to.equal('disconnecting');
                 client._sock._websocket.close = real;
                 client._sock._websocket.close();
-                expect(client._rfb_connection_state).to.equal('disconnected');
+                expect(client._rfbConnectionState).to.equal('disconnected');
             });
 
             it('should fail if we get a close event while connecting', function () {
                 sinon.spy(client, "_fail");
-                client._rfb_connection_state = 'connecting';
+                client._rfbConnectionState = 'connecting';
                 client._sock._websocket.close();
                 expect(client._fail).to.have.been.calledOnce;
             });
@@ -2872,7 +2871,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
         let client;
 
         beforeEach(function () {
-            client = make_rfb();
+            client = makeRFB();
             sinon.spy(RFB.messages, "clientEncodings");
         });
 
@@ -2946,21 +2945,21 @@ describe('Remote Frame Buffer Protocol Client', function () {
         it('should not send clientEncodings if not in connected state', function () {
             let newQuality;
 
-            client._rfb_connection_state = '';
+            client._rfbConnectionState = '';
             newQuality = 2;
             client.qualityLevel = newQuality;
             expect(RFB.messages.clientEncodings).to.not.have.been.called;
 
             RFB.messages.clientEncodings.resetHistory();
 
-            client._rfb_connection_state = 'connnecting';
+            client._rfbConnectionState = 'connnecting';
             newQuality = 6;
             client.qualityLevel = newQuality;
             expect(RFB.messages.clientEncodings).to.not.have.been.called;
 
             RFB.messages.clientEncodings.resetHistory();
 
-            client._rfb_connection_state = 'connected';
+            client._rfbConnectionState = 'connected';
             newQuality = 5;
             client.qualityLevel = newQuality;
             expect(RFB.messages.clientEncodings).to.have.been.calledOnce;
@@ -2974,7 +2973,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
         let client;
 
         beforeEach(function () {
-            client = make_rfb();
+            client = makeRFB();
             sinon.spy(RFB.messages, "clientEncodings");
         });
 
@@ -3048,21 +3047,21 @@ describe('Remote Frame Buffer Protocol Client', function () {
         it('should not send clientEncodings if not in connected state', function () {
             let newCompression;
 
-            client._rfb_connection_state = '';
+            client._rfbConnectionState = '';
             newCompression = 7;
             client.compressionLevel = newCompression;
             expect(RFB.messages.clientEncodings).to.not.have.been.called;
 
             RFB.messages.clientEncodings.resetHistory();
 
-            client._rfb_connection_state = 'connnecting';
+            client._rfbConnectionState = 'connnecting';
             newCompression = 6;
             client.compressionLevel = newCompression;
             expect(RFB.messages.clientEncodings).to.not.have.been.called;
 
             RFB.messages.clientEncodings.resetHistory();
 
-            client._rfb_connection_state = 'connected';
+            client._rfbConnectionState = 'connected';
             newCompression = 5;
             client.compressionLevel = newCompression;
             expect(RFB.messages.clientEncodings).to.have.been.calledOnce;

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -99,8 +99,8 @@ describe('Remote Frame Buffer Protocol Client', function () {
         const _sQ = new Uint8Array(sock._sQbufferSize);
         const rQ = new Uint8Array(sock._rQbufferSize);
 
-        Websock.prototype._old_allocate_buffers = Websock.prototype._allocate_buffers;
-        Websock.prototype._allocate_buffers = function () {
+        Websock.prototype._oldAllocateBuffers = Websock.prototype._allocateBuffers;
+        Websock.prototype._allocateBuffers = function () {
             this._sQ = _sQ;
             this._rQ = rQ;
         };
@@ -108,7 +108,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
     });
 
     after(function () {
-        Websock.prototype._allocate_buffers = Websock.prototype._old_allocate_buffers;
+        Websock.prototype._allocateBuffers = Websock.prototype._oldAllocateBuffers;
         this.clock.restore();
         window.requestAnimationFrame = raf;
     });

--- a/tests/test.util.js
+++ b/tests/test.util.js
@@ -22,37 +22,37 @@ describe('Utils', function () {
             console.warn.restore();
             console.error.restore();
             console.info.restore();
-            Log.init_logging();
+            Log.initLogging();
         });
 
         it('should use noop for levels lower than the min level', function () {
-            Log.init_logging('warn');
+            Log.initLogging('warn');
             Log.Debug('hi');
             Log.Info('hello');
             expect(console.log).to.not.have.been.called;
         });
 
         it('should use console.debug for Debug', function () {
-            Log.init_logging('debug');
+            Log.initLogging('debug');
             Log.Debug('dbg');
             expect(console.debug).to.have.been.calledWith('dbg');
         });
 
         it('should use console.info for Info', function () {
-            Log.init_logging('debug');
+            Log.initLogging('debug');
             Log.Info('inf');
             expect(console.info).to.have.been.calledWith('inf');
         });
 
         it('should use console.warn for Warn', function () {
-            Log.init_logging('warn');
+            Log.initLogging('warn');
             Log.Warn('wrn');
             expect(console.warn).to.have.been.called;
             expect(console.warn).to.have.been.calledWith('wrn');
         });
 
         it('should use console.error for Error', function () {
-            Log.init_logging('error');
+            Log.initLogging('error');
             Log.Error('err');
             expect(console.error).to.have.been.called;
             expect(console.error).to.have.been.calledWith('err');

--- a/tests/test.websock.js
+++ b/tests/test.websock.js
@@ -13,7 +13,7 @@ describe('Websock', function () {
         beforeEach(function () {
             sock = new Websock();
             // skip init
-            sock._allocate_buffers();
+            sock._allocateBuffers();
             sock._rQ.set(RQ_TEMPLATE);
             sock._rQlen = RQ_TEMPLATE.length;
         });
@@ -33,51 +33,51 @@ describe('Websock', function () {
 
         describe('rQpeek8', function () {
             it('should peek at the next byte without poping it off the queue', function () {
-                const bef_len = sock.rQlen;
+                const befLen = sock.rQlen;
                 const peek = sock.rQpeek8();
                 expect(sock.rQpeek8()).to.equal(peek);
-                expect(sock.rQlen).to.equal(bef_len);
+                expect(sock.rQlen).to.equal(befLen);
             });
         });
 
         describe('rQshift8()', function () {
             it('should pop a single byte from the receive queue', function () {
                 const peek = sock.rQpeek8();
-                const bef_len = sock.rQlen;
+                const befLen = sock.rQlen;
                 expect(sock.rQshift8()).to.equal(peek);
-                expect(sock.rQlen).to.equal(bef_len - 1);
+                expect(sock.rQlen).to.equal(befLen - 1);
             });
         });
 
         describe('rQshift16()', function () {
             it('should pop two bytes from the receive queue and return a single number', function () {
-                const bef_len = sock.rQlen;
+                const befLen = sock.rQlen;
                 const expected = (RQ_TEMPLATE[0] << 8) + RQ_TEMPLATE[1];
                 expect(sock.rQshift16()).to.equal(expected);
-                expect(sock.rQlen).to.equal(bef_len - 2);
+                expect(sock.rQlen).to.equal(befLen - 2);
             });
         });
 
         describe('rQshift32()', function () {
             it('should pop four bytes from the receive queue and return a single number', function () {
-                const bef_len = sock.rQlen;
+                const befLen = sock.rQlen;
                 const expected = (RQ_TEMPLATE[0] << 24) +
                                (RQ_TEMPLATE[1] << 16) +
                                (RQ_TEMPLATE[2] << 8) +
                                RQ_TEMPLATE[3];
                 expect(sock.rQshift32()).to.equal(expected);
-                expect(sock.rQlen).to.equal(bef_len - 4);
+                expect(sock.rQlen).to.equal(befLen - 4);
             });
         });
 
         describe('rQshiftStr', function () {
             it('should shift the given number of bytes off of the receive queue and return a string', function () {
-                const bef_len = sock.rQlen;
-                const bef_rQi = sock.rQi;
+                const befLen = sock.rQlen;
+                const befRQi = sock.rQi;
                 const shifted = sock.rQshiftStr(3);
                 expect(shifted).to.be.a('string');
-                expect(shifted).to.equal(String.fromCharCode.apply(null, Array.prototype.slice.call(new Uint8Array(RQ_TEMPLATE.buffer, bef_rQi, 3))));
-                expect(sock.rQlen).to.equal(bef_len - 3);
+                expect(shifted).to.equal(String.fromCharCode.apply(null, Array.prototype.slice.call(new Uint8Array(RQ_TEMPLATE.buffer, befRQi, 3))));
+                expect(sock.rQlen).to.equal(befLen - 3);
             });
 
             it('should shift the entire rest of the queue off if no length is given', function () {
@@ -112,12 +112,12 @@ describe('Websock', function () {
 
         describe('rQshiftBytes', function () {
             it('should shift the given number of bytes of the receive queue and return an array', function () {
-                const bef_len = sock.rQlen;
-                const bef_rQi = sock.rQi;
+                const befLen = sock.rQlen;
+                const befRQi = sock.rQi;
                 const shifted = sock.rQshiftBytes(3);
                 expect(shifted).to.be.an.instanceof(Uint8Array);
-                expect(shifted).to.array.equal(new Uint8Array(RQ_TEMPLATE.buffer, bef_rQi, 3));
-                expect(sock.rQlen).to.equal(bef_len - 3);
+                expect(shifted).to.array.equal(new Uint8Array(RQ_TEMPLATE.buffer, befRQi, 3));
+                expect(sock.rQlen).to.equal(befLen - 3);
             });
 
             it('should shift the entire rest of the queue off if no length is given', function () {
@@ -132,9 +132,9 @@ describe('Websock', function () {
             });
 
             it('should not modify the receive queue', function () {
-                const bef_len = sock.rQlen;
+                const befLen = sock.rQlen;
                 sock.rQslice(0, 2);
-                expect(sock.rQlen).to.equal(bef_len);
+                expect(sock.rQlen).to.equal(befLen);
             });
 
             it('should return an array containing the given slice of the receive queue', function () {
@@ -198,7 +198,7 @@ describe('Websock', function () {
                 sock._websocket.readyState = WebSocket.OPEN;
                 sock._sQ = new Uint8Array([1, 2, 3]);
                 sock._sQlen = 3;
-                const encoded = sock._encode_message();
+                const encoded = sock._encodeMessage();
 
                 sock.flush();
                 expect(sock._websocket.send).to.have.been.calledOnce;
@@ -232,22 +232,22 @@ describe('Websock', function () {
             });
         });
 
-        describe('send_string', function () {
+        describe('sendString', function () {
             beforeEach(function () {
                 sock.send = sinon.spy();
             });
 
             it('should call send after converting the string to an array', function () {
-                sock.send_string("\x01\x02\x03");
+                sock.sendString("\x01\x02\x03");
                 expect(sock.send).to.have.been.calledWith([1, 2, 3]);
             });
         });
     });
 
     describe('lifecycle methods', function () {
-        let old_WS;
+        let oldWS;
         before(function () {
-            old_WS = WebSocket;
+            oldWS = WebSocket;
         });
 
         let sock;
@@ -255,10 +255,10 @@ describe('Websock', function () {
             sock = new Websock();
             // eslint-disable-next-line no-global-assign
             WebSocket = sinon.spy();
-            WebSocket.OPEN = old_WS.OPEN;
-            WebSocket.CONNECTING = old_WS.CONNECTING;
-            WebSocket.CLOSING = old_WS.CLOSING;
-            WebSocket.CLOSED = old_WS.CLOSED;
+            WebSocket.OPEN = oldWS.OPEN;
+            WebSocket.CONNECTING = oldWS.CONNECTING;
+            WebSocket.CLOSING = oldWS.CLOSING;
+            WebSocket.CLOSED = oldWS.CLOSED;
 
             WebSocket.prototype.binaryType = 'arraybuffer';
         });
@@ -306,30 +306,30 @@ describe('Websock', function () {
                 expect(sock._websocket.close).not.to.have.been.called;
             });
 
-            it('should reset onmessage to not call _recv_message', function () {
-                sinon.spy(sock, '_recv_message');
+            it('should reset onmessage to not call _recvMessage', function () {
+                sinon.spy(sock, '_recvMessage');
                 sock.close();
                 sock._websocket.onmessage(null);
                 try {
-                    expect(sock._recv_message).not.to.have.been.called;
+                    expect(sock._recvMessage).not.to.have.been.called;
                 } finally {
-                    sock._recv_message.restore();
+                    sock._recvMessage.restore();
                 }
             });
         });
 
         describe('event handlers', function () {
             beforeEach(function () {
-                sock._recv_message = sinon.spy();
+                sock._recvMessage = sinon.spy();
                 sock.on('open', sinon.spy());
                 sock.on('close', sinon.spy());
                 sock.on('error', sinon.spy());
                 sock.open('ws://');
             });
 
-            it('should call _recv_message on a message', function () {
+            it('should call _recvMessage on a message', function () {
                 sock._websocket.onmessage(null);
-                expect(sock._recv_message).to.have.been.calledOnce;
+                expect(sock._recvMessage).to.have.been.calledOnce;
             });
 
             it('should call the open event handler on opening', function () {
@@ -350,7 +350,7 @@ describe('Websock', function () {
 
         after(function () {
             // eslint-disable-next-line no-global-assign
-            WebSocket = old_WS;
+            WebSocket = oldWS;
         });
     });
 
@@ -358,13 +358,13 @@ describe('Websock', function () {
         let sock;
         beforeEach(function () {
             sock = new Websock();
-            sock._allocate_buffers();
+            sock._allocateBuffers();
         });
 
         it('should support adding binary Uint8Array data to the receive queue', function () {
             const msg = { data: new Uint8Array([1, 2, 3]) };
             sock._mode = 'binary';
-            sock._recv_message(msg);
+            sock._recvMessage(msg);
             expect(sock.rQshiftStr(3)).to.equal('\x01\x02\x03');
         });
 
@@ -372,7 +372,7 @@ describe('Websock', function () {
             sock._eventHandlers.message = sinon.spy();
             const msg = { data: new Uint8Array([1, 2, 3]).buffer };
             sock._mode = 'binary';
-            sock._recv_message(msg);
+            sock._recvMessage(msg);
             expect(sock._eventHandlers.message).to.have.been.calledOnce;
         });
 
@@ -380,7 +380,7 @@ describe('Websock', function () {
             sock._eventHandlers.message = sinon.spy();
             const msg = { data: new Uint8Array([]).buffer };
             sock._mode = 'binary';
-            sock._recv_message(msg);
+            sock._recvMessage(msg);
             expect(sock._eventHandlers.message).not.to.have.been.called;
         });
 
@@ -391,7 +391,7 @@ describe('Websock', function () {
             sock.rQi = 6;
             const msg = { data: new Uint8Array([1, 2, 3]).buffer };
             sock._mode = 'binary';
-            sock._recv_message(msg);
+            sock._recvMessage(msg);
             expect(sock._rQlen).to.equal(0);
             expect(sock.rQi).to.equal(0);
         });
@@ -403,7 +403,7 @@ describe('Websock', function () {
             sock.rQi = 10;
             const msg = { data: new Uint8Array([1, 2]).buffer };
             sock._mode = 'binary';
-            sock._recv_message(msg);
+            sock._recvMessage(msg);
             expect(sock._rQlen).to.equal(12);
             expect(sock.rQi).to.equal(0);
         });
@@ -415,7 +415,7 @@ describe('Websock', function () {
             sock._rQbufferSize = 20;
             const msg = { data: new Uint8Array(30).buffer };
             sock._mode = 'binary';
-            sock._recv_message(msg);
+            sock._recvMessage(msg);
             expect(sock._rQlen).to.equal(30);
             expect(sock.rQi).to.equal(0);
             expect(sock._rQ.length).to.equal(240);  // keep the invariant that rQbufferSize / 8 >= rQlen
@@ -428,7 +428,7 @@ describe('Websock', function () {
             sock._rQbufferSize = 20;
             const msg = { data: new Uint8Array(6).buffer };
             sock._mode = 'binary';
-            sock._recv_message(msg);
+            sock._recvMessage(msg);
             expect(sock._rQlen).to.equal(6);
             expect(sock.rQi).to.equal(0);
             expect(sock._rQ.length).to.equal(48);
@@ -450,7 +450,7 @@ describe('Websock', function () {
             it('should only send the send queue up to the send queue length', function () {
                 sock._sQ = new Uint8Array([1, 2, 3, 4, 5]);
                 sock._sQlen = 3;
-                const res = sock._encode_message();
+                const res = sock._encodeMessage();
                 expect(res).to.array.equal(new Uint8Array([1, 2, 3]));
             });
 

--- a/tests/test.websock.js
+++ b/tests/test.websock.js
@@ -456,7 +456,7 @@ describe('Websock', function () {
 
             it('should properly pass the encoded data off to the actual WebSocket', function () {
                 sock.send([1, 2, 3]);
-                expect(sock._websocket._get_sent_data()).to.array.equal(new Uint8Array([1, 2, 3]));
+                expect(sock._websocket._getSentData()).to.array.equal(new Uint8Array([1, 2, 3]));
             });
         });
     });

--- a/utils/genkeysymdef.js
+++ b/utils/genkeysymdef.js
@@ -9,14 +9,14 @@
 
 const fs = require('fs');
 
-let show_help = process.argv.length === 2;
+let showHelp = process.argv.length === 2;
 let filename;
 
 for (let i = 2; i < process.argv.length; ++i) {
     switch (process.argv[i]) {
         case "--help":
         case "-h":
-            show_help = true;
+            showHelp = true;
             break;
         case "--file":
         case "-f":
@@ -26,11 +26,11 @@ for (let i = 2; i < process.argv.length; ++i) {
 }
 
 if (!filename) {
-    show_help = true;
+    showHelp = true;
     console.log("Error: No filename specified\n");
 }
 
-if (show_help) {
+if (showHelp) {
     console.log("Parses a *nix keysymdef.h to generate Unicode code point mappings");
     console.log("Usage: node parse.js [options] filename:");
     console.log("  -h [ --help ]                 Produce this help message");

--- a/utils/use_require_helpers.js
+++ b/utils/use_require_helpers.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 // util.promisify requires Node.js 8.x, so we have our own
 function promisify(original) {
-    return function promise_wrap() {
+    return function promiseWrap() {
         const args = Array.prototype.slice.call(arguments);
         return new Promise((resolve, reject) => {
             original.apply(this, args.concat((err, value) => {
@@ -19,39 +19,39 @@ const writeFile = promisify(fs.writeFile);
 
 module.exports = {
     'amd': {
-        appWriter: (base_out_path, script_base_path, out_path) => {
+        appWriter: (baseOutPath, scriptBasePath, outPath) => {
             // setup for requirejs
-            const ui_path = path.relative(base_out_path,
-                                          path.join(script_base_path, 'app', 'ui'));
-            return writeFile(out_path, `requirejs(["${ui_path}"], function (ui) {});`)
+            const uiPath = path.relative(baseOutPath,
+                                         path.join(scriptBasePath, 'app', 'ui'));
+            return writeFile(outPath, `requirejs(["${uiPath}"], function (ui) {});`)
                 .then(() => {
-                    console.log(`Please place RequireJS in ${path.join(script_base_path, 'require.js')}`);
-                    const require_path = path.relative(base_out_path,
-                                                       path.join(script_base_path, 'require.js'));
-                    return [ require_path ];
+                    console.log(`Please place RequireJS in ${path.join(scriptBasePath, 'require.js')}`);
+                    const requirePath = path.relative(baseOutPath,
+                                                      path.join(scriptBasePath, 'require.js'));
+                    return [ requirePath ];
                 });
         },
     },
     'commonjs': {
-        appWriter: (base_out_path, script_base_path, out_path) => {
+        appWriter: (baseOutPath, scriptBasePath, outPath) => {
             const browserify = require('browserify');
-            const b = browserify(path.join(script_base_path, 'app/ui.js'), {});
+            const b = browserify(path.join(scriptBasePath, 'app/ui.js'), {});
             return promisify(b.bundle).call(b)
-                .then(buf => writeFile(out_path, buf))
+                .then(buf => writeFile(outPath, buf))
                 .then(() => []);
         },
         removeModules: true,
     },
     'systemjs': {
-        appWriter: (base_out_path, script_base_path, out_path) => {
-            const ui_path = path.relative(base_out_path,
-                                          path.join(script_base_path, 'app', 'ui.js'));
-            return writeFile(out_path, `SystemJS.import("${ui_path}");`)
+        appWriter: (baseOutPath, scriptBasePath, outPath) => {
+            const uiPath = path.relative(baseOutPath,
+                                         path.join(scriptBasePath, 'app', 'ui.js'));
+            return writeFile(outPath, `SystemJS.import("${uiPath}");`)
                 .then(() => {
-                    console.log(`Please place SystemJS in ${path.join(script_base_path, 'system-production.js')}`);
-                    const systemjs_path = path.relative(base_out_path,
-                                                        path.join(script_base_path, 'system-production.js'));
-                    return [ systemjs_path ];
+                    console.log(`Please place SystemJS in ${path.join(scriptBasePath, 'system-production.js')}`);
+                    const systemjsPath = path.relative(baseOutPath,
+                                                       path.join(scriptBasePath, 'system-production.js'));
+                    return [ systemjsPath ];
                 });
         },
     },


### PR DESCRIPTION
Most of our code is written with camelCase naming. Let's standardize on that and enforce it using our linter.