### PR TITLE
Clipboard: handle multiple CR+LF

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -2356,7 +2356,7 @@ export default class RFB extends EventTargetMixin {
                         textData = textData.slice(0, -1);
                     }
 
-                    textData = textData.replace("\r\n", "\n");
+                    textData = textData.replaceAll("\r\n", "\n");
 
                     this.dispatchEvent(new CustomEvent(
                         "clipboard",

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -3263,11 +3263,11 @@ describe('Remote Frame Buffer Protocol Client', function () {
                     });
 
                     it('should update clipboard with correct escape characters from a Provide message ', function () {
-                        let expectedData = "Oh\nmy!";
+                        let expectedData = "Oh\nmy\n!";
                         let data = [3, 0, 0, 0];
                         const flags = [0x10, 0x00, 0x00, 0x01];
 
-                        let text = encodeUTF8("Oh\r\nmy!\0");
+                        let text = encodeUTF8("Oh\r\nmy\r\n!\0");
 
                         let deflatedText = deflateWithSize(text);
 


### PR DESCRIPTION
In case copied from the remote server text contains multiple new-lines, only the first occurence of "\r\n" is properly replaced with '\n'. If the received text is then directly written to clipboard with `navigator.clipboard.writeText(e.detail.text)`, empty lines will be duplicated on macOS.

![image](https://github.com/novnc/noVNC/assets/7023634/ea570311-c883-43e7-bf69-605bcbdf16b9)

This PR addresses this issue by replacing all the occurrences instead.