### PR TITLE
Add "touchpad mode" with pinch-zoom for mobile view.

### DIFF
--- a/app/images/touchpad.svg
+++ b/app/images/touchpad.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="25"
+   height="25"
+   viewBox="0 0 25 25"
+   version="1.1"
+   id="touchpad"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="touchpad.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     inkscape:document-units="mm"
+     inkscape:zoom="11.588216"
+     inkscape:cx="9.7081384"
+     inkscape:cy="15.921347"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g1">
+      <rect
+         style="fill:none;stroke:#ffffff;stroke-width:1.5;stroke-dasharray:none;stroke-opacity:1"
+         id="rect1"
+         width="20.896252"
+         height="20.896252"
+         x="1.8494672"
+         y="2.1561899"
+         rx="3.3434002"
+         ry="3.3434005" />
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:1.43009;stroke-dasharray:none;stroke-opacity:1"
+         d="m 1.8115321,15.999996 c 21.1096929,0 21.1096929,0 21.1096929,0"
+         id="path1" />
+      <path
+         style="fill:none;stroke:#ffffff;stroke-width:1.5;stroke-dasharray:none;stroke-opacity:1"
+         d="m 12.439821,15.80482 v 7.70143"
+         id="path2" />
+    </g>
+  </g>
+</svg>

--- a/app/styles/base.css
+++ b/app/styles/base.css
@@ -345,7 +345,10 @@ html {
   padding: 0 10px;
 }
 
-#noVNC_control_bar > .noVNC_scroll > * {
+/* Do not apply margin to #noVNC_mobilebuttons div. There is now
+   more than one button inside it, so we'll apply margins directly
+   to the buttons in another rule. */
+#noVNC_control_bar > .noVNC_scroll > *:not(#noVNC_mobile_buttons) {
   display: block;
   margin: 10px auto;
 }
@@ -553,6 +556,12 @@ html {
 :root:not(.noVNC_connected) #noVNC_mobile_buttons {
   display: none;
 }
