### PR TITLE
Fix connection race with existing WebSocket/RTCDatachannel

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -480,6 +480,10 @@ export default class RFB extends EventTargetMixin {
             } catch (e) {
                 this._fail("Error attaching channel (" + e + ")");
             }
+
+            if (this._sock.readyState === 'closed') {
+                this._fail("Cannot use already closed WebSocket/RTCDataChannel");
+            }
         }
 
         // Make our elements part of the page

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -484,6 +484,10 @@ export default class RFB extends EventTargetMixin {
             if (this._sock.readyState === 'closed') {
                 this._fail("Cannot use already closed WebSocket/RTCDataChannel");
             }
+
+            if (this._sock.readyState === 'open') {
+                this._socketOpen();
+            }
         }
 
         // Make our elements part of the page

--- a/core/websock.js
+++ b/core/websock.js
@@ -247,7 +247,7 @@ export default class Websock {
         this._websocket.binaryType = "arraybuffer";
         this._websocket.onmessage = this._recvMessage.bind(this);
 
-        const onOpen = () => {
+        this._websocket.onopen = () => {
             Log.Debug('>> WebSock.onopen');
             if (this._websocket.protocol) {
                 Log.Info("Server choose sub-protocol: " + this._websocket.protocol);
@@ -256,12 +256,6 @@ export default class Websock {
             this._eventHandlers.open();
             Log.Debug("<< WebSock.onopen");
         };
-
-        if (this.readyState === 'open') {
-            onOpen();
-        } else {
-            this._websocket.onopen = onOpen;
-        }
 
         this._websocket.onclose = (e) => {
             Log.Debug(">> WebSock.onclose");

--- a/core/websock.js
+++ b/core/websock.js
@@ -71,6 +71,29 @@ export default class Websock {
     }
 
     // Getters and Setters
+
+    get readyState() {
+        let subState;
+
+        if (this._websocket === null) {
+            return "unused";
+        }
+
+        subState = this._websocket.readyState;
+
+        if (ReadyStates.CONNECTING.includes(subState)) {
+            return "connecting";
+        } else if (ReadyStates.OPEN.includes(subState)) {
+            return "open";
+        } else if (ReadyStates.CLOSING.includes(subState)) {
+            return "closing";
+        } else if (ReadyStates.CLOSED.includes(subState)) {
+            return "closed";
+        }
+
+        return "unknown";
+    }
+
     get sQ() {
         return this._sQ;
     }
@@ -168,7 +191,7 @@ export default class Websock {
     // Send Queue
 
     flush() {
-        if (this._sQlen > 0 && ReadyStates.OPEN.indexOf(this._websocket.readyState) >= 0) {
+        if (this._sQlen > 0 && this.readyState === 'open') {
             this._websocket.send(this._encodeMessage());
             this._sQlen = 0;
         }
@@ -234,9 +257,7 @@ export default class Websock {
             Log.Debug("<< WebSock.onopen");
         };
 
-        // If the readyState cannot be found this defaults to assuming it's not open.
-        const isOpen = ReadyStates.OPEN.indexOf(this._websocket.readyState) >= 0;
-        if (isOpen) {
+        if (this.readyState === 'open') {
             onOpen();
         } else {
             this._websocket.onopen = onOpen;
@@ -257,8 +278,8 @@ export default class Websock {
 
     close() {
         if (this._websocket) {
-            if (ReadyStates.CONNECTING.indexOf(this._websocket.readyState) >= 0 ||
-                ReadyStates.OPEN.indexOf(this._websocket.readyState) >= 0) {
+            if (this.readyState === 'connecting' ||
+                this.readyState === 'open') {
                 Log.Info("Closing WebSocket connection");
                 this._websocket.close();
             }

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -183,6 +183,17 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 expect(attach).to.have.been.calledOnceWithExactly(sock);
             });
 
+            it('should refuse closed WebSocket/RTCDataChannel objects', function () {
+                let sock = new FakeWebSocket('ws://HOST:8675/PATH', []);
+                sock.readyState = WebSocket.CLOSED;
+                const client = new RFB(document.createElement('div'), sock);
+                let callback = sinon.spy();
+                client.addEventListener('disconnect', callback);
+                this.clock.tick();
+                expect(callback).to.have.been.calledOnce;
+                expect(callback.args[0][0].detail.clean).to.be.false;
+            });
+
             it('should report attach problems via event', function () {
                 attach.restore();
                 attach = sinon.stub(Websock.prototype, 'attach');

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -141,12 +141,14 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
     describe('Connecting/Disconnecting', function () {
         describe('#RFB (constructor)', function () {
-            let open;
+            let open, attach;
             beforeEach(function () {
                 open = sinon.spy(Websock.prototype, 'open');
+                attach = sinon.spy(Websock.prototype, 'attach');
             });
             afterEach(function () {
                 open.restore();
+                attach.restore();
             });
 
             it('should not connect from constructor', function () {
@@ -159,6 +161,14 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 new RFB(document.createElement('div'), 'ws://HOST:8675/PATH');
                 this.clock.tick();
                 expect(open).to.have.been.calledOnceWithExactly('ws://HOST:8675/PATH', []);
+            });
+
+            it('should handle WebSocket/RTCDataChannel objects', function () {
+                let sock = new FakeWebSocket('ws://HOST:8675/PATH', []);
+                new RFB(document.createElement('div'), sock);
+                this.clock.tick();
+                expect(open).to.not.have.been.called;
+                expect(attach).to.have.been.calledOnceWithExactly(sock);
             });
         });
 

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -183,6 +183,20 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 expect(attach).to.have.been.calledOnceWithExactly(sock);
             });
 
+            it('should handle already open WebSocket/RTCDataChannel objects', function () {
+                let sock = new FakeWebSocket('ws://HOST:8675/PATH', []);
+                sock._open();
+                const client = new RFB(document.createElement('div'), sock);
+                let callback = sinon.spy();
+                client.addEventListener('disconnect', callback);
+                this.clock.tick();
+                expect(open).to.not.have.been.called;
+                expect(attach).to.have.been.calledOnceWithExactly(sock);
+                // Check if it is ready for some data
+                sock._receiveData(new Uint8Array(['R', 'F', 'B', '0', '0', '3', '0', '0', '8']));
+                expect(callback).to.not.have.been.called;
+            });
+
             it('should refuse closed WebSocket/RTCDataChannel objects', function () {
                 let sock = new FakeWebSocket('ws://HOST:8675/PATH', []);
                 sock.readyState = WebSocket.CLOSED;

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -163,12 +163,37 @@ describe('Remote Frame Buffer Protocol Client', function () {
                 expect(open).to.have.been.calledOnceWithExactly('ws://HOST:8675/PATH', []);
             });
 
+            it('should report connection problems via event', function () {
+                open.restore();
+                open = sinon.stub(Websock.prototype, 'open');
+                open.throws(Error('Failure'));
+                const client = new RFB(document.createElement('div'), 'ws://HOST:8675/PATH');
+                let callback = sinon.spy();
+                client.addEventListener('disconnect', callback);
+                this.clock.tick();
+                expect(callback).to.have.been.calledOnce;
+                expect(callback.args[0][0].detail.clean).to.be.false;
+            });
+
             it('should handle WebSocket/RTCDataChannel objects', function () {
                 let sock = new FakeWebSocket('ws://HOST:8675/PATH', []);
                 new RFB(document.createElement('div'), sock);
                 this.clock.tick();
                 expect(open).to.not.have.been.called;
                 expect(attach).to.have.been.calledOnceWithExactly(sock);
+            });
+
+            it('should report attach problems via event', function () {
+                attach.restore();
+                attach = sinon.stub(Websock.prototype, 'attach');
+                attach.throws(Error('Failure'));
+                let sock = new FakeWebSocket('ws://HOST:8675/PATH', []);
+                const client = new RFB(document.createElement('div'), sock);
+                let callback = sinon.spy();
+                client.addEventListener('disconnect', callback);
+                this.clock.tick();
+                expect(callback).to.have.been.calledOnce;
+                expect(callback.args[0][0].detail.clean).to.be.false;
             });
         });
 

--- a/tests/test.websock.js
+++ b/tests/test.websock.js
@@ -270,6 +270,27 @@ describe('Websock', function () {
             // it('should initialize the event handlers')?
         });
 
+        describe('attaching', function () {
+            it('should attach to an existing open websocket', function () {
+                let ws = new FakeWebSocket('ws://localhost:8675');
+                ws._open();
+                let callback = sinon.spy();
+                sock.on('open', callback);
+                sock.attach(ws);
+                expect(WebSocket).to.not.have.been.called;
+                expect(callback).to.have.been.calledOnce;
+            });
+
+            it('should attach to an existing connecting websocket', function () {
+                let ws = new FakeWebSocket('ws://localhost:8675');
+                let callback = sinon.spy();
+                sock.on('open', callback);
+                sock.attach(ws);
+                expect(WebSocket).to.not.have.been.called;
+                expect(callback).to.not.have.been.called;
+            });
+        });
+
         describe('closing', function () {
             beforeEach(function () {
                 sock.open('ws://localhost');

--- a/tests/test.websock.js
+++ b/tests/test.websock.js
@@ -271,23 +271,10 @@ describe('Websock', function () {
         });
 
         describe('attaching', function () {
-            it('should attach to an existing open websocket', function () {
+            it('should attach to an existing websocket', function () {
                 let ws = new FakeWebSocket('ws://localhost:8675');
-                ws._open();
-                let callback = sinon.spy();
-                sock.on('open', callback);
                 sock.attach(ws);
                 expect(WebSocket).to.not.have.been.called;
-                expect(callback).to.have.been.calledOnce;
-            });
-
-            it('should attach to an existing connecting websocket', function () {
-                let ws = new FakeWebSocket('ws://localhost:8675');
-                let callback = sinon.spy();
-                sock.on('open', callback);
-                sock.attach(ws);
-                expect(WebSocket).to.not.have.been.called;
-                expect(callback).to.not.have.been.called;
             });
         });
 

--- a/tests/test.websock.js
+++ b/tests/test.websock.js
@@ -363,6 +363,93 @@ describe('Websock', function () {
             });
         });
 
+        describe('ready state', function () {
+            it('should be "unused" after construction', function () {
+                let sock = new Websock();
+                expect(sock.readyState).to.equal('unused');
+            });
+
+            it('should be "connecting" if WebSocket is connecting', function () {
+                let sock = new Websock();
+                let ws = new FakeWebSocket();
+                ws.readyState = WebSocket.CONNECTING;
+                sock.attach(ws);
+                expect(sock.readyState).to.equal('connecting');
+            });
+
+            it('should be "open" if WebSocket is open', function () {
+                let sock = new Websock();
+                let ws = new FakeWebSocket();
+                ws.readyState = WebSocket.OPEN;
+                sock.attach(ws);
+                expect(sock.readyState).to.equal('open');
+            });
+
+            it('should be "closing" if WebSocket is closing', function () {
+                let sock = new Websock();
+                let ws = new FakeWebSocket();
+                ws.readyState = WebSocket.CLOSING;
+                sock.attach(ws);
+                expect(sock.readyState).to.equal('closing');
+            });
+
+            it('should be "closed" if WebSocket is closed', function () {
+                let sock = new Websock();
+                let ws = new FakeWebSocket();
+                ws.readyState = WebSocket.CLOSED;
+                sock.attach(ws);
+                expect(sock.readyState).to.equal('closed');
+            });
+
+            it('should be "unknown" if WebSocket state is unknown', function () {
+                let sock = new Websock();
+                let ws = new FakeWebSocket();
+                ws.readyState = 666;
+                sock.attach(ws);
+                expect(sock.readyState).to.equal('unknown');
+            });
+
+            it('should be "connecting" if RTCDataChannel is connecting', function () {
+                let sock = new Websock();
+                let ws = new FakeWebSocket();
+                ws.readyState = 'connecting';
+                sock.attach(ws);
+                expect(sock.readyState).to.equal('connecting');
+            });
+
+            it('should be "open" if RTCDataChannel is open', function () {
+                let sock = new Websock();
+                let ws = new FakeWebSocket();
+                ws.readyState = 'open';
+                sock.attach(ws);
+                expect(sock.readyState).to.equal('open');
+            });
+
+            it('should be "closing" if RTCDataChannel is closing', function () {
+                let sock = new Websock();
+                let ws = new FakeWebSocket();
+                ws.readyState = 'closing';
+                sock.attach(ws);
+                expect(sock.readyState).to.equal('closing');
+            });
+
+            it('should be "closed" if RTCDataChannel is closed', function () {
+                let sock = new Websock();
+                let ws = new FakeWebSocket();
+                ws.readyState = 'closed';
+                sock.attach(ws);
+                expect(sock.readyState).to.equal('closed');
+            });
+
+            it('should be "unknown" if RTCDataChannel state is unknown', function () {
+                let sock = new Websock();
+                let ws = new FakeWebSocket();
+                ws.readyState = 'foobar';
+                sock.attach(ws);
+                expect(sock.readyState).to.equal('unknown');
+            });
+        });
+
         after(function () {
             // eslint-disable-next-line no-global-assign
             WebSocket = oldWS;


### PR DESCRIPTION
New attempt at #1537. Instead of bypassing `setTimeout()` when using an existing object, we instead get rid of the reason for that timeout.

@TimSBSquare , could you test this? I don't have any setup here that uses existing objects.