### PR TITLE
Prefix websocket path with server path

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -180,7 +180,7 @@ const UI = {
         UI.initSetting('shared', true);
         UI.initSetting('view_only', false);
         UI.initSetting('show_dot', false);
-        UI.initSetting('path', window.location.pathname.substr(1) + '/../websockify');
+        UI.initSetting('path', window.location.pathname.substring(1) + '/../websockify');
         UI.initSetting('repeaterID', '');
         UI.initSetting('reconnect', false);
         UI.initSetting('reconnect_delay', 5000);

--- a/app/ui.js
+++ b/app/ui.js
@@ -180,7 +180,7 @@ const UI = {
         UI.initSetting('shared', true);
         UI.initSetting('view_only', false);
         UI.initSetting('show_dot', false);
-        UI.initSetting('path', 'websockify');
+        UI.initSetting('path', window.location.pathname.substr(1) + '/../websockify');
         UI.initSetting('repeaterID', '');
         UI.initSetting('reconnect', false);
         UI.initSetting('reconnect_delay', 5000);


### PR DESCRIPTION
Fixes #1737 and it should work for all of the different scenarios where the relative assets also work. This includes, for example:
   - /
   - /vnc.html
   - /vnc/
   - /vnc/vnc.html

It won't work for:
 - /vnc (but the assets don't work either, so it's consistent)
 - /vnc.html/ (but this results in a 404 by default anyway)