### PR TITLE
Wrong MacOS meta key (⌘) keysym

### DIFF
--- a/core/input/domkeytable.js
+++ b/core/input/domkeytable.js
@@ -50,7 +50,7 @@ addLeftRight("Shift", KeyTable.XK_Shift_L, KeyTable.XK_Shift_R);
 // - Symbol
 // - SymbolLock
 // - Hyper
-// - Super
+addLeftRight("Super", KeyTable.XK_Super_L, KeyTable.XK_Super_R);
 
 // 3.3. Whitespace Keys
 

--- a/core/input/domkeytable.js
+++ b/core/input/domkeytable.js
@@ -43,7 +43,7 @@ addStandard("CapsLock", KeyTable.XK_Caps_Lock);
 addLeftRight("Control", KeyTable.XK_Control_L, KeyTable.XK_Control_R);
 // - Fn
 // - FnLock
-addLeftRight("Meta", KeyTable.XK_Super_L, KeyTable.XK_Super_R);
+addLeftRight("Meta", KeyTable.XK_Meta_L, KeyTable.XK_Meta_R);
 addStandard("NumLock", KeyTable.XK_Num_Lock);
 addStandard("ScrollLock", KeyTable.XK_Scroll_Lock);
 addLeftRight("Shift", KeyTable.XK_Shift_L, KeyTable.XK_Shift_R);


### PR DESCRIPTION
Fixes #1696 by correcting `Meta` key in domkeytable and adding `Super` with correct `XK_Super_` keysyms.