### PR TITLE
Add support for forward and back mouse buttons

### DIFF
--- a/core/encodings.js
+++ b/core/encodings.js
@@ -30,6 +30,7 @@ export const encodings = {
     pseudoEncodingXvp: -309,
     pseudoEncodingFence: -312,
     pseudoEncodingContinuousUpdates: -313,
+    pseudoEncodingExtendedMouseButtons: -316,
     pseudoEncodingCompressLevel9: -247,
     pseudoEncodingCompressLevel0: -256,
     pseudoEncodingVMwareCursor: 0x574d5664,

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -3265,6 +3265,7 @@ describe('Remote Frame Buffer protocol client', function () {
                     expect(spy).to.have.been.calledOnce;
                     expect(spy.args[0][0].detail.name).to.equal('som€ nam€');
                 });
+
             });
 
             describe('Caps Lock and Num Lock remote fixup', function () {
@@ -3757,6 +3758,7 @@ describe('Remote Frame Buffer protocol client', function () {
     describe('Asynchronous events', function () {
         let client;
         let pointerEvent;
+        let extendedPointerEvent;
         let keyEvent;
         let qemuKeyEvent;
 
@@ -3770,12 +3772,14 @@ describe('Remote Frame Buffer protocol client', function () {
             client.focusOnClick = false;
 
             pointerEvent = sinon.spy(RFB.messages, 'pointerEvent');
+            extendedPointerEvent = sinon.spy(RFB.messages, 'extendedPointerEvent');
             keyEvent = sinon.spy(RFB.messages, 'keyEvent');
             qemuKeyEvent = sinon.spy(RFB.messages, 'QEMUExtendedKeyEvent');
         });
 
         afterEach(function () {
             pointerEvent.restore();
+            extendedPointerEvent.restore();
             keyEvent.restore();
             qemuKeyEvent.restore();
         });
@@ -3882,6 +3886,23 @@ describe('Remote Frame Buffer protocol client', function () {
 
                 expect(pointerEvent).to.have.been.calledOnceWith(client._sock,
                                                                  50, 70, 0x0);
+            });
+
+            it('should send extended pointer event when server supports extended pointer events', function () {
+                // Enable extended pointer events
+                sendFbuMsg([{ x: 0, y: 0, width: 0, height: 0, encoding: -316 }], [[]], client);
+
+                sendMouseButtonEvent(50, 70, true, 0x10, client);
+
+                expect(extendedPointerEvent).to.have.been.calledOnceWith(client._sock,
+                                                                         50, 70, 0x100);
+            });
+
+            it('should send normal pointer event when server does not support extended pointer events', function () {
+                sendMouseButtonEvent(50, 70, true, 0x10, client);
+
+                expect(pointerEvent).to.have.been.calledOnceWith(client._sock,
+                                                                 50, 70, 0x100);
             });
 
             describe('Event aggregation', function () {
@@ -5135,10 +5156,35 @@ describe('RFB messages', function () {
         });
 
         it('should send correct data for pointer events', function () {
+            RFB.messages.pointerEvent(sock, 12345, 54321, 0x2b);
+            let expected =
+                [ 5, 0x2b, 0x30, 0x39, 0xd4, 0x31];
+            expect(sock).to.have.sent(new Uint8Array(expected));
+        });
+
+        it('should send correct data for pointer events with marker bit set', function () {
             RFB.messages.pointerEvent(sock, 12345, 54321, 0xab);
             let expected =
-                [ 5, 0xab, 0x30, 0x39, 0xd4, 0x31];
+                [ 5, 0x2b, 0x30, 0x39, 0xd4, 0x31];
             expect(sock).to.have.sent(new Uint8Array(expected));
+        });
+
+        it('should send correct data for pointer events with extended button bits set', function () {
+            RFB.messages.pointerEvent(sock, 12345, 54321, 0x3ab);
+            let expected =
+                [ 5, 0x2b, 0x30, 0x39, 0xd4, 0x31];
+            expect(sock).to.have.sent(new Uint8Array(expected));
+        });
+
+        it('should send correct data for extended pointer events', function () {
+            RFB.messages.extendedPointerEvent(sock, 12345, 54321, 0xab);
+            let expected =
+                [ 5, 0xab, 0x30, 0x39, 0xd4, 0x31, 0x1];
+            expect(sock).to.have.sent(new Uint8Array(expected));
+        });
+
+        it('should not send invalid data for extended pointer events', function () {
+            expect(() => RFB.messages.extendedPointerEvent(sock, 12345, 54321, 0x3ab)).to.throw(Error);
         });
     });
 


### PR DESCRIPTION
This commit implements the extendedMouseButtons pseudo-encoding, which makes it possible to use the forward and back mouse buttons.

It looks like chromium is the only browser that has support for this currently.  See #1918 for more info.

Confirmed that it works with chromium on Mac, Linux and Windows against TigerVNC server.