+
+#noVNC_mobile_buttons > .noVNC_button {
+  display: block;
+  margin: 10px auto;
+}
+
 @media not all and (any-pointer: coarse) {
   /* FIXME: The button for the virtual keyboard is the only button in this
             group of "mobile buttons". It is bad to assume that no touch

--- a/app/ui.js
+++ b/app/ui.js
@@ -232,6 +232,9 @@ const UI = {
         document.getElementById("noVNC_view_drag_button")
             .addEventListener('click', UI.toggleViewDrag);
 
+        document.getElementById("noVNC_touchpad_button")
+            .addEventListener('click', UI.toggleTouchpadMode);
+
         document.getElementById("noVNC_control_bar_handle")
             .addEventListener('mousedown', UI.controlbarHandleMouseDown);
         document.getElementById("noVNC_control_bar_handle")
@@ -1586,11 +1589,34 @@ const UI = {
         }
     },
 
-/* ------^-------
- *   /KEYBOARD
- * ==============
- *   EXTRA KEYS
- * ------v------*/
+    /* ------^-------
+     *  /KEYBOARD
+     * ==============
+     *   TOUCHPAD
+     * ------v------*/
+
+        toggleTouchpadMode() {
+            if (!UI.rfb) return;
+    
+            UI.rfb.touchpadMode = !UI.rfb.touchpadMode;
+            UI.updateTouchpadButton();
+        },
+    
+        updateTouchpadButton() {
+            const touchpadButton = document.getElementById('noVNC_touchpad_button');
+    
+            if (UI.rfb.touchpadMode) {
+                touchpadButton.classList.add("noVNC_selected");
+            } else {
+                touchpadButton.classList.remove("noVNC_selected");
+            }
+        },
+    
+   /* ------^-------
+    *   /TOUCHPAD
+    * ==============
+    *   EXTRA KEYS
+    * ------v------*/
 
     openExtraKeys() {
         UI.closeAllPanels();

--- a/app/ui.js
+++ b/app/ui.js
@@ -465,10 +465,10 @@ const UI = {
     },
 
     /**
-     * @param {string} text 
-     * @param { "normal" | "info" | "warn" | "warning" | "error" } statusType 
-     * @param {number} time 
-     * @returns 
+     * @param {string} text
+     * @param { "normal" | "info" | "warn" | "warning" | "error" } statusType
+     * @param {number} time
+     * @returns
      */
     showStatus(text, statusType, time) {
         const statusElem = document.getElementById('noVNC_status');
@@ -1614,44 +1614,41 @@ const UI = {
      *   TOUCHPAD
      * ------v------*/
 
-        toggleTouchpadMode() {
-            if (!UI.rfb) return;
-    
-            UI.rfb.touchpadMode = !UI.rfb.touchpadMode;
-            WebUtil.writeSetting('touchpad_mode', UI.rfb.touchpadMode);
-            UI.updateTouchpadMode();
-            UI.updateViewDrag();
-        },
-    
-        updateTouchpadMode() {
-            if (UI.rfb.touchpadMode) {
-                UI.rfb.dragViewport = false;
-                
-                UI.forceSetting('resize', 'off');
-                UI.forceSetting('view_clip', true);
-                UI.forceSetting('show_dot', true);
+    toggleTouchpadMode() {
+        if (!UI.rfb) return;
 
-                UI.rfb.clipViewport = true;
-                UI.rfb.scaleViewport = false;
-                UI.rfb.resizeSession = false;
-                UI.rfb.showDotCursor = true;
-            }
-            else {
-                UI.enableSetting('resize');
-                UI.enableSetting('view_clip');
-                UI.enableSetting('show_dot');
-            }
+        UI.rfb.touchpadMode = !UI.rfb.touchpadMode;
+        WebUtil.writeSetting('touchpad_mode', UI.rfb.touchpadMode);
+        UI.updateTouchpadMode();
+        UI.updateViewDrag();
+    },
 
-            UI.updateViewDrag
+    updateTouchpadMode() {
+        if (UI.rfb.touchpadMode) {
+            UI.rfb.dragViewport = false;
 
-            const touchpadButton = document.getElementById('noVNC_touchpad_button');
-            if (UI.rfb.touchpadMode) {
-                touchpadButton.classList.add("noVNC_selected");
-            } else {
-                touchpadButton.classList.remove("noVNC_selected");
-            }
-        },
-    
+            UI.forceSetting('resize', 'off');
+            UI.forceSetting('view_clip', true);
+            UI.forceSetting('show_dot', true);
+
+            UI.rfb.clipViewport = true;
+            UI.rfb.scaleViewport = false;
+            UI.rfb.resizeSession = false;
+            UI.rfb.showDotCursor = true;
+        } else {
+            UI.enableSetting('resize');
+            UI.enableSetting('view_clip');
+            UI.enableSetting('show_dot');
+        }
+
+        const touchpadButton = document.getElementById('noVNC_touchpad_button');
+        if (UI.rfb.touchpadMode) {
+            touchpadButton.classList.add("noVNC_selected");
+        } else {
+            touchpadButton.classList.remove("noVNC_selected");
+        }
+    },
+
    /* ------^-------
     *   /TOUCHPAD
     * ==============

--- a/core/display.js
+++ b/core/display.js
@@ -96,8 +96,8 @@ export default class Display {
     /**
      * Attempt to move the viewport by the specified amounts
      * and returns the amount of actual position change.
-     * @param {number} moveByX 
-     * @param {number} moveByY 
+     * @param {number} moveByX
+     * @param {number} moveByY
      * @return {{ x: number, y: number }}
      */
     viewportTryMoveBy(moveByX, moveByY) {
@@ -105,7 +105,7 @@ export default class Display {
             return {
                 x: 0,
                 y: 0
-            }
+            };
         }
 
         const vpX = this._viewportLoc.x;
@@ -116,7 +116,7 @@ export default class Display {
         return {
             x: this._viewportLoc.x - vpX,
             y: this._viewportLoc.y - vpY
-        }
+        };
     }
 
     viewportChangePos(deltaX, deltaY) {

--- a/core/display.js
+++ b/core/display.js
@@ -87,7 +87,37 @@ export default class Display {
         return this._fbHeight;
     }
 
+    get viewportLocation() {
+        return this._viewportLoc;
+    }
+
     // ===== PUBLIC METHODS =====
+
+    /**
+     * Attempt to move the viewport by the specified amounts
+     * and returns the amount of actual position change.
+     * @param {number} moveByX 
+     * @param {number} moveByY 
+     * @return {{ x: number, y: number }}
+     */
+    viewportTryMoveBy(moveByX, moveByY) {
+        if (moveByX === 0 && moveByY === 0) {
+            return {
+                x: 0,
+                y: 0
+            }
+        }
+
+        const vpX = this._viewportLoc.x;
+        const vpY = this._viewportLoc.y;
+
+        this.viewportChangePos(moveByX, moveByY);
+
+        return {
+            x: this._viewportLoc.x - vpX,
+            y: this._viewportLoc.y - vpY
+        }
+    }
 
     viewportChangePos(deltaX, deltaY) {
         const vp = this._viewportLoc;
@@ -431,6 +461,10 @@ export default class Display {
         }
 
         this._rescale(scaleRatio);
+    }
+
+    rescale(factor) {
+        this._rescale(factor);
     }
 
     // ===== PRIVATE METHODS =====

--- a/core/input/gesturehandler.js
+++ b/core/input/gesturehandler.js
@@ -61,7 +61,7 @@ export default class GestureHandler {
     }
 
     /**
-     * @param {boolean} enabled 
+     * @param {boolean} enabled
      */
     set touchpadMode(enabled) {
         this._touchpadMode = enabled;
@@ -115,8 +115,8 @@ export default class GestureHandler {
     }
 
     /**
-     * 
-     * @param {TouchEvent} e 
+     *
+     * @param {TouchEvent} e
      */
     _eventHandler(e) {
         let fn;
@@ -179,7 +179,7 @@ export default class GestureHandler {
             movementY: 0,
             angle: 0,
         });
-        
+
         switch (this._tracked.length) {
             case 1:
                 this._startLongpressTimeout();
@@ -199,7 +199,7 @@ export default class GestureHandler {
         }
     }
 
-   _touchMove(id, x, y) {
+    _touchMove(id, x, y) {
         let touch = this._tracked.find(t => t.id === id);
 
         // If this is an update for a touch we're not tracking, ignore it
@@ -495,7 +495,7 @@ export default class GestureHandler {
         detail['clientX'] = pos.x;
         detail['clientY'] = pos.y;
 
-        if (this._touchpadMode && 
+        if (this._touchpadMode &&
             this._tracked.length === 1) {
 
             const touch = this._tracked[0];

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -290,6 +290,7 @@ export default class RFB extends EventTargetMixin {
         this._clippingViewport = false;
         this._scaleViewport = false;
         this._resizeSession = false;
+        this.touchpadMode = false;
 
         this._showDotCursor = false;
         if (options.showDotCursor !== undefined) {

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -188,7 +188,7 @@ export default class RFB extends EventTargetMixin {
         this._viewportHasMoved = false;
         this._accumulatedWheelDeltaX = 0;
         this._accumulatedWheelDeltaY = 0;
-        
+
         // Gesture state
         this._gestureLastTapTime = null;
         this._gestureFirstDoubleTapEv = null;
@@ -413,7 +413,7 @@ export default class RFB extends EventTargetMixin {
             this._sendEncodings();
         }
     }
-    
+
     /**
      * @returns {boolean}
      */
@@ -422,7 +422,7 @@ export default class RFB extends EventTargetMixin {
     }
 
     /**
-     * @param {boolean} enabled 
+     * @param {boolean} enabled
      */
     set touchpadMode(enabled) {
         if (!this._gestures) {
@@ -556,7 +556,7 @@ export default class RFB extends EventTargetMixin {
         const container = document.getElementById('noVNC_container');
         const containerBounds = container.getBoundingClientRect();
         const x = containerBounds.left + (containerBounds.width * .5);
-        const y = containerBounds.top + (containerBounds.height * .5)
+        const y = containerBounds.top + (containerBounds.height * .5);
         this._cursor.move(x, y);
 
         const elementPos = clientToElement(x, y, this._canvas);
@@ -1299,8 +1299,7 @@ export default class RFB extends EventTargetMixin {
                     case 'onetap':
                         if (this._touchpadMode) {
                             this._handleTouchpadOneTapEvent();
-                        }
-                        else {
+                        } else {
                             this._handleTapEvent(ev, 0x1);
                         }
                         break;
@@ -1326,12 +1325,12 @@ export default class RFB extends EventTargetMixin {
                         // sequence.
                         if (this._touchpadMode) {
                             if (this._touchpadTapTimeoutId > 0) {
-                                    this._clearTouchpadTapTimeoutId();
-                                    this._isTouchpadDragging = true;
-                                    this._mouseButtonMask = 0x1;
-                                    const cursorPos = this._getCursorPositionToCanvas();
-                                    this._sendMouse(cursorPos.x, cursorPos.y, 0x1);
-                                }
+                                this._clearTouchpadTapTimeoutId();
+                                this._isTouchpadDragging = true;
+                                this._mouseButtonMask = 0x1;
+                                const cursorPos = this._getCursorPositionToCanvas();
+                                this._sendMouse(cursorPos.x, cursorPos.y, 0x1);
+                            }
                             break;
                         }
                         this._fakeMouseMove(ev, pos.x, pos.y);
@@ -1343,8 +1342,7 @@ export default class RFB extends EventTargetMixin {
                         if (this._touchpadMode) {
                             const cursorPos = this._getCursorPositionToCanvas();
                             this._handleMouseButton(cursorPos.x, cursorPos.y, true, 0x4);
-                        }
-                        else {
+                        } else {
                             this._fakeMouseMove(ev, pos.x, pos.y);
                             this._handleMouseButton(pos.x, pos.y, true, 0x4);
                         }
@@ -1382,8 +1380,7 @@ export default class RFB extends EventTargetMixin {
                         // current position, not to where the touch currently is.
                         if (this._touchpadMode) {
                             this._handleTouchpadMove(ev.detail.movementX, ev.detail.movementY);
-                        }
-                        else {
+                        } else {
                             this._fakeMouseMove(ev, pos.x, pos.y);
                         }
                         break;
@@ -1427,7 +1424,7 @@ export default class RFB extends EventTargetMixin {
                         // We don't know if the mouse was moved so we need to move it
                         // every update.
                         this._fakeMouseMove(ev, pos.x, pos.y);
-                     
+
                         if (Math.abs(magnitude - this._gestureLastMagnitudeX) > GESTURE_ZOOMSENS) {
                             this._handleKeyEvent(KeyTable.XK_Control_L, "ControlLeft", true);
                             while ((magnitude - this._gestureLastMagnitudeX) > GESTURE_ZOOMSENS) {
@@ -1472,8 +1469,7 @@ export default class RFB extends EventTargetMixin {
                         if (this._touchpadMode) {
                             const cursorPos = this._getCursorPositionToCanvas();
                             this._handleMouseButton(cursorPos.x, cursorPos.y, false, 0x4);
-                        }
-                        else {
+                        } else {
                             this._fakeMouseMove(ev, pos.x, pos.y);
                             this._handleMouseButton(pos.x, pos.y, false, 0x4);
                         }
@@ -1484,10 +1480,10 @@ export default class RFB extends EventTargetMixin {
     }
 
     // TouchpadMode Private Methods
-       
+
     /**
-     * @param {number} movementX 
-     * @param {number} movementY 
+     * @param {number} movementX
+     * @param {number} movementY
      */
     _handleTouchpadMove(movementX, movementY) {
 
@@ -1511,12 +1507,10 @@ export default class RFB extends EventTargetMixin {
 
         // See if the cursor has moved outside the center deadzone.
         const deadzone = this._getTouchpadCursorDeadZone();
-        const moveViewportX = 
-            Math.min(safeX - deadzone.left, 0) +
+        const moveViewportX = Math.min(safeX - deadzone.left, 0) +
             Math.max(safeX - deadzone.right, 0);
 
-        const moveViewportY =
-            Math.min(safeY - deadzone.top, 0) +
+        const moveViewportY = Math.min(safeY - deadzone.top, 0) +
             Math.max(safeY - deadzone.bottom, 0);
 
         // Try moving the viewport, getting the actual amount it moved.
@@ -1534,8 +1528,8 @@ export default class RFB extends EventTargetMixin {
         const posFromCanvas = clientToElement(safeX, safeY, this._canvas);
         const hotspot = this._cursor.hotspot;
         this._sendMouse(
-            posFromCanvas.x + hotspot.x, 
-            posFromCanvas.y + hotspot.y, 
+            posFromCanvas.x + hotspot.x,
+            posFromCanvas.y + hotspot.y,
             this._mouseButtonMask);
     }
 
@@ -1547,7 +1541,7 @@ export default class RFB extends EventTargetMixin {
             this._sendTouchpadTap();
             return;
         }
-        
+
         this._touchpadTapTimeoutId = window.setTimeout(() => {
             this._clearTouchpadTapTimeoutId();
             this._sendTouchpadTap();
@@ -1556,8 +1550,8 @@ export default class RFB extends EventTargetMixin {
     }
 
     /**
-     * 
-     * @param {number} magnitude 
+     *
+     * @param {number} magnitude
      */
     _handleTouchpadPinchZoom(magnitude) {
         if (this._lastTouchpadPinchMagnitude > 0) {
@@ -1570,16 +1564,16 @@ export default class RFB extends EventTargetMixin {
             // Capture the current viewport size.
             const originalVpW = this._display.viewportLocation.w;
             const originalVpH = this._display.viewportLocation.h;
-            
+
             // Change viewport size based on new scale.
             const newWidth = container.clientWidth * this._currentPinchScale;
             const newHeight = container.clientHeight * this._currentPinchScale;
             this._display.viewportChangeSize(newWidth, newHeight);
-            
+
             // Apply scaling to CSS.
             const visualScale = container.clientWidth / newWidth;
             this._display.rescale(visualScale);
-        
+
             // Adjust viewport location to keep it centered.
             const moveX = (originalVpW - this._display.viewportLocation.w) / 2;
             const moveY =  (originalVpH - this._display.viewportLocation.h) / 2;
@@ -1644,7 +1638,7 @@ export default class RFB extends EventTargetMixin {
         const canvasCenter = {
             x: canvasBounds.width * .5,
             y: canvasBounds.height * .5
-        }
+        };
         const xFromCenter = canvasBounds.width * .1;
         const yFromCenter = canvasBounds.height * .1;
         const innerWidth = xFromCenter * 2;
@@ -1657,7 +1651,7 @@ export default class RFB extends EventTargetMixin {
             left: canvasCenter.x - xFromCenter,
             right: canvasCenter.x + xFromCenter,
             width: innerWidth
-        }
+        };
     }
 
     // Message Handlers

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -1532,7 +1532,11 @@ export default class RFB extends EventTargetMixin {
         // Finally, translate the coordinates to those relative to the
         // canvas and send the pointer move event to the remote machine.
         const posFromCanvas = clientToElement(safeX, safeY, this._canvas);
-        this._sendMouse(posFromCanvas.x, posFromCanvas.y, this._mouseButtonMask);
+        const hotspot = this._cursor.hotspot;
+        this._sendMouse(
+            posFromCanvas.x + hotspot.x, 
+            posFromCanvas.y + hotspot.y, 
+            this._mouseButtonMask);
     }
 
     _handleTouchpadOneTapEvent() {
@@ -1616,7 +1620,10 @@ export default class RFB extends EventTargetMixin {
      * @returns {{x: number, y: number}}
      */
     _getCursorPositionToCanvas() {
-        const cursorPos = this._cursor.position;
+        const cursorPos = {
+            x: this._cursor.position.x + this._cursor.hotspot.x,
+            y: this._cursor.position.y + this._cursor.hotspot.y
+        };
         return clientToElement(cursorPos.x, cursorPos.y, this._canvas);
     }
 

--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -11,17 +11,26 @@
 import * as Log from './logging.js';
 
 // Touch detection
-export let isTouchDevice = ('ontouchstart' in document.documentElement) ||
-                                 // requried for Chrome debugger
-                                 (document.ontouchstart !== undefined) ||
-                                 // required for MS Surface
-                                 (navigator.maxTouchPoints > 0) ||
-                                 (navigator.msMaxTouchPoints > 0);
+let _touchEventOccurred = false;
 window.addEventListener('touchstart', function onFirstTouch() {
-    isTouchDevice = true;
+    _touchEventOccurred = true;
     window.removeEventListener('touchstart', onFirstTouch, false);
 }, false);
 
+// This needs to be a function to allow the exported value
+// to update if touchstart event fires.  Also, the other
+// values are dynamic and can change without a page reload
+// (e.g. opening the emulator in dev tools), so we don't want
+// to assign them to a variable that captures their current value.
+export function isTouchDevice() {
+    return _touchEventOccurred ||
+        ('ontouchstart' in document.documentElement) ||
+        // requried for Chrome debugger
+        (document.ontouchstart !== undefined) ||
+        // required for MS Surface
+        (navigator.maxTouchPoints > 0) ||
+        (navigator.msMaxTouchPoints > 0);
+};
 
 // The goal is to find a certain physical width, the devicePixelRatio
 // brings us a bit closer but is not optimal.

--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -30,7 +30,7 @@ export function isTouchDevice() {
         // required for MS Surface
         (navigator.maxTouchPoints > 0) ||
         (navigator.msMaxTouchPoints > 0);
-};
+}
 
 // The goal is to find a certain physical width, the devicePixelRatio
 // brings us a bit closer but is not optimal.

--- a/core/util/cursor.js
+++ b/core/util/cursor.js
@@ -43,6 +43,13 @@ export default class Cursor {
     get position() {
         return this._position;
     }
+
+     /**
+     * @returns {{ x: number, y: number }}
+     */
+     get hotspot() {
+        return this._hotSpot;
+    }
     
     attach(target) {
         if (this._target) {

--- a/core/util/cursor.js
+++ b/core/util/cursor.js
@@ -6,7 +6,7 @@
 
 import { supportsCursorURIs, isTouchDevice } from './browser.js';
 
-const useFallback = !supportsCursorURIs || isTouchDevice;
+const useFallback = () => !supportsCursorURIs || isTouchDevice();
 
 export default class Cursor {
     constructor() {
@@ -14,7 +14,7 @@ export default class Cursor {
 
         this._canvas = document.createElement('canvas');
 
-        if (useFallback) {
+        if (useFallback()) {
             this._canvas.style.position = 'fixed';
             this._canvas.style.zIndex = '65535';
             this._canvas.style.pointerEvents = 'none';
@@ -37,6 +37,13 @@ export default class Cursor {
         };
     }
 
+    /**
+     * @returns {{ x: number, y: number }}
+     */
+    get position() {
+        return this._position;
+    }
+    
     attach(target) {
         if (this._target) {
             this.detach();
@@ -44,7 +51,7 @@ export default class Cursor {
 
         this._target = target;
 
-        if (useFallback) {
+        if (useFallback()) {
             document.body.appendChild(this._canvas);
 
             const options = { capture: true, passive: true };
@@ -62,7 +69,7 @@ export default class Cursor {
             return;
         }
 
-        if (useFallback) {
+        if (useFallback()) {
             const options = { capture: true, passive: true };
             this._target.removeEventListener('mouseover', this._eventHandlers.mouseover, options);
             this._target.removeEventListener('mouseleave', this._eventHandlers.mouseleave, options);
@@ -95,7 +102,7 @@ export default class Cursor {
         ctx.clearRect(0, 0, w, h);
         ctx.putImageData(img, 0, 0);
 
-        if (useFallback) {
+        if (useFallback()) {
             this._updatePosition();
         } else {
             let url = this._canvas.toDataURL();
@@ -116,7 +123,7 @@ export default class Cursor {
     // Mouse events might be emulated, this allows
     // moving the cursor in such cases
     move(clientX, clientY) {
-        if (!useFallback) {
+        if (!useFallback()) {
             return;
         }
         // clientX/clientY are relative the _visual viewport_,

--- a/core/util/cursor.js
+++ b/core/util/cursor.js
@@ -44,13 +44,13 @@ export default class Cursor {
         return this._position;
     }
 
-     /**
+    /**
      * @returns {{ x: number, y: number }}
      */
-     get hotspot() {
+    get hotspot() {
         return this._hotSpot;
     }
-    
+
     attach(target) {
         if (this._target) {
             this.detach();

--- a/vnc.html
+++ b/vnc.html
@@ -79,6 +79,9 @@
             <div id="noVNC_mobile_buttons">
                 <input type="image" alt="Keyboard" src="app/images/keyboard.svg"
                     id="noVNC_keyboard_button" class="noVNC_button" title="Show Keyboard">
+
+                <input type="image" alt="Touchpad Mode" src="app/images/touchpad.svg"
+                    id="noVNC_touchpad_button" class="noVNC_button" title="Touchpad Mode">
             </div>
 
             <!-- Extra manual keys -->


### PR DESCRIPTION
This PR adds a "touchpad mode" option for input when in mobile view.  It includes pinch-zoom.

![Screenshot_20240204-114726](https://github.com/novnc/noVNC/assets/20995508/87f9a295-6861-4281-9122-a367a961aabc)


In touchpad mode, it will function similar to other remote control apps (RealVNC, TeamViewer, etc.).  Touch movements will "push" the cursor in the same direction, and tap events will occur at the cursor's current location.

Long-press or two-tap will perform a right-click.  Double-tap-and-drag will perform a click-and-drag with the left mouse button.

https://github.com/novnc/noVNC/assets/20995508/99c448fe-d1b4-4123-863f-ae8564ae1833

