### PR TITLE
WIP: US-International Keyboard Deadkeys

### DIFF
--- a/core/input/keysym.js
+++ b/core/input/keysym.js
@@ -1,6 +1,42 @@
 /* eslint-disable key-spacing */
 
 export default {
+    // TODO remove unused
+    XK_dead_grave:                  0xfe50, // `
+    XK_dead_acute:                  0xfe51, // ´
+    XK_dead_circumflex:             0xfe52, // ^
+    XK_dead_tilde:                  0xfe53, // ~
+    XK_dead_macron:                 0xfe54,
+    XK_dead_breve:                  0xfe55,
+    XK_dead_abovedot:               0xfe56,
+    XK_dead_diaeresis:              0xfe57,
+    XK_dead_abovering:              0xfe58,
+    XK_dead_doubleacute:            0xfe59,
+    XK_dead_caron:                  0xfe5a,
+    XK_dead_cedilla:                0xfe5b,
+    XK_dead_ogonek:                 0xfe5c,
+    XK_dead_iota:                   0xfe5d,
+    XK_dead_voiced_sound:           0xfe5e,
+    XK_dead_semivoiced_sound:       0xfe5f,
+    XK_dead_belowdot:               0xfe60,
+    XK_dead_hook:                   0xfe61,
+    XK_dead_horn:                   0xfe62,
+    XK_dead_stroke:                 0xfe63,
+    XK_dead_abovecomma:             0xfe64,
+    XK_dead_psili:                  0xfe64,  /* non-deprecated alias for dead_abovecomma */
+    XK_dead_abovereversedcomma:     0xfe65,
+    XK_dead_dasia:                  0xfe65,  /* non-deprecated alias for dead_abovereversedcomma */
+    XK_dead_doublegrave:            0xfe66,
+    XK_dead_belowring:              0xfe67,
+    XK_dead_belowmacron:            0xfe68,
+    XK_dead_belowcircumflex:        0xfe69,
+    XK_dead_belowtilde:             0xfe6a,
+    XK_dead_belowbreve:             0xfe6b,
+    XK_dead_belowdiaeresis:         0xfe6c,
+    XK_dead_invertedbreve:          0xfe6d,
+    XK_dead_belowcomma:             0xfe6e,
+    XK_dead_currency:               0xfe6f,
+
     XK_VoidSymbol:                  0xffffff, /* Void symbol */
 
     XK_BackSpace:                   0xff08, /* Back space, back char */

--- a/core/input/util.js
+++ b/core/input/util.js
@@ -175,6 +175,10 @@ export function getKeysym(evt) {
         return DOMKeyTable[key][location];
     }
 
+    if(key === "Dead" ){
+        return getDeadKeysym(evt);
+    }
+
     // Now we need to look at the Unicode symbol instead
 
     // Special key? (FIXME: Should have been caught earlier)
@@ -188,4 +192,32 @@ export function getKeysym(evt) {
     }
 
     return null;
+}
+
+// Try to guess Keysym for Dead key. For now only should work for US-int
+// TODO test
+// TODO try to find and implement Dead keys for more keyboard layouts
+export function getDeadKeysym(evt) {
+    switch(evt.code){
+        case "Quote":
+            if (evt.shiftKey){
+                return KeyTable.XK_dead_diaeresis //
+            } else {
+                return KeyTable.XK_dead_acute // ´
+            }
+        case "Backquote":
+            if (evt.shiftKey){
+                return KeyTable.XK_dead_grave
+            } else {
+                return KeyTable.XK_dead_tilde
+            }
+        case 'Digit6':
+            if (evt.shiftKey){
+                return KeyTable.XK_dead_circumflex
+            }
+
+        default:
+            console.log(evt)
+            return null
+    }
 }


### PR DESCRIPTION
This proof of concept for Solution 1 for  issues #350 

# Solution 1, guess dead key from event.code etz.
This has the problem this depends on they keyboard layout. which is unknown to the browser.
But:

You only have to do this for Dead Keys, not all keys
there lots of overlap between keyboard layouts, [dead keys list](https://kbdlayout.info/features/deadkeys)
when the overlap, it works for both
If the conflict you can't resolve it
This is not a perfect solution. But you can get it to work for most used keyboard layouts, with deadkeys.
Which might be better the Nothing.

I have a working POC that works for us international keyboard layout with:

XK_dead_grave: `
XK_dead_diaeresis: "
XK_dead_acute: ´
XK_dead_circumflex: ^
XK_dead_tilde: ~
