### PR TITLE
Normalize the credentials presence check

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1427,8 +1427,8 @@ export default class RFB extends EventTargetMixin {
 
         // negotiated Plain subtype, server waits for password
         if (this._rfbVeNCryptState == 4) {
-            if (!this._rfbCredentials.username ||
-                !this._rfbCredentials.password) {
+            if (this._rfbCredentials.username === undefined ||
+                this._rfbCredentials.password === undefined) {
                 this.dispatchEvent(new CustomEvent(
                     "credentialsrequired",
                     { detail: { types: ["username", "password"] } }));


### PR DESCRIPTION
Most places that check for the presence / absence of credentials compare
them against `undefined`, except the one for Plain authentication.

This change makes the very last place to use the same pattern (instead
of checking for falsiness) for consistency. Additionally, there are ways
to configure PAM to accept empty passwords, so it's possible for a user
to legitimately send an empty string as password.