### PR TITLE
Mask unsupported clipboard characters

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -492,8 +492,14 @@ export default class RFB extends EventTargetMixin {
         } else {
             let data = new Uint8Array(text.length);
             for (let i = 0; i < text.length; i++) {
-                // FIXME: text can have values outside of Latin1/Uint8
-                data[i] = text.charCodeAt(i);
+                let code = text.charCodeAt(i);
+
+                /* Only ISO 8859-1 is supported */
+                if (code > 0xff) {
+                    code = 0x3f; // '?'
+                }
+
+                data[i] = code;
             }
 
             RFB.messages.clientCutText(this._sock, data);

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -490,16 +490,27 @@ export default class RFB extends EventTargetMixin {
             this._clipboardText = text;
             RFB.messages.extendedClipboardNotify(this._sock, [extendedClipboardFormatText]);
         } else {
-            let data = new Uint8Array(text.length);
-            for (let i = 0; i < text.length; i++) {
-                let code = text.charCodeAt(i);
+            let length, i;
+            let data;
+
+            length = 0;
+            // eslint-disable-next-line no-unused-vars
+            for (let codePoint of text) {
+                length++;
+            }
+
+            data = new Uint8Array(length);
+
+            i = 0;
+            for (let codePoint of text) {
+                let code = codePoint.codePointAt(0);
 
                 /* Only ISO 8859-1 is supported */
                 if (code > 0xff) {
                     code = 0x3f; // '?'
                 }
 
-                data[i] = code;
+                data[i++] = code;
             }
 
             RFB.messages.clientCutText(this._sock, data);

--- a/tests/assertions.js
+++ b/tests/assertions.js
@@ -29,12 +29,6 @@ chai.use(function (_chai, utils) {
 
     _chai.Assertion.addMethod('sent', function (targetData) {
         const obj = this._obj;
-        obj.inspect = () => {
-            const res = { _websocket: obj._websocket, rQi: obj._rQi, _rQ: new Uint8Array(obj._rQ.buffer, 0, obj._rQlen),
-                          _sQ: new Uint8Array(obj._sQ.buffer, 0, obj._sQlen) };
-            res.prototype = obj;
-            return res;
-        };
         const data = obj._websocket._getSentData();
         let same = true;
         if (data.length != targetData.length) {

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -433,6 +433,14 @@ describe('Remote Frame Buffer Protocol Client', function () {
                                                                                new Uint8Array([97, 98, 99]));
                 });
 
+                it('should mask unsupported characters', function () {
+                    client.clipboardPasteFrom('abc€');
+
+                    expect(RFB.messages.clientCutText).to.have.been.calledOnce;
+                    expect(RFB.messages.clientCutText).to.have.been.calledWith(client._sock,
+                                                                               new Uint8Array([97, 98, 99, 63]));
+                });
+
                 it('should send an notify if extended clipboard is supported by server', function () {
                     // Send our capabilities
                     let data = [3, 0, 0, 0];

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -115,6 +115,7 @@ describe('Remote Frame Buffer Protocol Client', function () {
     });
 
     after(function () {
+        Websock.prototype._allocateBuffers = Websock.prototype._oldAllocateBuffers;
         delete Websock.prototype.inspect;
         this.clock.restore();
         window.requestAnimationFrame = raf;

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -111,11 +111,11 @@ describe('Remote Frame Buffer Protocol Client', function () {
         };
 
         // Avoiding printing the entire Websock buffer on errors
-        Websock.prototype.toString = function () { return "[object Websock]"; };
+        Websock.prototype.inspect = function () { return "[object Websock]"; };
     });
 
     after(function () {
-        delete Websock.prototype.toString;
+        delete Websock.prototype.inspect;
         this.clock.restore();
         window.requestAnimationFrame = raf;
         window.ResizeObserver = realObserver;

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -441,6 +441,14 @@ describe('Remote Frame Buffer Protocol Client', function () {
                                                                                new Uint8Array([97, 98, 99, 63]));
                 });
 
+                it('should mask characters, not UTF-16 code points', function () {
+                    client.clipboardPasteFrom('😂');
+
+                    expect(RFB.messages.clientCutText).to.have.been.calledOnce;
+                    expect(RFB.messages.clientCutText).to.have.been.calledWith(client._sock,
+                                                                               new Uint8Array([63]));
+                });
+
                 it('should send an notify if extended clipboard is supported by server', function () {
                     // Send our capabilities
                     let data = [3, 0, 0, 0];


### PR DESCRIPTION
Add a more explicit '?' for characters that the clipboard cannot handle, instead of getting random junk.