### PR TITLE
Use semantic tags instead of style tags

### DIFF
--- a/vnc.html
+++ b/vnc.html
@@ -330,7 +330,7 @@
             The server has provided the following identifying information:
         </div>
         <div id="noVNC_fingerprint_block">
-            <b>Fingerprint:</b>
+            Fingerprint:
             <span id="noVNC_fingerprint"></span>
         </div>
         <div>


### PR DESCRIPTION
It is good practice to provide styling that help indicate the importance of the presented text.