### PR TITLE
Replace JavaScript .noVNC_touch with CSS @media (any-pointer: coarse)

### DIFF
--- a/app/styles/base.css
+++ b/app/styles/base.css
@@ -725,12 +725,9 @@ html {
     font-size: calc(25vw - 30px);
   }
 }
-#noVNC_connect_button {
-  cursor: pointer;
+#noVNC_connect_box {
+  padding: 12px;
 
-  padding: 10px;
-
-  color: white;
   background-color: rgb(110, 132, 163);
   border-radius: 12px;
 
@@ -739,26 +736,26 @@ html {
 
   box-shadow: 6px 6px 0px rgba(0, 0, 0, 0.5);
 }
-#noVNC_connect_button div {
-  margin: 2px;
+#noVNC_connect_box button {
+  width: 100%;
   padding: 5px 30px;
-  border: 1px solid rgb(83, 99, 122);
-  border-bottom-width: 2px;
+
+  cursor: pointer;
+
+  border-color: rgb(83, 99, 122);
   border-radius: 5px;
+
   background: linear-gradient(to top, rgb(110, 132, 163), rgb(99, 119, 147));
+  color: white;
 
   /* This avoids it jumping around when :active */
   vertical-align: middle;
 }
-#noVNC_connect_button div:active {
-  border-bottom-width: 1px;
-  margin-top: 3px;
-}
-:root:not(.noVNC_touch) #noVNC_connect_button div:hover {
+#noVNC_connect_box button:hover {
   background: linear-gradient(to top, rgb(110, 132, 163), rgb(105, 125, 155));
 }
 
-#noVNC_connect_button img {
+#noVNC_connect_box img {
   vertical-align: bottom;
   height: 1.3em;
 }

--- a/app/styles/base.css
+++ b/app/styles/base.css
@@ -321,6 +321,7 @@ html {
 .noVNC_right #noVNC_control_bar.noVNC_open #noVNC_control_bar_handle:after {
   transform: none;
 }
+/* Larger touch area for the handle, used when a touch screen is available */
 #noVNC_control_bar_handle div {
   position: absolute;
   right: -35px;

--- a/app/styles/base.css
+++ b/app/styles/base.css
@@ -22,8 +22,6 @@
 /*
  * State variables (set on :root):
  *
- * noVNC_touch: Device has touch input
- *
  * noVNC_loading: Page is still loading
  * noVNC_connecting: Connecting to server
  * noVNC_reconnecting: Re-establishing a connection
@@ -328,9 +326,12 @@ html {
   top: 0;
   width: 50px;
   height: 100%;
-}
-:root:not(.noVNC_touch) #noVNC_control_bar_handle div {
   display: none;
+}
+@media (any-pointer: coarse) {
+  #noVNC_control_bar_handle div {
+    display: unset;
+  }
 }
 .noVNC_right #noVNC_control_bar_handle div {
   left: -35px;
@@ -414,12 +415,14 @@ html {
 
 /* Android browsers don't properly update hover state if touch events are
  * intercepted, like they are when clicking on the remote screen. */
-:root.noVNC_touch #noVNC_control_bar .noVNC_button:not(:disabled):hover {
-  background-color: transparent;
-}
-:root.noVNC_touch #noVNC_control_bar .noVNC_button.noVNC_selected:not(:disabled):hover {
-  border-color: rgba(0, 0, 0, 0.8);
-  background-color: rgba(0, 0, 0, 0.5);
+@media (any-pointer: coarse) {
+  #noVNC_control_bar .noVNC_button:not(:disabled):hover {
+    background-color: transparent;
+  }
+  #noVNC_control_bar .noVNC_button.noVNC_selected:not(:disabled):hover {
+    border-color: rgba(0, 0, 0, 0.8);
+    background-color: rgba(0, 0, 0, 0.5);
+  }
 }
 
 
@@ -550,8 +553,10 @@ html {
 :root:not(.noVNC_connected) #noVNC_mobile_buttons {
   display: none;
 }
