### PR TITLE
Better resize rate limiting 

### DIFF
--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -1070,9 +1070,16 @@ describe('Remote Frame Buffer protocol client', function () {
             container.style.width = '70px';
             container.style.height = '80px';
 
+            sinon.spy(RFB.messages, "setDesktopSize");
+
             sendExtendedDesktopSize(client, 0, 0, 4, 4, 0x7890abcd, 0x12345678);
 
-            sinon.spy(RFB.messages, "setDesktopSize");
+            if (RFB.messages.setDesktopSize.calledOnce) {
+                let width = RFB.messages.setDesktopSize.args[0][1];
+                let height = RFB.messages.setDesktopSize.args[0][2];
+                sendExtendedDesktopSize(client, 1, 0, width, height, 0x7890abcd, 0x12345678);
+                RFB.messages.setDesktopSize.resetHistory();
+            }
         });
 
         afterEach(function () {
@@ -1111,6 +1118,7 @@ describe('Remote Frame Buffer protocol client', function () {
             expect(RFB.messages.setDesktopSize).to.have.been.calledWith(
                 sinon.match.object, 70, 80, 0x7890abcd, 0x12345678);
 
+            sendExtendedDesktopSize(client, 1, 0, 70, 80, 0x7890abcd, 0x12345678);
             RFB.messages.setDesktopSize.resetHistory();
 
             // Second message should not trigger a resize
@@ -1163,6 +1171,8 @@ describe('Remote Frame Buffer protocol client', function () {
             expect(RFB.messages.setDesktopSize).to.have.been.calledOnce;
             expect(RFB.messages.setDesktopSize).to.have.been.calledWith(
                 sinon.match.object, 40, 50, 0x7890abcd, 0x12345678);
+
+            sendExtendedDesktopSize(client, 1, 0, 40, 50, 0x7890abcd, 0x12345678);
             RFB.messages.setDesktopSize.resetHistory();
 
             container.style.width = '70px';

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -257,6 +257,29 @@ describe('Remote Frame Buffer protocol client', function () {
         client._sock._websocket._receiveData(new Uint8Array(data));
     }
 
+    function sendExtendedDesktopSize(client, reason, result, width, height, screenId, screenFlags) {
+        let rectInfo = { x: reason, y: result, width: width, height: height, encoding: -308 };
+        let rectData = [
+            0x01,        // number of screens = 1
+            0x00, 0x00,
+            0x00,        // padding
+            (screenId >> 24) & 0xff,
+            (screenId >> 16) & 0xff,
+            (screenId >> 8) & 0xff,
+            screenId & 0xff,
+            0x00, 0x00,  // screen x
+            0x00, 0x00,  // screen y
+            (width >> 8) & 0xff,
+            width & 0xff,
+            (height >> 8) & 0xff,
+            height & 0xff,
+            (screenFlags >> 24) & 0xff,
+            (screenFlags >> 16) & 0xff,
+            (screenFlags >> 8) & 0xff,
+            screenFlags & 0xff];
+        sendFbuMsg([rectInfo], [rectData], client);
+    }
+
     describe('Connecting/Disconnecting', function () {
         describe('#RFB (constructor)', function () {
             let open, attach;
@@ -650,16 +673,10 @@ describe('Remote Frame Buffer protocol client', function () {
         });
 
         it('should update the viewport when the remote session resizes', function () {
-            // Simple ExtendedDesktopSize FBU message
-            const incoming = [ 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
-                               0x00, 0xff, 0x00, 0xff, 0xff, 0xff, 0xfe, 0xcc,
-                               0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                               0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x00, 0xff,
-                               0x00, 0x00, 0x00, 0x00 ];
-
             sinon.spy(client._display, "viewportChangeSize");
 
-            client._sock._websocket._receiveData(new Uint8Array(incoming));
+            // Simple ExtendedDesktopSize FBU message
+            sendExtendedDesktopSize(client, 0, 0, 4, 4, 0x7890abcd, 0x12345678);
             // The resize will cause scrollbars on the container, this causes a
             // resize observation in the browsers
             fakeResizeObserver.fire();
@@ -951,27 +968,7 @@ describe('Remote Frame Buffer protocol client', function () {
             container.style.height = '80px';
             client.scaleViewport = true;
 
-            const incoming = [ 0x00,        // msg-type=FBU
-                               0x00,        // padding
-                               0x00, 0x01,  // number of rects = 1
-                               0x00, 0x00,  // reason = server initialized
-                               0x00, 0x00,  // status = no error
-                               0x00, 0x04,  // new width = 4
-                               0x00, 0x04,  // new height = 4
-                               0xff, 0xff,
-                               0xfe, 0xcc,  // enc = (-308) ExtendedDesktopSize
-                               0x01,        // number of screens = 1
-                               0x00, 0x00,
-                               0x00,        // padding
-                               0x78, 0x90,
-                               0xab, 0xcd,  // screen id = 0
-                               0x00, 0x00,  // screen x = 0
-                               0x00, 0x00,  // screen y = 0
-                               0x00, 0x04,  // screen width = 4
-                               0x00, 0x04,  // screen height = 4
-                               0x12, 0x34,
-                               0x56, 0x78]; // screen flags
-            client._sock._websocket._receiveData(new Uint8Array(incoming));
+            sendExtendedDesktopSize(client, 0, 0, 4, 4, 0x7890abcd, 0x12345678);
         });
 
         it('should update display scale factor when changing the property', function () {
@@ -1039,16 +1036,9 @@ describe('Remote Frame Buffer protocol client', function () {
         });
 
         it('should update the scaling when the remote session resizes', function () {
-            // Simple ExtendedDesktopSize FBU message
-            const incoming = [ 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
-                               0x00, 0xff, 0x00, 0xff, 0xff, 0xff, 0xfe, 0xcc,
-                               0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                               0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0x00, 0xff,
-                               0x00, 0x00, 0x00, 0x00 ];
-
             sinon.spy(client._display, "autoscale");
 
-            client._sock._websocket._receiveData(new Uint8Array(incoming));
+            sendExtendedDesktopSize(client, 0, 0, 4, 4, 0x7890abcd, 0x12345678);
             // The resize will cause scrollbars on the container, this causes a
             // resize observation in the browsers
             fakeResizeObserver.fire();
@@ -1080,27 +1070,7 @@ describe('Remote Frame Buffer protocol client', function () {
             container.style.width = '70px';
             container.style.height = '80px';
 
-            const incoming = [ 0x00,        // msg-type=FBU
-                               0x00,        // padding
-                               0x00, 0x01,  // number of rects = 1
-                               0x00, 0x00,  // reason = server initialized
-                               0x00, 0x00,  // status = no error
-                               0x00, 0x04,  // new width = 4
-                               0x00, 0x04,  // new height = 4
-                               0xff, 0xff,
-                               0xfe, 0xcc,  // enc = (-308) ExtendedDesktopSize
-                               0x01,        // number of screens = 1
-                               0x00, 0x00,
-                               0x00,        // padding
-                               0x78, 0x90,
-                               0xab, 0xcd,  // screen id = 0
-                               0x00, 0x00,  // screen x = 0
-                               0x00, 0x00,  // screen y = 0
-                               0x00, 0x04,  // screen width = 4
-                               0x00, 0x04,  // screen height = 4
-                               0x12, 0x34,
-                               0x56, 0x78]; // screen flags
-            client._sock._websocket._receiveData(new Uint8Array(incoming));
+            sendExtendedDesktopSize(client, 0, 0, 4, 4, 0x7890abcd, 0x12345678);
 
             sinon.spy(RFB.messages, "setDesktopSize");
         });
@@ -1124,31 +1094,9 @@ describe('Remote Frame Buffer protocol client', function () {
             container.style.width = '70px';
             container.style.height = '80px';
 
-            // Simple ExtendedDesktopSize FBU message
-            const incoming = [ 0x00,        // msg-type=FBU
-                               0x00,        // padding
-                               0x00, 0x01,  // number of rects = 1
-                               0x00, 0x00,  // reason = server initialized
-                               0x00, 0x00,  // status = no error
-                               0x00, 0x04,  // new width = 4
-                               0x00, 0x04,  // new height = 4
-                               0xff, 0xff,
-                               0xfe, 0xcc,  // enc = (-308) ExtendedDesktopSize
-                               0x01,        // number of screens = 1
-                               0x00, 0x00,
-                               0x00,        // padding
-                               0x78, 0x90,
-                               0xab, 0xcd,  // screen id = 0
-                               0x00, 0x00,  // screen x = 0
-                               0x00, 0x00,  // screen y = 0
-                               0x00, 0x04,  // screen width = 4
-                               0x00, 0x04,  // screen height = 4
-                               0x12, 0x34,
-                               0x56, 0x78]; // screen flags
-
             // First message should trigger a resize
 
-            client._sock._websocket._receiveData(new Uint8Array(incoming));
+            sendExtendedDesktopSize(client, 0, 0, 4, 4, 0x7890abcd, 0x12345678);
 
             // It should match the current size of the container,
             // not the reported size from the server
@@ -1160,7 +1108,7 @@ describe('Remote Frame Buffer protocol client', function () {
 
             // Second message should not trigger a resize
 
-            client._sock._websocket._receiveData(new Uint8Array(incoming));
+            sendExtendedDesktopSize(client, 0, 0, 4, 4, 0x7890abcd, 0x12345678);
 
             expect(RFB.messages.setDesktopSize).to.not.have.been.called;
         });
@@ -1187,13 +1135,7 @@ describe('Remote Frame Buffer protocol client', function () {
                 sinon.match.object, 40, 50, 0x7890abcd, 0x12345678);
 
             // Server responds with the requested size 40x50
-            const incoming = [ 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
-                               0x00, 0x28, 0x00, 0x32, 0xff, 0xff, 0xfe, 0xcc,
-                               0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                               0x00, 0x00, 0x00, 0x00, 0x00, 0x28, 0x00, 0x32,
-                               0x00, 0x00, 0x00, 0x00];
-
-            client._sock._websocket._receiveData(new Uint8Array(incoming));
+            sendExtendedDesktopSize(client, 1, 0, 40, 50, 0x7890abcd, 0x12345678);
             clock.tick(1000);
 
             RFB.messages.setDesktopSize.resetHistory();
@@ -1282,18 +1224,11 @@ describe('Remote Frame Buffer protocol client', function () {
         });
 
         it('should not try to override a server resize', function () {
-            // Simple ExtendedDesktopSize FBU message, new size: 100x100
-            const incoming = [ 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
-                               0x00, 0x64, 0x00, 0x64, 0xff, 0xff, 0xfe, 0xcc,
-                               0x01, 0x00, 0x00, 0x00, 0xab, 0xab, 0xab, 0xab,
-                               0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x04,
-                               0x11, 0x22, 0x33, 0x44 ];
-
             // Note that this will cause the browser to display scrollbars
             // since the framebuffer is 100x100 and the container is 70x80.
             // The usable space (clientWidth/clientHeight) will be even smaller
             // due to the scrollbars taking up space.
-            client._sock._websocket._receiveData(new Uint8Array(incoming));
+            sendExtendedDesktopSize(client, 0, 0, 100, 100, 0xabababab, 0x11223344);
             // The scrollbars cause the ResizeObserver to fire
             fakeResizeObserver.fire();
             clock.tick(1000);

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -1082,6 +1082,13 @@ describe('Remote Frame Buffer protocol client', function () {
         it('should only request a resize when turned on', function () {
             client.resizeSession = false;
             expect(RFB.messages.setDesktopSize).to.not.have.been.called;
+
+            container.style.width = '40px';
+            container.style.height = '50px';
+            fakeResizeObserver.fire();
+            clock.tick(1000);
+            expect(RFB.messages.setDesktopSize).to.not.have.been.called;
+
             client.resizeSession = true;
             expect(RFB.messages.setDesktopSize).to.have.been.calledOnce;
         });


### PR DESCRIPTION
Be more aggressive with resizing, limiting it to once ever 100 ms instead of after a 500 ms idle period. This gives a more responsive user experience.

Basically, https://github.com/TigerVNC/tigervnc/pull/1904 for noVNC.