### PR TITLE
Display warning prompt before closing tab

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1155,6 +1155,8 @@ const UI = {
         UI.showStatus(msg);
         UI.updateVisualState('connected');
 
+        UI.updateBeforeUnload();
+
         // Do this last because it can only be used on rendered elements
         UI.rfb.focus();
     },
@@ -1191,6 +1193,8 @@ const UI = {
             UI.showStatus(_("Disconnected"), 'normal');
         }
 
+        UI.updateBeforeUnload();
+
         document.title = PAGE_TITLE;
 
         UI.openControlbar();
@@ -1209,6 +1213,24 @@ const UI = {
             msg = _("New connection has been rejected");
         }
         UI.showStatus(msg, 'error');
+    },
+
+    handleBeforeUnload(e) {
+        // Trigger a "Leave site?" warning prompt before closing the
+        // page. Modern browsers (Oct 2025) accept either (or both)
+        // preventDefault() or a nonempty returnValue, though the latter is
+        // considered legacy. The custom string is ignored by modern browsers,
+        // which display a native message, but older browsers will show it.
+        e.preventDefault();
+        e.returnValue = _("Are you sure you want to disconnect the session?");
+    },
+
+    updateBeforeUnload() {
+        // Remove first to avoid adding duplicates
+        window.removeEventListener("beforeunload", UI.handleBeforeUnload);
+        if (!UI.rfb?.viewOnly && UI.connected) {
+            window.addEventListener("beforeunload", UI.handleBeforeUnload);
+        }
     },
 
 /* ------^-------
@@ -1736,6 +1758,8 @@ const UI = {
     updateViewOnly() {
         if (!UI.rfb) return;
         UI.rfb.viewOnly = UI.getSetting('view_only');
+
+        UI.updateBeforeUnload();
 
         // Hide input related buttons in view only mode
         if (UI.rfb.viewOnly) {


### PR DESCRIPTION
Some key combinations appear to be intercepted by browsers, such as Ctrl+W, which closes a tab. Incidentally this in particular is widely used, e.g. for deleting the last word in a terminal or to cut text in emacs. Mobile browsers don't seem to have this problem at all, as I can perform this combination perfectly fine without closing the current tab.

This PR adds a guard to prevent accidentally disconnecting an active session by triggering a "Leave site?" warning prompt. It's implemented to only trigger for an active connection, since that's when it's particularly irritating having to reconnect. Note that closing the tab manually also triggers the warning prompt, though not in mobile browser. The "beforeunload" event in question is allegedly much less reliably fired in mobile browsers, but as mentioned above, they don't exhibit the same fundamental problem.

Tested in
- macOS 15.7
  - Safari 26
- Fedora 42
  - Firefox 144
  - Chromium 141
- iOS 26
  - Safari 26
- Android 13
  - Firefox 144
  - Chrome 141