### PR TITLE
Add UTF8 support for clipboard

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -490,9 +490,9 @@ export default class RFB extends EventTargetMixin {
             this._clipboardText = text;
             RFB.messages.extendedClipboardNotify(this._sock, [extendedClipboardFormatText]);
         } else {
+            text = encodeUTF8(text);
             let data = new Uint8Array(text.length);
             for (let i = 0; i < text.length; i++) {
-                // FIXME: text can have values outside of Latin1/Uint8
                 data[i] = text.charCodeAt(i);
             }
 


### PR DESCRIPTION
Convert clipboard content to UTF8 before serialization.