### PR TITLE
Remove incorrect RFB protocol version dependency in authentication result

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1962,13 +1962,6 @@ export default class RFB extends EventTargetMixin {
     }
 
     _handleSecurityResult() {
-        // There is no security choice, and hence no security result
-        // until RFB 3.7
-        if (this._rfbVersion < 3.7) {
-            this._rfbInitState = 'ClientInitialisation';
-            return true;
-        }
-
         if (this._sock.rQwait('VNC auth response ', 4)) { return false; }
 
         const status = this._sock.rQshift32();

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1925,7 +1925,7 @@ export default class RFB extends EventTargetMixin {
     _negotiateAuthentication() {
         switch (this._rfbAuthScheme) {
             case securityTypeNone:
-                this._rfbInitState = 'SecurityResult';
+                this._rfbInitState = 'ClientInitialisation';
                 return true;
 
             case securityTypeXVP:


### PR DESCRIPTION
fixes #1773
Reason: RFB protocol specifies a 4 byte authentication result response, independent of the RFB protocol version.