### PR TITLE
Fixing snap package that was broken in the 1.2.0 update:

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 
-snapctl restart novnc.novncsvc
+snapctl restart novnc-unofficial.novncsvc

--- a/snap/local/svc_wrapper.sh
+++ b/snap/local/svc_wrapper.sh
@@ -21,7 +21,7 @@ snapctl get services | jq -c '.[]' | while read service; do # for each service t
     listen_port_valid=$?
     if [ ! $listen_port_valid ] || [ -z "$vnc_host_port" ]; then
         # invalid values mean the service is disabled, do nothing except for printing a message (logged in /var/log/system or systemd journal)
-        echo "novnc: not starting service ${service} with listen_port ${listen_port} and vnc_host_port ${vnc_host_port}"
+        echo "novnc-unofficial: not starting service ${service} with listen_port ${listen_port} and vnc_host_port ${vnc_host_port}"
     else
         # start (and fork with '&') the service using the specified listen port and VNC host:port
         $SNAP/utils/launch.sh --listen $listen_port --vnc $vnc_host_port &

--- a/snap/local/svc_wrapper.sh
+++ b/snap/local/svc_wrapper.sh
@@ -24,6 +24,6 @@ snapctl get services | jq -c '.[]' | while read service; do # for each service t
         echo "novnc: not starting service ${service} with listen_port ${listen_port} and vnc_host_port ${vnc_host_port}"
     else
         # start (and fork with '&') the service using the specified listen port and VNC host:port
-        $SNAP/launch.sh --listen $listen_port --vnc $vnc_host_port &
+        $SNAP/utils/launch.sh --listen $listen_port --vnc $vnc_host_port &
     fi
 done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: novnc
 base: core18 # the base snap is the execution environment for this snap
-version: '@VERSION@'
+version: 1.2.0
 summary: Open Source VNC client using HTML5 (WebSockets, Canvas)
 description: |
   Open Source VNC client using HTML5 (WebSockets, Canvas).
@@ -13,13 +13,17 @@ confinement: strict
 
 parts:
     novnc:
-        source: build/
+        source: https://github.com/novnc/noVNC/archive/v1.2.0.tar.gz
         plugin: dump
         stage-packages:
-            - websockify
             - bash
             - jq
-            - python-numpy
+            - python3-numpy
+            
+    websockify:
+        source: https://github.com/novnc/websockify/archive/v0.9.0.tar.gz
+        plugin: python
+        stage-packages:
             - python3-numpy
 
 hooks:
@@ -28,9 +32,9 @@ hooks:
 
 apps:
     novnc:
-        command: ./launch.sh
+        command: utils/launch.sh
         plugs: [network, network-bind]
     novncsvc:
-        command: ./svc_wrapper.sh
+        command: snap/local/svc_wrapper.sh
         daemon: forking
         plugs: [network, network-bind]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,8 @@ confinement: strict
 parts:
     novnc:
         source: https://github.com/tkedwards/noVNC.git
-        plugin: git
+        source-type: git
+        plugin: dump
         stage-packages:
             - bash
             - jq

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: novnc
+name: novnc-unofficial
 base: core18 # the base snap is the execution environment for this snap
 version: 1.2.0
 summary: Open Source VNC client using HTML5 (WebSockets, Canvas)
@@ -13,15 +13,15 @@ confinement: strict
 
 parts:
     novnc:
-        source: https://github.com/novnc/noVNC/archive/v1.2.0.tar.gz
-        plugin: dump
+        source: https://github.com/tkedwards/noVNC.git
+        plugin: git
         stage-packages:
             - bash
             - jq
-            - python3-numpy
             
     websockify:
-        source: https://github.com/novnc/websockify/archive/v0.9.0.tar.gz
+        source: https://github.com/novnc/websockify.git
+        source-type: git
         plugin: python
         stage-packages:
             - python3-numpy


### PR DESCRIPTION
- Fix path to launch.sh - it's in the utils/ directory, not the top-level
- Version should be '1.2.0', previously it was some variable which looks like it comes from an external build program (this results in the snap being unable to build)
- Source of the novnc part has been fixed to reference the correct release file on github, not a 'build' directory on local machine (not present in the novnc sources)
- Websockify is now built direct from the 0.9.0 release on github. It appears that the version previously used (from the websockify package on Ubuntu) is too old to support 1.2.0 release of novnc (errors: "code 400, message Client must support 'binary' or 'base64' protocol")
- paths to launch.sh and svc_wrapper.sh have been corrected to where they actually are in the novnc sourc from github