### PR TITLE
Avoid exception when cursor was removed from DOM already

### DIFF
--- a/core/util/cursor.js
+++ b/core/util/cursor.js
@@ -69,7 +69,9 @@ export default class Cursor {
             this._target.removeEventListener('mousemove', this._eventHandlers.mousemove, options);
             this._target.removeEventListener('mouseup', this._eventHandlers.mouseup, options);
 
-            document.body.removeChild(this._canvas);
+            if (document.contains(this._canvas)) {
+                document.body.removeChild(this._canvas);
+            }
         }
 
         this._target = null;


### PR DESCRIPTION
Hi,
we were getting a `NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node` from this call because the cursor had already been removed from the DOM.
This happens in our case because we use noVNC together with [Turbo](https://turbo.hotwired.dev/handbook/introduction). This is a library / framework that replaces parts of the page or the entire document with server side rendered content.

So when leaving the page with the connected noVNC on it, we need to call `rfb.disconnect()` to close the connection, since we remain in the same JS context. By the time we do that, the DOM is already replaced though, so the canvas is no longer in `document` and the error occurs.

Since this line in noVNC is intended to remove the element from the DOM, we argue, that it is not an error if it was not in the DOM in the first place.

Thank you for your time and effort!