### PR TITLE
Fix unrecognized option "p" in busybox ps

### DIFF
--- a/utils/novnc_proxy
+++ b/utils/novnc_proxy
@@ -193,7 +193,7 @@ echo "Starting webserver and WebSockets proxy on port ${PORT}"
 ${WEBSOCKIFY} ${SYSLOG_ARG} ${SSLONLY} --web ${WEB} ${CERT:+--cert ${CERT}} ${KEY:+--key ${KEY}} ${PORT} ${VNC_DEST} ${HEARTBEAT_ARG} ${IDLETIMEOUT_ARG} ${RECORD_ARG} ${TIMEOUT_ARG} ${WEBAUTH_ARG} ${AUTHPLUGIN_ARG} ${AUTHSOURCE_ARG} &
 proxy_pid="$!"
 sleep 1
-if ! ps -p ${proxy_pid} >/dev/null; then
+if [ -z "$proxy_pid" ] || ! ps -eo pid= | grep -w "$proxy_pid" > /dev/null; then
     proxy_pid=
     echo "Failed to start WebSockets proxy"
     exit 1


### PR DESCRIPTION
This will fix
`ps: unrecognized option: p`

on busybox ps (Alpine Linux).

I see that they already made a patch:
https://git.alpinelinux.org/aports/tree/testing/novnc/alpine-specific-launch.js.patch?id=5a37614f7bd6e97952c56e6d221b838fe46fbdaf

Changes in this PR will have both GNU/non-GNU compatibility.

Notes:
The "-e" option is not needed and will be ignored in busybox ps.
Hence it will not cause errors like the "-p" option.
https://github.com/mirror/busybox/blob/master/procps/ps.c#L585