### PR TITLE
Added details for no-store caching to EMBEDDING.md

### DIFF
--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -83,7 +83,8 @@ browser reuses from its cache). To avoid this issue, the browser must be told
 to always revalidate cached files using conditional requests. The correct
 semantics are achieved via the (confusingly named) `Cache-Control: no-cache`
 header that needs to be provided in the web server responses.
-
+In additon to the `no-cache` header, the `no-store` header can be used to
+ prevent similar caching issues at caching layers above the browser level.
 ### Example Server Configurations
 
 Apache:
@@ -94,12 +95,14 @@ Apache:
     LoadModule headers_module modules/mod_headers.so
 
     # In the <Directory> or <Location> block related to noVNC
-    Header set Cache-Control "no-cache"
+    Header set Cache-Control "no-cache" # Do not cache in browser
+    # Header set Cache-Control "no-cache, no-store" # Request no caching anywhere
 ```
 
 Nginx:
 
 ```
     # In the location block related to noVNC
-    add_header Cache-Control no-cache;
+    add_header Cache-Control no-cache; # Do not cache in browser
+    # add_header Cache-Control no-cache, no-store; # Request no caching anywhere
 ```


### PR DESCRIPTION
Hi there, I saw an update in unraid around `no-cache` headers, and thought the configuration could be improved, and found my way to the EMBEDDING.md file.

# Thinking
If users are using NOVNC across WAN or a reverse proxy/vpn, there may be caching at play beyond browser caching.
In particular this may be useful for Unraids configuration.
Adding a `no-store` Cache-Control header can prevent unintended caching at the ISP level/levels above the browser cache.

Let me know if that sounds reasonable, or if I'm overlooking something. Or if opening a pull request for this is unreasonable/not your process. Thanks for the cool and useful project.