### PR TITLE
Support grabbing the pointer with the Pointer Lock API

### DIFF
--- a/app/images/pointer.svg
+++ b/app/images/pointer.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="25"
+   height="25"
+   viewBox="0 0 25 25"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="pointer.svg"
+   inkscape:export-filename="/home/ossman/devel/noVNC/images/keyboard.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#717171"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="6.9841519"
+     inkscape:cy="18.584699"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1403"
+     inkscape:window-x="2560"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:document-rotation="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1027.3622)">
+    <path
+       style="fill:#ffffff;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6.3910823,1030.3965 v 17.497 l 3.5465954,-2.6671 1.5862113,4.1015 4.336661,-1.5752 -1.59331,-4.2624 4.341678,-0.3562 z"
+       id="path879" />
+  </g>
+</svg>

--- a/app/ui.js
+++ b/app/ui.js
@@ -1041,7 +1041,7 @@ const UI = {
         UI.rfb.addEventListener("clipboard", UI.clipboardReceive);
         UI.rfb.addEventListener("bell", UI.bell);
         UI.rfb.addEventListener("desktopname", UI.updateDesktopName);
-        UI.rfb.addEventListener("pointerlock", UI.pointerLockChanged);
+        UI.rfb.addEventListener("inputlock", UI.inputLockChanged);
         UI.rfb.clipViewport = UI.getSetting('view_clip');
         UI.rfb.scaleViewport = UI.getSetting('resize') === 'scale';
         UI.rfb.resizeSession = UI.getSetting('resize') === 'remote';
@@ -1324,7 +1324,7 @@ const UI = {
     },
 
     requestPointerLock() {
-        UI.rfb.requestPointerLock();
+        UI.rfb.requestInputLock({ pointer: true });
     },
 
 /* ------^-------
@@ -1695,8 +1695,8 @@ const UI = {
         document.title = e.detail.name + " - " + PAGE_TITLE;
     },
 
-    pointerLockChanged(e) {
-        if (e.detail.pointerlock) {
+    inputLockChanged(e) {
+        if (e.detail.pointer) {
             document
                 .getElementById("noVNC_pointer_lock_button")
                 .classList.add("noVNC_selected");

--- a/app/ui.js
+++ b/app/ui.js
@@ -1251,6 +1251,7 @@ const UI = {
             document.getElementById('noVNC_fullscreen_button')
                 .classList.remove("noVNC_selected");
         }
+        UI.updatePointerLockButton();
     },
 
 /* ------^-------
@@ -1308,8 +1309,13 @@ const UI = {
 
     updatePointerLockButton() {
         // Only show the button if the pointer lock API is properly supported
+        // AND in fullscreen.
         if (
             UI.connected &&
+            (document.fullscreenElement || // alternative standard method
+             document.mozFullScreenElement || // currently working methods
+             document.webkitFullscreenElement ||
+             document.msFullscreenElement) &&
             (document.pointerLockElement !== undefined ||
                 document.mozPointerLockElement !== undefined)
         ) {

--- a/app/ui.js
+++ b/app/ui.js
@@ -224,6 +224,10 @@ const UI = {
         document.getElementById("noVNC_view_drag_button")
             .addEventListener('click', UI.toggleViewDrag);
 
+        document
+            .getElementById("noVNC_pointer_lock_button")
+            .addEventListener("click", UI.requestPointerLock);
+
         document.getElementById("noVNC_control_bar_handle")
             .addEventListener('mousedown', UI.controlbarHandleMouseDown);
         document.getElementById("noVNC_control_bar_handle")
@@ -441,6 +445,7 @@ const UI = {
             UI.updatePowerButton();
             UI.keepControlbar();
         }
+        UI.updatePointerLockButton();
 
         // State change closes dialogs as they may not be relevant
         // anymore
@@ -1036,6 +1041,7 @@ const UI = {
         UI.rfb.addEventListener("clipboard", UI.clipboardReceive);
         UI.rfb.addEventListener("bell", UI.bell);
         UI.rfb.addEventListener("desktopname", UI.updateDesktopName);
+        UI.rfb.addEventListener("pointerlock", UI.pointerLockChanged);
         UI.rfb.clipViewport = UI.getSetting('view_clip');
         UI.rfb.scaleViewport = UI.getSetting('resize') === 'scale';
         UI.rfb.resizeSession = UI.getSetting('resize') === 'remote';
@@ -1296,6 +1302,33 @@ const UI = {
 
 /* ------^-------
  * /VIEW CLIPPING
+ * ==============
+ *  POINTER LOCK
+ * ------v------*/
+
+    updatePointerLockButton() {
+        // Only show the button if the pointer lock API is properly supported
+        if (
+            UI.connected &&
+            (document.pointerLockElement !== undefined ||
+                document.mozPointerLockElement !== undefined)
+        ) {
+            document
+                .getElementById("noVNC_pointer_lock_button")
+                .classList.remove("noVNC_hidden");
+        } else {
+            document
+                .getElementById("noVNC_pointer_lock_button")
+                .classList.add("noVNC_hidden");
+        }
+    },
+
+    requestPointerLock() {
+        UI.rfb.requestPointerLock();
+    },
+
+/* ------^-------
+ * /POINTER LOCK
  * ==============
  *    VIEWDRAG
  * ------v------*/
@@ -1660,6 +1693,18 @@ const UI = {
         UI.desktopName = e.detail.name;
         // Display the desktop name in the document title
         document.title = e.detail.name + " - " + PAGE_TITLE;
+    },
+
+    pointerLockChanged(e) {
+        if (e.detail.pointerlock) {
+            document
+                .getElementById("noVNC_pointer_lock_button")
+                .classList.add("noVNC_selected");
+        } else {
+            document
+                .getElementById("noVNC_pointer_lock_button")
+                .classList.remove("noVNC_selected");
+        }
     },
 
     bell(e) {

--- a/core/encodings.js
+++ b/core/encodings.js
@@ -28,6 +28,7 @@ export const encodings = {
     pseudoEncodingCompressLevel9: -247,
     pseudoEncodingCompressLevel0: -256,
     pseudoEncodingVMwareCursor: 0x574d5664,
+    pseudoEncodingVMwareCursorPosition: 0x574d5666,
     pseudoEncodingExtendedClipboard: 0xc0a1e5ce
 };
 

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -170,6 +170,7 @@ export default class RFB extends EventTargetMixin {
             windowResize: this._windowResize.bind(this),
             handleMouse: this._handleMouse.bind(this),
             handlePointerLockChange: this._handlePointerLockChange.bind(this),
+            handlePointerLockError: this._handlePointerLockError.bind(this),
             handleWheel: this._handleWheel.bind(this),
             handleGesture: this._handleGesture.bind(this),
         };
@@ -479,12 +480,22 @@ export default class RFB extends EventTargetMixin {
         this._canvas.blur();
     }
 
-    requestPointerLock() {
-        if (this._canvas.requestPointerLock) {
-            this._canvas.requestPointerLock();
-        } else if (this._canvas.mozRequestPointerLock) {
-            this._canvas.mozRequestPointerLock();
+    requestInputLock(locks) {
+        if (locks.pointer) {
+            if (this._canvas.requestPointerLock) {
+                this._canvas.requestPointerLock();
+                return;
+            }
+            if (this._canvas.mozRequestPointerLock) {
+                this._canvas.mozRequestPointerLock();
+                return;
+            }
         }
+        // If we were not able to request any lock, still let the user know
+        // about the result.
+        this.dispatchEvent(new CustomEvent(
+            "inputlock",
+            { detail: { pointer: this._pointerLock }, }));
     }
 
     clipboardPasteFrom(text) {
@@ -549,8 +560,14 @@ export default class RFB extends EventTargetMixin {
         // preventDefault() on mousedown doesn't stop this event for some
         // reason so we have to explicitly block it
         this._canvas.addEventListener('contextmenu', this._eventHandlers.handleMouse);
-        // This needs to be installed in document instead of the canvas.
-        document.addEventListener('pointerlockchange', this._eventHandlers.handlePointerLockChange);
+        // Pointer Lock listeners need to be installed in document instead of the canvas.
+        if (document.onpointerlockchange !== undefined) {
+            document.addEventListener('pointerlockchange', this._eventHandlers.handlePointerLockChange, false);
+            document.addEventListener('pointerlockerror', this._eventHandlers.handlePointerLockError, false);
+        } else if (document.onmozpointerlockchange !== undefined) {
+            document.addEventListener('mozpointerlockchange', this._eventHandlers.handlePointerLockChange, false);
+            document.addEventListener('mozpointerlockerror', this._eventHandlers.handlePointerLockError, false);
+        }
 
         // Wheel events
         this._canvas.addEventListener("wheel", this._eventHandlers.handleWheel);
@@ -575,7 +592,13 @@ export default class RFB extends EventTargetMixin {
         this._canvas.removeEventListener('mousemove', this._eventHandlers.handleMouse);
         this._canvas.removeEventListener('click', this._eventHandlers.handleMouse);
         this._canvas.removeEventListener('contextmenu', this._eventHandlers.handleMouse);
-        document.removeEventListener('pointerlockchange', this._eventHandlers.handlePointerLockChange);
+        if (document.onpointerlockchange !== undefined) {
+            document.removeEventListener('pointerlockchange', this._eventHandlers.handlePointerLockChange);
+            document.removeEventListener('pointerlockerror', this._eventHandlers.handlePointerLockError);
+        } else if (document.onmozpointerlockchange !== undefined) {
+            document.removeEventListener('mozpointerlockchange', this._eventHandlers.handlePointerLockChange);
+            document.removeEventListener('mozpointerlockerror', this._eventHandlers.handlePointerLockError);
+        }
         this._canvas.removeEventListener("mousedown", this._eventHandlers.focusCanvas);
         this._canvas.removeEventListener("touchstart", this._eventHandlers.focusCanvas);
         window.removeEventListener('resize', this._eventHandlers.windowResize);
@@ -1031,8 +1054,14 @@ export default class RFB extends EventTargetMixin {
             this._cursor.setEmulateCursor(false);
         }
         this.dispatchEvent(new CustomEvent(
-            "pointerlock",
-            { detail: { pointerlock: this._pointerLock }, }));
+            "inputlock",
+            { detail: { pointer: this._pointerLock }, }));
+    }
+
+    _handlePointerLockError() {
+        this.dispatchEvent(new CustomEvent(
+            "inputlock",
+            { detail: { pointer: this._pointerLock }, }));
     }
 
     _sendMouse(x, y, mask) {

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -914,6 +914,7 @@ export default class RFB extends EventTargetMixin {
             } else if (pos.y > this._fbHeight) {
                 pos.y = this._fbHeight;
             }
+            this._cursor.move(pos.x, pos.y);
         } else {
             pos = clientToElement(ev.clientX, ev.clientY,
                                   this._canvas);
@@ -1024,8 +1025,10 @@ export default class RFB extends EventTargetMixin {
             document.mozPointerLockElement === this._canvas
         ) {
             this._pointerLock = true;
+            this._cursor.setEmulateCursor(true);
         } else {
             this._pointerLock = false;
+            this._cursor.setEmulateCursor(false);
         }
         this.dispatchEvent(new CustomEvent(
             "pointerlock",

--- a/docs/API.md
+++ b/docs/API.md
@@ -113,6 +113,10 @@ protocol stream.
   - The `capabilities` event is fired when `RFB.capabilities` is
     updated.
 
+[`pointerlock`](#pointerlock)
+  - The `pointerlock` event is fired when the Pointer Lock is acquired (or
+    released) by the canvas.
+
 ### Methods
 
 [`RFB.disconnect()`](#rfbdisconnect)
@@ -145,6 +149,9 @@ protocol stream.
 
 [`RFB.clipboardPasteFrom()`](#rfbclipboardPasteFrom)
   - Send clipboard contents to server.
+
+[`RFB.requestPointerLock()`](#rfbrequestPointerLock)
+  - Requests that the RFB canvas acquire a Pointer Lock.
 
 ### Details
 
@@ -261,6 +268,15 @@ which is a `DOMString` specifying the new name.
 The `capabilities` event is fired whenever an entry is added or removed
 from `RFB.capabilities`. The `detail` property is an `Object` with the
 property `capabilities` containing the new value of `RFB.capabilities`.
+
+#### pointerlock
+
+The `pointerlock` event is fired when the state of the canvas' Pointer Lock has
+changed, either because it has successfully acquired the lock and will have
+full control of the mouse pointer, or because the lock was released by the user
+pressing the ESC key or performing a browser-specific gesture. The `detail`
+property is an `Object` with the property `pointerlock` containing whether the
+lock is currently held or not.
 
 #### RFB.disconnect()
 
@@ -383,3 +399,19 @@ to the remote server.
 
 **`text`**
   - A `DOMString` specifying the clipboard data to send.
+
+#### RFB.requestPointerLock()
+
+The `RFB.requestPointerLock()` method is used to request that the RFB canvas
+hold a [Pointer
+Lock](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API), which
+hides the mouse cursor and provides relative motion events. This must be called
+directly from an event handler where a user has directly interacted with the
+browser for the browser to allow this.
+
+If the acquisition of the pointer lock is successful, a `pointerlock` event
+will be fired.
+
+##### Syntax
+
+    RFB.requestPointerLock( );

--- a/docs/API.md
+++ b/docs/API.md
@@ -113,9 +113,9 @@ protocol stream.
   - The `capabilities` event is fired when `RFB.capabilities` is
     updated.
 
-[`pointerlock`](#pointerlock)
-  - The `pointerlock` event is fired when the Pointer Lock is acquired (or
-    released) by the canvas.
+[`inputlock`](#inputlock)
+  - The `inputlock` event is fired when an input lock is acquired (or released)
+    by the canvas.
 
 ### Methods
 
@@ -150,8 +150,8 @@ protocol stream.
 [`RFB.clipboardPasteFrom()`](#rfbclipboardPasteFrom)
   - Send clipboard contents to server.
 
-[`RFB.requestPointerLock()`](#rfbrequestPointerLock)
-  - Requests that the RFB canvas acquire a Pointer Lock.
+[`RFB.requestInputLock()`](#rfbrequestInputLock)
+  - Requests that the RFB canvas acquire an input lock.
 
 ### Details
 
@@ -269,14 +269,14 @@ The `capabilities` event is fired whenever an entry is added or removed
 from `RFB.capabilities`. The `detail` property is an `Object` with the
 property `capabilities` containing the new value of `RFB.capabilities`.
 
-#### pointerlock
+#### inputlock
 
-The `pointerlock` event is fired when the state of the canvas' Pointer Lock has
-changed, either because it has successfully acquired the lock and will have
-full control of the mouse pointer, or because the lock was released by the user
-pressing the ESC key or performing a browser-specific gesture. The `detail`
-property is an `Object` with the property `pointerlock` containing whether the
-lock is currently held or not.
+The `inputlock` event is fired after a request to acquire an input lock or
+whenever the state of the canvas' input lock has changed, the latter typically
+occurs because the lock was released by the user pressing the ESC key or
+performing a browser-specific gesture.  The `detail` property is an `Object`
+with the property `pointer` containing whether the Pointer Lock is currently
+held or not.
 
 #### RFB.disconnect()
 
@@ -400,18 +400,23 @@ to the remote server.
 **`text`**
   - A `DOMString` specifying the clipboard data to send.
 
-#### RFB.requestPointerLock()
+#### RFB.requestInputLock()
 
-The `RFB.requestPointerLock()` method is used to request that the RFB canvas
-hold a [Pointer
-Lock](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API), which
-hides the mouse cursor and provides relative motion events. This must be called
-directly from an event handler where a user has directly interacted with the
-browser for the browser to allow this.
-
-If the acquisition of the pointer lock is successful, a `pointerlock` event
-will be fired.
+The `RFB.requestInputLock()` method is used to request that the RFB canvas hold
+an input lock. An `inputlock` event will be fired with the result of the
+acquisition of the requested locks.
 
 ##### Syntax
 
-    RFB.requestPointerLock( );
+    RFB.requestInputLock( { pointer: true } );
+
+###### Parameters
+
+**`pointer`**
+  - Requests to acquire a [Pointer
+    Lock](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API),
+    which hides the local mouse cursor and provides relative motion events.
+    This must be called directly from an event handler where a user has
+    directly interacted with an element through an [engagement
+    gesture](https://w3c.github.io/pointerlock/#dfn-engagement-gesture) (e.g. a
+    click or touch event) for the browser to allow this.

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -2683,14 +2683,14 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 client._resize(100, 100);
 
                 const spy = sinon.spy();
-                client.addEventListener("pointerlock", spy);
+                client.addEventListener("inputlock", spy);
                 let stub = sinon.stub(document, 'pointerLockElement');
                 stub.get(function () { return client._canvas; });
                 client._handlePointerLockChange();
                 stub.restore();
                 client._sock._websocket._receiveData(new Uint8Array([0x02, 0x02]));
                 expect(spy).to.have.been.calledOnce;
-                expect(spy.args[0][0].detail.pointerlock).to.be.true;
+                expect(spy.args[0][0].detail.pointer).to.be.true;
 
                 const cursorSpy = sinon.spy(client, '_handleVMwareCursorPosition');
                 client._sock._websocket._receiveData(new Uint8Array(incoming));

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -2514,6 +2514,27 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 client._canvas.dispatchEvent(ev);
             }
 
+            function supportsSendMouseMovementEvent() {
+                // Some browsers (like Safari) support the movementX /
+                // movementY properties of MouseEvent, but do not allow creation
+                // of non-trusted events with those properties.
+                let ev;
+
+                ev = new MouseEvent('mousemove',
+                                    { 'movementX': 100,
+                                      'movementY': 100 });
+                return ev.movementX === 100 && ev.movementY === 100;
+            }
+
+            function sendMouseMovementEvent(dx, dy) {
+                let ev;
+
+                ev = new MouseEvent('mousemove',
+                                    { 'movementX': dx,
+                                      'movementY': dy });
+                client._canvas.dispatchEvent(ev);
+            }
+
             function sendMouseButtonEvent(x, y, down, button) {
                 let pos = elementToClient(x, y);
                 let ev;
@@ -2625,6 +2646,62 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
                 expect(pointerEvent).to.have.been.calledOnceWith(client._sock,
                                                                  50, 70, 0x0);
+            });
+
+            it('should ignore remote cursor position updates', function () {
+                if (!supportsSendMouseMovementEvent()) {
+                    this.skip();
+                    return;
+                }
+                // Simple VMware Cursor Position FBU message with pointer coordinates
+                // (50, 50).
+                const incoming = [ 0x00, 0x00, 0x00, 0x01, 0x00, 0x32, 0x00, 0x32,
+                                   0x00, 0x00, 0x00, 0x00, 0x57, 0x4d, 0x56, 0x66 ];
+                client._resize(100, 100);
+
+                const cursorSpy = sinon.spy(client, '_handleVMwareCursorPosition');
+                client._sock._websocket._receiveData(new Uint8Array(incoming));
+                expect(cursorSpy).to.have.been.calledOnceWith();
+                cursorSpy.restore();
+
+                expect(client._mousePos).to.deep.equal({ });
+                sendMouseMoveEvent(10, 10);
+                clock.tick(100);
+                expect(pointerEvent).to.have.been.calledOnceWith(client._sock,
+                                                                 10, 10, 0x0);
+            });
+
+            it('should handle remote mouse position updates in pointer lock mode', function () {
+                if (!supportsSendMouseMovementEvent()) {
+                    this.skip();
+                    return;
+                }
+                // Simple VMware Cursor Position FBU message with pointer coordinates
+                // (50, 50).
+                const incoming = [ 0x00, 0x00, 0x00, 0x01, 0x00, 0x32, 0x00, 0x32,
+                                   0x00, 0x00, 0x00, 0x00, 0x57, 0x4d, 0x56, 0x66 ];
+                client._resize(100, 100);
+
+                const spy = sinon.spy();
+                client.addEventListener("pointerlock", spy);
+                let stub = sinon.stub(document, 'pointerLockElement');
+                stub.get(function () { return client._canvas; });
+                client._handlePointerLockChange();
+                stub.restore();
+                client._sock._websocket._receiveData(new Uint8Array([0x02, 0x02]));
+                expect(spy).to.have.been.calledOnce;
+                expect(spy.args[0][0].detail.pointerlock).to.be.true;
+
+                const cursorSpy = sinon.spy(client, '_handleVMwareCursorPosition');
+                client._sock._websocket._receiveData(new Uint8Array(incoming));
+                expect(cursorSpy).to.have.been.calledOnceWith();
+                cursorSpy.restore();
+
+                expect(client._mousePos).to.deep.equal({ x: 50, y: 50 });
+                sendMouseMovementEvent(10, 10);
+                clock.tick(100);
+                expect(pointerEvent).to.have.been.calledOnceWith(client._sock,
+                                                                 60, 60, 0x0);
             });
 
             describe('Event Aggregation', function () {

--- a/vnc.html
+++ b/vnc.html
@@ -79,6 +79,11 @@
                 id="noVNC_view_drag_button" class="noVNC_button noVNC_hidden"
                 title="Move/Drag Viewport">
 
+            <!-- Lock pointer events -->
+            <input type="image" alt="Lock pointer" src="app/images/pointer.svg"
+                id="noVNC_pointer_lock_button" class="noVNC_button noVNC_hidden"
+                title="Lock pointer">
+
             <!--noVNC Touch Device only buttons-->
             <div id="noVNC_mobile_buttons">
                 <input type="image" alt="Keyboard" src="app/images/keyboard.svg"


### PR DESCRIPTION
This change adds the following:

a) A new button on the UI to enter full pointer lock mode, which invokes
   the Pointer Lock API[1] on the canvas, which hides the cursor and
   makes mouse events provide relative motion from the previous event
   (through `movementX` and `movementY`). These can be added to the
   previously-known mouse position to convert it back to an absolute
   position.
b) Adds support for the VMware Cursor Position pseudo-encoding[2], which
   servers can use when they make cursor position changes themselves.
   This is done by some APIs like SDL, when they detect that the client
   does not support relative mouse movement[3] and then "warp"[4] the
   cursor to the center of the window, to calculate the relative mouse
   motion themselves.
c) When the canvas is in pointer lock mode and the cursor is not being
   locally displayed, it updates the cursor position with the
   information that the server sends, since the actual position of the
   cursor does not matter locally anymore, since it's not visible.
d) Adds some tests for the above.

You can try this out end-to-end with TigerVNC with
https://github.com/TigerVNC/tigervnc/pull/1198 applied!

Fixes: #1493 under some circumstances (at least all SDL games would now
work).

1: https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API
2: https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#vmware-cursor-position-pseudo-encoding
3: https://hg.libsdl.org/SDL/file/28e3b60e2131/src/events/SDL_mouse.c#l804
4: https://tronche.com/gui/x/xlib/input/XWarpPointer.html