### PR TITLE
Use "Full Screen" instead of "Fullscreen"

### DIFF
--- a/vnc.html
+++ b/vnc.html
@@ -149,9 +149,9 @@
             </div>
 
             <!-- Toggle fullscreen -->
-            <input type="image" alt="Fullscreen" src="app/images/fullscreen.svg"
+            <input type="image" alt="Full Screen" src="app/images/fullscreen.svg"
                 id="noVNC_fullscreen_button" class="noVNC_button noVNC_hidden"
-                title="Fullscreen">
+                title="Full Screen">
 
             <!-- Settings -->
             <input type="image" alt="Settings" src="app/images/settings.svg"


### PR DESCRIPTION
"Fullscreen", or more correctly "Full-screen", refers to the
adjective. In this case, we want the tooltip of the full-screen button to
refer to the noun "Full Screen" as this seems to be the convention.

See:
https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/f/full-screen
https://english.stackexchange.com/questions/162421/fullscreen-or-full-screen
https://ell.stackexchange.com/questions/157952/full-screen-full-screen-or-fullscreen