### PR TITLE
Use history API's replaceState() method to hide query for privacy

### DIFF
--- a/app/webutil.js
+++ b/app/webutil.js
@@ -36,6 +36,7 @@ export function getQueryVar(name, defVal) {
     if (typeof defVal === 'undefined') { defVal = null; }
 
     if (match) {
+        history.replaceState(null, "", window.location.pathname.slice(1, 1));
         return decodeURIComponent(match[1]);
     }
 


### PR DESCRIPTION
For example; you are using autoconnect in your browser and you want to make a screenshot, it wouldn't be so handy-dandy if your VNC password was exposed. 
If my proposal for this change isn't welcome, or if there are any other factors, feel free to close the pull request.