### PR TITLE
Fix sQpushBytes sending the beginning of the array multiple times

### DIFF
--- a/core/websock.js
+++ b/core/websock.js
@@ -208,7 +208,7 @@ export default class Websock {
                 chunkSize = bytes.length - offset;
             }
 
-            this._sQ.set(bytes.subarray(offset, chunkSize), this._sQlen);
+            this._sQ.set(bytes.subarray(offset, offset + chunkSize), this._sQlen);
             this._sQlen += chunkSize;
             offset += chunkSize;
         }


### PR DESCRIPTION
It turns out that pasting large amounts of text didn't work.