### PR TITLE
Allow custom scale values

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -287,6 +287,7 @@ export default class RFB extends EventTargetMixin {
         this._viewOnly = false;
         this._clipViewport = false;
         this._scaleViewport = false;
+        this._customScale = null;
         this._resizeSession = false;
 
         this._showDotCursor = false;
@@ -326,8 +327,19 @@ export default class RFB extends EventTargetMixin {
         this._updateClip();
     }
 
+    get customScale() { return this._customScale; }
+    set customScale(level) {
+        this._customScale = level;
+        if (level) {
+            this.scaleViewport = false;
+        }
+    }
+
     get scaleViewport() { return this._scaleViewport; }
     set scaleViewport(scale) {
+        if (scale) {
+            this.customScale = null;
+        }
         this._scaleViewport = scale;
         // Scaling trumps clipping, so we may need to adjust
         // clipping when enabling or disabling scaling
@@ -742,7 +754,7 @@ export default class RFB extends EventTargetMixin {
 
     _updateScale() {
         if (!this._scaleViewport) {
-            this._display.scale = 1.0;
+            this._display.scale = this._customScale || 1.0;
         } else {
             const size = this._screenSize();
             this._display.autoscale(size.w, size.h);

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -741,6 +741,21 @@ describe('Remote Frame Buffer Protocol Client', function () {
             expect(spy.set).to.have.been.calledWith(false);
         });
 
+        it('should update the custom scale setting when changing the property', function () {
+            client.customScale = 1.5;
+
+            const spy = sinon.spy(client, "customScale", ["set"]);
+
+            client.scaleViewport = false;
+            expect(spy.set).to.not.have.been.called;
+
+            spy.set.resetHistory();
+
+            client.scaleViewport = true;
+            expect(spy.set).to.have.been.calledOnce;
+            expect(spy.set).to.have.been.calledWith(null);
+        });
+
         it('should update the scaling when the container size changes', function () {
             sinon.spy(client._display, "autoscale");
 
@@ -785,6 +800,34 @@ describe('Remote Frame Buffer Protocol Client', function () {
 
             expect(client._display.autoscale).to.not.have.been.called;
         });
+    });
+
+    describe('Custom Scale', function () {
+        let client;
+        beforeEach(function () {
+            client = makeRFB();
+            container.style.width = '70px';
+            container.style.height = '80px';
+            client.scaleViewport = true;
+        });
+
+        it('should update display scale factor when setting the property', function () {
+            const spy = sinon.spy(client._display, "scale", ["set"]);
+            sinon.spy(client._display, "autoscale");
+
+            client.customScale = 1.5;
+            expect(spy.set).to.have.been.calledOnce;
+            expect(spy.set).to.have.been.calledWith(1.5);
+            expect(client._display.autoscale).to.not.have.been.called;
+        });
+
+        it('should not update display scale factor when nullifying the property', function () {
+            const spy = sinon.spy(client._display, "scale", ["set"]);
+
+            client.customScale = null;
+            expect(spy.set).to.not.have.been.called;
+        });
+
     });
 
     describe('Remote resize', function () {


### PR DESCRIPTION
I have a use case for allowing my end user to set a custom scale/zoom level.  Rather than providing only 'fit to window / auto-scale', or 'actual size' (i.e. clipping mode), I'd like to offer them the ability to scale at 1.5x, for example.

The scenario this would help address is that of multiple screens on the remote device. When there are two or more screens being shared simultaneously via VNC, a custom scale would allow the end user to fit just one of those screens in their viewport, by manually matching the height of their targeted remote screen to their own viewport height, via custom scaling.

When using fit-to-window/auto-scale, the multiple screens tend to appear much too small.  Switching to actual size _might_ work out just fine, but depending on the resolution of the remote screens, they may end up much too tall.