### PR TITLE
Allow continued reconnect tries

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1133,7 +1133,9 @@ const UI = {
             } else {
                 UI.showStatus(_("Failed to connect to server"), 'error');
             }
-        } else if (UI.getSetting('reconnect', false) === true && !UI.inhibitReconnect) {
+        }
+        // If reconnecting is allowed process it now
+        if (UI.getSetting('reconnect', false) === true && !UI.inhibitReconnect) {
             UI.updateVisualState('reconnecting');
 
             const delay = parseInt(UI.getSetting('reconnect_delay'));


### PR DESCRIPTION
Currently novnc will only retry once (assuming the server is unavailable) and then stop (as the detail from is unclean, usually "failed to connect"). Minor change will continue to reconnect every reconnect_delay seconds until either reconnected or user intervention cancels the attempt.

Enhancement to #747 