### PR TITLE
Preload status bar images

### DIFF
--- a/vnc.html
+++ b/vnc.html
@@ -50,6 +50,11 @@
     <!-- Stylesheets -->
     <link rel="stylesheet" href="app/styles/base.css">
 
+    <!-- Images that will later appear via CSS -->
+    <link rel="preload" as="image" href="app/images/info.svg">
+    <link rel="preload" as="image" href="app/images/error.svg">
+    <link rel="preload" as="image" href="app/images/warning.svg">
+
     <script src="app/error-handler.js"></script>
     <script type="module" crossorigin="anonymous" src="app/ui.js"></script>
 </head>


### PR DESCRIPTION
These are used via CSS, which means the browser doesn't load them until
an element actually gets those CSS rules. There can be some delay to
this loading which causes visual glitches. By preloading we can make
sure those images are cached and ready when the status bar appears.