### PR TITLE
Fix issue where tests fail to find chai library.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/preset-env": "latest",
     "babel-plugin-import-redirect": "latest",
     "browserify": "latest",
-    "chai": "latest",
+    "chai": "<6.0.0",
     "commander": "latest",
     "eslint": "latest",
     "fs-extra": "latest",


### PR DESCRIPTION
A breaking change to how the chai library is bundled was made between 5.x.x and 6.x.x (it was originally made in 5.3.1, but that change was reverted in 5.3.2, then made again after bumping the major version number). This results in all locally executed karma tests failing due to a missing file.

This is a temporary work around until someone correctly fixes our usage or this libary.