### PR TITLE
Add english to list of supported languages

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1762,7 +1762,7 @@ const UI = {
 };
 
 // Set up translations
-const LINGUAS = ["cs", "de", "el", "es", "fr", "it", "ja", "ko", "nl", "pl", "pt_BR", "ru", "sv", "tr", "zh_CN", "zh_TW"];
+const LINGUAS = ["cs", "de", "el", "en", "es", "fr", "it", "ja", "ko", "nl", "pl", "pt_BR", "ru", "sv", "tr", "zh_CN", "zh_TW"];
 l10n.setup(LINGUAS);
 if (l10n.language === "en" || l10n.dictionary !== undefined) {
     UI.prime();


### PR DESCRIPTION
Adds "en" to the list of supported languages so that it can at least get picked up as a language in that "Second Pass: fallback" when translating. 
This is so that it doesn't ignore english in cases where a browser doesn't have "English" or "English-US" as their set language, but have something like "English-Canada" or "English-UK" as their primary language set in their browser.

