### PR TITLE
Added support for RTCDataChannel

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -165,9 +165,9 @@ connection to a specified VNC server.
     existing contents of the `HTMLElement` will be untouched, but new
     elements will be added during the lifetime of the `RFB` object.
 
-**`url`**
+**`urlOrDataChannel`**
   - A `DOMString` specifying the VNC server to connect to. This must be
-    a valid WebSocket URL.
+    a valid WebSocket URL. This can also be a `WebSocket` or `RTCDataChannel`.
 
 **`options`** *Optional*
   - An `Object` specifying extra details about how the connection

--- a/tests/fake.websocket.js
+++ b/tests/fake.websocket.js
@@ -6,6 +6,10 @@ export default class FakeWebSocket {
         this.binaryType = "arraybuffer";
         this.extensions = "";
 
+        this.onerror = null;
+        this.onmessage = null;
+        this.onopen = null;
+
         if (!protocols || typeof protocols === 'string') {
             this.protocol = protocols;
         } else {

--- a/tests/test.websock.js
+++ b/tests/test.websock.js
@@ -254,13 +254,7 @@ describe('Websock', function () {
         beforeEach(function () {
             sock = new Websock();
             // eslint-disable-next-line no-global-assign
-            WebSocket = sinon.spy();
-            WebSocket.OPEN = oldWS.OPEN;
-            WebSocket.CONNECTING = oldWS.CONNECTING;
-            WebSocket.CLOSING = oldWS.CLOSING;
-            WebSocket.CLOSED = oldWS.CLOSED;
-
-            WebSocket.prototype.binaryType = 'arraybuffer';
+            WebSocket = sinon.spy(FakeWebSocket);
         });
 
         describe('opening', function () {
@@ -278,7 +272,7 @@ describe('Websock', function () {
 
         describe('closing', function () {
             beforeEach(function () {
-                sock.open('ws://');
+                sock.open('ws://localhost');
                 sock._websocket.close = sinon.spy();
             });
 
@@ -324,7 +318,7 @@ describe('Websock', function () {
                 sock.on('open', sinon.spy());
                 sock.on('close', sinon.spy());
                 sock.on('error', sinon.spy());
-                sock.open('ws://');
+                sock.open('ws://localhost');
             });
 
             it('should call _recvMessage on a message', function () {


### PR DESCRIPTION
This work is originally by Ryan Castner <castner.rr@gmail.com> and submitted as a PR here https://github.com/novnc/noVNC/pull/1362

Architecturally it is much the same except it doesn't rename a lot of variables to make this more reviewable. It also avoids unrelated changes such as replacing .onclose with an event listener, which caused numerous test failures.

It also adds in ppoffice's fix to initialise the buffers.

Like the original author I don't have enough time available to refactor this project to the new style event listeners.