### PR TITLE
Test v2 of setup-node in github actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
       - run: npm install
       - run: npm run lint
   html:


### PR DESCRIPTION
It seems our github actions use node v10 which is very old, it doesn't work with new versions of eslint apparently. Ideally we don't want to force a version, so let's see if setting `@v2` helps.