### PR TITLE
Save new expected client size on resize

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -724,6 +724,7 @@ export default class RFB extends EventTargetMixin {
         window.requestAnimationFrame(() => {
             this._updateClip();
             this._updateScale();
+            this._saveExpectedClientSize();
         });
 
         if (this._resizeSession) {

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -776,6 +776,25 @@ describe('Remote Frame Buffer Protocol Client', function () {
             expect(client._display.autoscale).to.have.been.calledWith(40, 50);
         });
 
+        it('should update the scaling when the container returns to previous size', function () {
+            client._saveExpectedClientSize();
+
+            sinon.spy(client._display, "autoscale");
+
+            container.style.width = '40px';
+            container.style.height = '50px';
+            fakeResizeObserver.fire();
+            clock.tick(1000);
+
+            container.style.width = '70px';
+            container.style.height = '80px';
+            fakeResizeObserver.fire();
+            clock.tick(1000);
+
+            expect(client._display.autoscale).to.have.been.calledTwice;
+            expect(client._display.autoscale).to.have.been.calledWith(70, 80);
+        });
+
         it('should update the scaling when the remote session resizes', function () {
             // Simple ExtendedDesktopSize FBU message
             const incoming = [ 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
Hello,

`_handleResize()` doesn't save new expected size if window was resized which cause a bug if window was resized to different size, and then return back to original (e.g. go fullscreen and back to windowed).
Since the expected client size wasn't changed during fullscreen resize, the `_handleResize` would not resize window during resize to original size as it would exit because of `this._clientHasExpectedSize()`.

The PR add save of new expected client size to fix the issue