-:root:not(.noVNC_touch) #noVNC_mobile_buttons {
-  display: none;
+@media not (any-pointer: coarse) {
+  :root.noVNC_connected #noVNC_mobile_buttons {
+    display: none;
+  }
 }
 
 /* Extra manual keys */

--- a/app/styles/base.css
+++ b/app/styles/base.css
@@ -389,19 +389,18 @@ html {
   vertical-align: middle;
   border:1px solid rgba(255, 255, 255, 0.2);
   border-radius: 6px;
+  background-color: transparent;
   background-image: unset; /* we don't want the gradiant from input.css */
 }
 #noVNC_control_bar .noVNC_button.noVNC_selected {
   border-color: rgba(0, 0, 0, 0.8);
   background-color: rgba(0, 0, 0, 0.5);
 }
-/* Android browsers don't properly update hover state if touch events are
- * intercepted, like they are when clicking on the remote screen. */
-:root:not(.noVNC_touch) #noVNC_control_bar .noVNC_button.noVNC_selected:not(:disabled):hover {
+#noVNC_control_bar .noVNC_button.noVNC_selected:not(:disabled):hover {
   border-color: rgba(0, 0, 0, 0.4);
   background-color: rgba(0, 0, 0, 0.2);
 }
-:root:not(.noVNC_touch) #noVNC_control_bar .noVNC_button:not(:disabled):hover {
+#noVNC_control_bar .noVNC_button:not(:disabled):hover {
   background-color: rgba(255, 255, 255, 0.2);
 }
 #noVNC_control_bar .noVNC_button:not(:disabled):active {
@@ -411,6 +410,17 @@ html {
 #noVNC_control_bar .noVNC_button.noVNC_hidden {
   display: none !important;
 }
