### PR TITLE
ping keepalive feature

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -91,7 +91,7 @@ const extendedClipboardActionProvide = 1 << 28;
 export default class RFB extends EventTargetMixin {
     constructor(target, urlOrChannel, options) {
         if (!target) {
-            throw new Error("Must specify target");
+            throw new ("Must specify target");
         }
         if (!urlOrChannel) {
             throw new Error("Must specify URL, WebSocket or RTCDataChannel");
@@ -2508,6 +2508,7 @@ export default class RFB extends EventTargetMixin {
     this._socketError(
       "Keepalive timeout: No keepalive update received in the last 10 seconds."
     );
+    this.disconnect();
   }
 
   // Function to reset the keepalive timer

--- a/core/rfb.js
+++ b/core/rfb.js
@@ -634,8 +634,10 @@ export default class RFB extends EventTargetMixin {
                 throw e;
             }
         }
+        if (KEEP_ALIVE_INTERVAL >0 && this._keepaliveTimer) clearTimeout(this._keepaliveTimer)
         clearTimeout(this._resizeTimeout);
         clearTimeout(this._mouseMoveTimer);
+        
         Log.Debug("<< RFB.disconnect");
     }
 


### PR DESCRIPTION
Implements a keepalive feature

x11vnc server implements 1x1 frame update buffer ping every n seconds 

I am managing it on the client side to know if connection is broken .

to disable feature KEEP_ALIVE_INTERVAL must be set <= 0
