### PR TITLE
Disable setting showDotCursor in RFB constructor

### DIFF
--- a/core/rfb.js
+++ b/core/rfb.js
@@ -300,10 +300,6 @@ export default class RFB extends EventTargetMixin {
         this._resizeSession = false;
 
         this._showDotCursor = false;
-        if (options.showDotCursor !== undefined) {
-            Log.Warn("Specifying showDotCursor as a RFB constructor argument is deprecated");
-            this._showDotCursor = options.showDotCursor;
-        }
 
         this._qualityLevel = 6;
         this._compressionLevel = 2;


### PR DESCRIPTION
This has been deprecated for around six years now. Let's remove the deprecation warning and disable setting `showDotCursor` via the options-parameter.