### PR TITLE
Fix modifier keys not being sent on Firefox

### DIFF
--- a/core/input/keyboard.js
+++ b/core/input/keyboard.js
@@ -208,6 +208,14 @@ export default class Keyboard {
             return;
         }
 
+	// The event gives us some very useful info about modkeys but
+	// when fingerprinting is on, it only stores this info without
+	// sending it, so we have to manually send the modkeys ourselves
+	if (browser.isFirefox()) {
+		this._updateModifierState(false, false);
+		this._updateModifierState(e, true);
+	}
+
         this._sendKeyEvent(keysym, code, true, numlock, capslock);
     }
 
@@ -241,6 +249,22 @@ export default class Keyboard {
             if ('ShiftLeft' in this._keyDownList) {
                 this._sendKeyEvent(this._keyDownList['ShiftLeft'],
                                    'ShiftLeft', false);
+            }
+        }
+    }
+
+    _updateModifierState(e, isKeyDown) {
+        const modMap = {
+            shiftKey: KeyTable.XK_Shift_L,
+            ctrlKey: KeyTable.XK_Control_L,
+            altKey: KeyTable.XK_Alt_L,
+            metaKey: KeyTable.XK_Super_L
+        };
+
+        for (let key in modMap) {
+            if(!e) this._sendKeyEvent(modMap[key], key, false);
+            if (e[key]) {
+                this._sendKeyEvent(modMap[key], key, isKeyDown);
             }
         }
     }


### PR DESCRIPTION
This commit allows for modifier keys to be sent on Firefox, even if ``privacy.resistFingerprinting`` is enabled or not.

Firefox *does* set the modifiers in the event itself but when ``privacy.resistFingerprinting`` is enabled it doesn't send them, therefore this code handles that issue and sends it manually allowing for key combos like Ctrl+Alt+Delete to work out of the box.

I've tested this on Firefox and Librewolf with both ``privacy.resistFingerprinting`` enabled and disabled, both give the same intended result.

This also fixes #1882