### PR TITLE
Adding Security & Privacy feature

### DIFF
--- a/app/webutil.js
+++ b/app/webutil.js
@@ -26,13 +26,13 @@ export function initLogging(level) {
 // For privacy (Using a hastag #, the parameters will not be sent to the server)
 // the url can be requested in the following way:
 // https://www.example.com#myqueryparam=myvalue&password=secreatvalue
-// 
+//
 // Even Mixing public and non public parameters will work:
 // https://www.example.com?nonsecretparam=example.com#password=secreatvalue
 export function getQueryVar(name, defVal) {
     "use strict";
     const re = new RegExp('.*[?&]' + name + '=([^&#]*)'),
-        match = ''.concat(document.location.href," ", window.location.hash).match(re);
+        match = ''.concat(document.location.href, " ", window.location.hash).match(re);
     if (typeof defVal === 'undefined') { defVal = null; }
 
     if (match) {

--- a/app/webutil.js
+++ b/app/webutil.js
@@ -20,10 +20,19 @@ export function initLogging(level) {
 }
 
 // Read a query string variable
+// A URL with a query parameter can look like this (But will most probably get logged on the http server):
+// https://www.example.com?myqueryparam=myvalue
+// 
+// For privacy (Using a hastag #, the parameters will not be sent to the server)
+// the url can be requested in the following way:
+// https://www.example.com#myqueryparam=myvalue&password=secreatvalue
+// 
+// Even Mixing public and non public parameters will work:
+// https://www.example.com?nonsecretparam=example.com#password=secreatvalue
 export function getQueryVar(name, defVal) {
     "use strict";
     const re = new RegExp('.*[?&]' + name + '=([^&#]*)'),
-        match = document.location.href.match(re);
+        match = ''.concat(document.location.href," ", window.location.hash).match(re);
     if (typeof defVal === 'undefined') { defVal = null; }
 
     if (match) {

--- a/vnc_lite.html
+++ b/vnc_lite.html
@@ -111,19 +111,18 @@
         function readQueryVariable(name, defaultValue) {
             // A URL with a query parameter can look like this (But will most probably get logged on the http server):
             // https://www.example.com?myqueryparam=myvalue
-            // 
+            //
             // For privacy (Using a hastag #, the parameters will not be sent to the server)
             // the url can be requested in the following way:
             // https://www.example.com#myqueryparam=myvalue&password=secreatvalue
-            // 
+            //
             // Even Mixing public and non public parameters will work:
             // https://www.example.com?nonsecretparam=example.com#password=secreatvalue
-            // 
             //
             // Note that we use location.href instead of location.search
             // because Firefox < 53 has a bug w.r.t location.search
             const re = new RegExp('.*[?&]' + name + '=([^&#]*)'),
-                  match = ''.concat(document.location.href," ", window.location.hash).match(re);
+                  match = ''.concat(document.location.href, " ", window.location.hash).match(re);
 
             if (match) {
                 // We have to decode the URL since want the cleartext value

--- a/vnc_lite.html
+++ b/vnc_lite.html
@@ -109,13 +109,21 @@
         // query string. If the variable isn't defined in the URL
         // it returns the default value instead.
         function readQueryVariable(name, defaultValue) {
-            // A URL with a query parameter can look like this:
+            // A URL with a query parameter can look like this (But will most probably get logged on the http server):
             // https://www.example.com?myqueryparam=myvalue
+            // 
+            // For privacy (Using a hastag #, the parameters will not be sent to the server)
+            // the url can be requested in the following way:
+            // https://www.example.com#myqueryparam=myvalue&password=secreatvalue
+            // 
+            // Even Mixing public and non public parameters will work:
+            // https://www.example.com?nonsecretparam=example.com#password=secreatvalue
+            // 
             //
             // Note that we use location.href instead of location.search
             // because Firefox < 53 has a bug w.r.t location.search
             const re = new RegExp('.*[?&]' + name + '=([^&#]*)'),
-                  match = document.location.href.match(re);
+                  match = ''.concat(document.location.href," ", window.location.hash).match(re);
 
             if (match) {
                 // We have to decode the URL since want the cleartext value


### PR DESCRIPTION

The changes add more privacy and security to noVNC, it allows the user to use the novnc client without logging in the server sensitive parameters like (password/path etc..) by using a hastag # instead of a question mark. It keeps the old method of indicating the parameters but add this extra option.

Examples:
 A URL with a query parameter can look like this (But will most probably get logged on the http server):
 `https://www.example.com?myqueryparam=myvalue`
 
  For privacy (Using a hastag #, the parameters will not be sent to the server)
 the url can be requested in the following way:
 `https://www.example.com#myqueryparam=myvalue&password=secreatvalue`

Even Mixing public and non public parameters will work:
 `https://www.example.com?nonsecretparam=example.com#password=secreatvalue`

thanks