### PR TITLE
Update github actions to latest versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,18 +10,18 @@ jobs:
   npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           GITREV=$(git rev-parse --short HEAD)
           echo $GITREV
           sed -i "s/^\(.*\"version\".*\)\"\([^\"]\+\)\"\(.*\)\$/\1\"\2-g$GITREV\"\3/" package.json
         if: github.event_name != 'release'
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Needs to be explicitly specified for auth to work
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: npm
           path: lib
@@ -49,7 +49,7 @@ jobs:
   snap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: |
           GITREV=$(git rev-parse --short HEAD)
           echo $GITREV
@@ -61,7 +61,7 @@ jobs:
           sed -i "s/^version:.*/version: '$VERSION'/" snap/snapcraft.yaml
       - uses: snapcore/action-build@v1
         id: snapcraft
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,14 +6,14 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - run: npm update
       - run: npm run lint
   html:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - run: npm update
       - run: git ls-tree --name-only -r HEAD | grep -E "[.](html|css)$" | xargs ./utils/validate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - run: npm update
       - run: npm run test
         env:

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -6,8 +6,8 @@ jobs:
   translate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - run: npm update
       - run: sudo apt-get install gettext
       - run: make -C po update-pot

--- a/utils/convert.js
+++ b/utils/convert.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const path = require('path');
-const program = require('commander');
+const { program } = require('commander');
 const fs = require('fs');
 const fse = require('fs-extra');
 const babel = require('@babel/core');


### PR DESCRIPTION
Primarily to avoid the versions that are now deprecated, but also update actions/upload-artifact to keep us up to date.