### PR TITLE
Let browser handle parsing of urls before relaying

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1058,7 +1058,12 @@ const UI = {
             if (port) {
                 url.port = port;
             }
-            url.pathname = '/' + path;
+
+            // "./" is needed to force URL() to interpret the path-variable as
+            // a path and not as an URL. This is relevant if for example path
+            // starts with more than one "/", in which case it would be
+            // interpreted as a host name instead.
+            url = new URL("./" + path, url);
         } else {
             // Current (May 2024) browsers support relative WebSocket
             // URLs natively, but we need to support older browsers for


### PR DESCRIPTION
Apparently there is some magic happening under the surface when the `path`-string containing a search query is assigned to `url.pathname`.

This is what caused `?` to be translated to `%3F`.