### PR TITLE
Add 'core/input/keyboard' to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "docs/LIBRARY.md",
     "docs/LICENSE*"
   ],
-  "exports": "./core/rfb.js",
+  "exports": {
+    ".": "./core/rfb.js",
+    "./core/input/keyboard": "./core/input/keyboard.js"
+  },
   "scripts": {
     "lint": "eslint app core po/po2js po/xgettext-html tests utils",
     "test": "karma start karma.conf.cjs"


### PR DESCRIPTION
Allow noVNC users to use Keyboard utility: it is useful it required to grab events from other then canvas element