+
+/* Android browsers don't properly update hover state if touch events are
+ * intercepted, like they are when clicking on the remote screen. */
+:root.noVNC_touch #noVNC_control_bar .noVNC_button:not(:disabled):hover {
+  background-color: transparent;
+}
+:root.noVNC_touch #noVNC_control_bar .noVNC_button.noVNC_selected:not(:disabled):hover {
+  border-color: rgba(0, 0, 0, 0.8);
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
 
 /* Panels */
 .noVNC_panel {

--- a/app/styles/input.css
+++ b/app/styles/input.css
@@ -198,18 +198,20 @@ select:hover {
   background-position: calc(100% - 7px), left top;
   background-repeat: no-repeat;
 }
-/* We don't want a hover style after touch input */
-:root.noVNC_touch input[type=button]:hover,
-:root.noVNC_touch input[type=color]:hover,
-:root.noVNC_touch input[type=image]:hover,
-:root.noVNC_touch input[type=reset]:hover,
-:root.noVNC_touch input[type=submit]:hover,
-:root.noVNC_touch input::file-selector-button:hover,
-:root.noVNC_touch button:hover {
-  background-image: var(--bg-gradient);
-}
-:root.noVNC_touch select:hover {
-  background-image: var(--select-arrow), var(--bg-gradient);
+@media (any-pointer: coarse) {
+  /* We don't want a hover style after touch input */
+  input[type=button]:hover,
+  input[type=color]:hover,
+  input[type=image]:hover,
+  input[type=reset]:hover,
+  input[type=submit]:hover,
+  input::file-selector-button:hover,
+  button:hover {
+    background-image: var(--bg-gradient);
+  }
+  select:hover {
+    background-image: var(--select-arrow), var(--bg-gradient);
+  }
 }
 
 /*
@@ -252,14 +254,14 @@ select:disabled,
 textarea:disabled {
   opacity: 0.4;
 }
-:root:not(.noVNC_touch) input[type=button]:disabled,
-:root:not(.noVNC_touch) input[type=color]:disabled,
-:root:not(.noVNC_touch) input[type=image]:disabled,
-:root:not(.noVNC_touch) input[type=reset]:disabled,
-:root:not(.noVNC_touch) input[type=submit]:disabled,
-:root:not(.noVNC_touch) input:disabled::file-selector-button,
-:root:not(.noVNC_touch) button:disabled,
-:root:not(.noVNC_touch) select:disabled {
+input[type=button]:disabled,
+input[type=color]:disabled,
+input[type=image]:disabled,
+input[type=reset]:disabled,
+input[type=submit]:disabled,
+input:disabled::file-selector-button,
+button:disabled,
+select:disabled {
   background-image: var(--bg-gradient);
   border-bottom-width: 2px;
   margin-top: 0;
@@ -267,7 +269,7 @@ textarea:disabled {
 input[type=file]:disabled {
   background-image: none;
 }
-:root:not(.noVNC_touch) select:disabled {
+select:disabled {
   background-image: var(--select-arrow), var(--bg-gradient);
 }
 input[type=image]:disabled {

--- a/app/styles/input.css
+++ b/app/styles/input.css
@@ -180,20 +180,33 @@ input::file-selector-button {
 /*
  * Hover
  */
-:root:not(.noVNC_touch) input[type=button]:hover,
-:root:not(.noVNC_touch) input[type=color]:hover,
-:root:not(.noVNC_touch) input[type=image]:hover,
-:root:not(.noVNC_touch) input[type=reset]:hover,
-:root:not(.noVNC_touch) input[type=submit]:hover,
-:root:not(.noVNC_touch) input::file-selector-button:hover,
-:root:not(.noVNC_touch) button:hover {
+input[type=button]:hover,
+input[type=color]:hover,
+input[type=image]:hover,
+input[type=reset]:hover,
+input[type=submit]:hover,
+input::file-selector-button:hover,
+button:hover {
   background-image: linear-gradient(to top, rgb(255, 255, 255), rgb(250, 250, 250));
 }
-:root:not(.noVNC_touch) select:hover {
+select:hover {
   background-image: var(--select-arrow),
     linear-gradient(to top, rgb(255, 255, 255), rgb(250, 250, 250));
   background-position: calc(100% - 7px), left top;
   background-repeat: no-repeat;
+}
+/* We don't want a hover style after touch input */
+:root.noVNC_touch input[type=button]:hover,
+:root.noVNC_touch input[type=color]:hover,
+:root.noVNC_touch input[type=image]:hover,
+:root.noVNC_touch input[type=reset]:hover,
+:root.noVNC_touch input[type=submit]:hover,
+:root.noVNC_touch input::file-selector-button:hover,
+:root.noVNC_touch button:hover {
+  background-image: var(--bg-gradient);
+}
+:root.noVNC_touch select:hover {
+  background-image: var(--select-arrow), var(--bg-gradient);
 }
 
 /*

--- a/app/styles/input.css
+++ b/app/styles/input.css
@@ -42,6 +42,9 @@ select {
 
   padding-left: 20px;
   padding-right: 20px;
+
+  /* Disable Chrome's touch tap highlight */
+  -webkit-tap-highlight-color: transparent;
 }
 
 /*

--- a/app/styles/input.css
+++ b/app/styles/input.css
@@ -68,13 +68,13 @@ select {
           https://bugzilla.mozilla.org/show_bug.cgi?id=1805406 */
 select:active {
   /* Rotated arrow */
-  --select-arrow: url('data:image/svg+xml;utf8, \
+  background-image: url('data:image/svg+xml;utf8, \
       <svg width="8" height="6" version="1.1" viewBox="0 0 8 6" \
            xmlns="http://www.w3.org/2000/svg" transform="rotate(180)" > \
           <path d="m6.5 1.5 -2.5 3 -2.5 -3 5 0" stroke-width="3" \
                 stroke="rgb(31,31,31)" fill="none" \
                 stroke-linecap="round" stroke-linejoin="round" /> \
-      </svg>');
+      </svg>'), var(--bg-gradient);
 }
 option {
   color: black;

--- a/app/styles/input.css
+++ b/app/styles/input.css
@@ -20,7 +20,8 @@ input, input::file-selector-button, button, select, textarea {
   border: 1px solid rgb(192, 192, 192);
   border-radius: 5px;
   color: black;
-  background-image: linear-gradient(to top, rgb(255, 255, 255) 80%, rgb(240, 240, 240));
+  --bg-gradient: linear-gradient(to top, rgb(255, 255, 255) 80%, rgb(240, 240, 240));
+  background-image: var(--bg-gradient);
 }
 
 /*
@@ -54,8 +55,7 @@ select {
                 stroke="rgb(31,31,31)" fill="none" \
                 stroke-linecap="round" stroke-linejoin="round" /> \
       </svg>');
-  background-image: var(--select-arrow),
-    linear-gradient(to top, rgb(255, 255, 255), rgb(240, 240, 240));
+  background-image: var(--select-arrow), var(--bg-gradient);
   background-position: calc(100% - 7px), left top;
   background-repeat: no-repeat;
   padding-right: calc(2*7px + 8px);
@@ -244,7 +244,7 @@ textarea:disabled {
 :root:not(.noVNC_touch) input:disabled::file-selector-button,
 :root:not(.noVNC_touch) button:disabled,
 :root:not(.noVNC_touch) select:disabled {
-  background-image: linear-gradient(to top, rgb(255, 255, 255), rgb(240, 240, 240));
+  background-image: var(--bg-gradient);
   border-bottom-width: 2px;
   margin-top: 0;
 }
@@ -252,8 +252,7 @@ input[type=file]:disabled {
   background-image: none;
 }
 :root:not(.noVNC_touch) select:disabled {
-  background-image: var(--select-arrow),
-    linear-gradient(to top, rgb(255, 255, 255), rgb(240, 240, 240));
+  background-image: var(--select-arrow), var(--bg-gradient);
 }
 input[type=image]:disabled {
   /* See Firefox bug:

--- a/app/ui.js
+++ b/app/ui.js
@@ -319,7 +319,8 @@ const UI = {
     addConnectionControlHandlers() {
         document.getElementById("noVNC_disconnect_button")
             .addEventListener('click', UI.disconnect);
-        document.getElementById("noVNC_connect_button")
+        document.getElementById("noVNC_connect_box")
+            .getElementsByTagName('button')[0]
             .addEventListener('click', UI.connect);
         document.getElementById("noVNC_cancel_reconnect_button")
             .addEventListener('click', UI.cancelReconnect);

--- a/app/ui.js
+++ b/app/ui.js
@@ -88,7 +88,6 @@ const UI = {
 
         // Adapt the interface for touch screen devices
         if (isTouchDevice) {
-            document.documentElement.classList.add("noVNC_touch");
             // Remove the address bar
             setTimeout(() => window.scrollTo(0, 1), 100);
         }

--- a/vnc.html
+++ b/vnc.html
@@ -274,9 +274,9 @@
     <div class="noVNC_center">
         <div id="noVNC_connect_dlg">
             <div class="noVNC_logo" translate="no"><span>no</span>VNC</div>
-            <div id="noVNC_connect_button"><div>
+            <div id="noVNC_connect_box"><button>
                 <img alt="" src="app/images/connect.svg"> Connect
-            </div></div>
+            </button></div>
         </div>
     </div>
 


### PR DESCRIPTION
Here's some more CSS cleanup. Many parts of the code were relying on the class `root.noVNC_touch`, which was set by the JavaScript. Firstly, this dependency isn't ideal, and secondly, it made many CSS selectors very complex.

Instead, we can use `@media (any-pointer: coarse)` to detect if there is a coarse (not accurate) pointing device available. This basically translates to; if there is a touch screen available. Our testing shows that this method is comparable.

Moreover, here's a 3rd party source where testing results for this media query can be found:

https://patrickhlauke.github.io/touch/pointer-hover-any-pointer-any-hover/results/

Note that this approach still isn't perfect. For example, on Linux, even if a touch screen is plugged in, we still get `False` on `any-pointer: coarse`. Also note that `any-pointer: coarse` isn't the perfect selector to decide if we need to show the on-screen keyboard button or not, but it's the best we got at the moment.