### PR TITLE
Don't crash if we can't use localStorage

### DIFF
--- a/tests/test.webutil.js
+++ b/tests/test.webutil.js
@@ -92,6 +92,11 @@ describe('WebUtil', function () {
                     expect(window.localStorage.setItem).to.have.been.calledWithExactly('test', 'value');
                     expect(WebUtil.readSetting('test')).to.equal('value');
                 });
+
+                it('should not crash when local storage save fails', function () {
+                    localStorage.setItem.throws(new DOMException());
+                    expect(WebUtil.writeSetting('test', 'value')).to.not.throw;
+                });
             });
 
             describe('setSetting', function () {
@@ -137,6 +142,11 @@ describe('WebUtil', function () {
                     WebUtil.writeSetting('test', 'something else');
                     expect(WebUtil.readSetting('test')).to.equal('something else');
                 });
+
+                it('should not crash when local storage read fails', function () {
+                    localStorage.getItem.throws(new DOMException());
+                    expect(WebUtil.readSetting('test')).to.not.throw;
+                });
             });
 
             // this doesn't appear to be used anywhere
@@ -144,6 +154,11 @@ describe('WebUtil', function () {
                 it('should remove the setting from local storage', function () {
                     WebUtil.eraseSetting('test');
                     expect(window.localStorage.removeItem).to.have.been.calledWithExactly('test');
+                });
+
+                it('should not crash when local storage remove fails', function () {
+                    localStorage.removeItem.throws(new DOMException());
+                    expect(WebUtil.eraseSetting('test')).to.not.throw;
                 });
             });
         });


### PR DESCRIPTION
Our settings are not a fatal requirement, we can fall back on the default values if they can't be accessed. A scenario where we've seen this happen is when cookies are disabled in the browser. It seems `localStorage` is disabled along with cookies in these settings.

Fixes issue #1577.