### PR TITLE
Add wakelock support

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -28,6 +28,7 @@ const UI = {
 
     connected: false,
     desktopName: "",
+    wakelock: null,
 
     statusTimeout: null,
     hideKeyboardTimeout: null,
@@ -189,6 +190,7 @@ const UI = {
         UI.initSetting('repeaterID', '');
         UI.initSetting('reconnect', false);
         UI.initSetting('reconnect_delay', 5000);
+        UI.initSetting('use_wakelock', false);
     },
     // Adds a link to the label elements on the corresponding input elements
     setupSettingLabels() {
@@ -1154,6 +1156,10 @@ const UI = {
         UI.showStatus(msg);
         UI.updateVisualState('connected');
 
+        if (UI.getSetting('use_wakelock')) {
+            UI.wakelockAcquire();
+        }
+
         // Do this last because it can only be used on rendered elements
         UI.rfb.focus();
     },
@@ -1166,6 +1172,11 @@ const UI = {
         // the server, we need to do it here as well since
         // UI.disconnect() won't be used in those cases.
         UI.connected = false;
+
+        if (UI.wakelock !== null) {
+            UI.wakelock.release();
+            UI.wakelock = null;
+        }
 
         UI.rfb = undefined;
 
@@ -1794,6 +1805,36 @@ const UI = {
         optn.value = value;
         selectbox.options.add(optn);
     },
+
+    wakelockAcquire() {
+        if (!("wakeLock" in navigator)) {
+            Log.Warn("wakelock api not supported. Is this page served by https?");
+            return;
+        }
+        navigator.wakeLock.request("screen").then((wakelock) => {
+            UI.wakelock = wakelock;
+            Log.Info("acquired wakelock successfully.");
+
+            wakelock.addEventListener("release", UI.wakelockReleased);
+        }).catch(err => Log.Error("Failed to acquire wakelock: " + err));
+    },
+
+    wakelockReleased(e) {
+        if (UI.wakelock !== null && document.visibilityState !== "visible") {
+            Log.Warn("Wakelock released due to document becoming hidden, trying to reacquire");
+            const visibilityListener = () => {
+                Log.Debug("Wakelock visibility listener state change: " + document.visibilityState);
+                if (document.visibilityState === "visible") {
+                    UI.wakelockAcquire();
+                    document.removeEventListener("visibilitychange", visibilityListener);
+                }
+            };
+            document.addEventListener("visibilitychange", visibilityListener);
+        } else {
+            Log.Debug("Wakelock released, likely as part of disconnecting.");
+        }
+    },
+
 
 /* ------^-------
  *    /MISC

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -95,6 +95,10 @@ Currently, the following options are available:
 * `logging` - The console log level. Can be one of `error`, `warn`, `info` or
   `debug`.
 
+* `use_wakelock` - Should we prevent the (local) display from going into sleep
+  mode while a connection is active? Useful for view-only sessions where there
+  unlikely to be any keyboard/mouse activity to keep the device active.
+
 ## HTTP serving considerations
 ### Browser cache issue
 


### PR DESCRIPTION
Add a new configuration option `use_wakelock` to allow noVNC to stop the local display from going to sleep. This is especially useful with view-only sessions.

We only hold the view lock while connected to a server. We will also attempt to reacquire the wakelock if we lost it due to a visibility change (the tab becoming inactive, or during the transition into/from fullscreen).

All existing unittests have been run (with #1983 manually patched into my working directory), and the change has been manually tested in Firefox 142.