### PR TITLE
Speed up Websock receive queue reads via DataView

### DIFF
--- a/core/websock.js
+++ b/core/websock.js
@@ -105,43 +105,21 @@ export default class Websock {
     }
 
     rQshift8() {
-        return this._rQshift(1);
+        const offset = this._rQi;
+        this._rQi += 1;
+        return this._rQdv.getUint8(offset);
     }
 
     rQshift16() {
-        return this._rQshift(2);
+        const offset = this._rQi;
+        this._rQi += 2;
+        return this._rQdv.getUint16(offset, false);
     }
 
     rQshift32() {
-        return this._rQshift(4);
-    }
-
-    // Use DataView for faster integer reads (with a fallback for uncommon sizes)
-    _rQshift(bytes) {
-        if (!this._rQdv && this._rQ) {
-            this._rQdv = new DataView(this._rQ.buffer);
-        }
-
-        if (this._rQdv && (bytes === 1 || bytes === 2 || bytes === 4)) {
-            const offset = this._rQi;
-            this._rQi += bytes;
-
-            let res;
-            if (bytes === 1) {
-                res = this._rQdv.getUint8(offset);
-            } else if (bytes === 2) {
-                res = this._rQdv.getUint16(offset, false);
-            } else {
-                res = this._rQdv.getUint32(offset, false);
-            }
-            return res >>> 0;
-        }
-
-        let res = 0;
-        for (let byte = bytes - 1; byte >= 0; byte--) {
-            res += this._rQ[this._rQi++] << (byte * 8);
-        }
-        return res >>> 0;
+        const offset = this._rQi;
+        this._rQi += 4;
+        return this._rQdv.getUint32(offset, false);
     }
 
     rQlen() {

--- a/tests/perf/rfb_stream_bench.html
+++ b/tests/perf/rfb_stream_bench.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>noVNC RFB Stream Benchmark</title>
+        <script type="module" src="./rfb_stream_bench.js"></script>
+    </head>
+    <body>
+        <main>
+            <h1>noVNC RFB Stream Benchmark</h1>
+            <p id="status">idle</p>
+            <pre id="result"></pre>
+        </main>
+    </body>
+</html>

--- a/tests/perf/rfb_stream_bench.js
+++ b/tests/perf/rfb_stream_bench.js
@@ -1,0 +1,317 @@
+const statusEl = document.getElementById('status');
+const resultEl = document.getElementById('result');
+
+const search = new URLSearchParams(window.location.search);
+const scenario = search.get('scenario') || 'protocol-copyrect';
+const repoUrl = search.get('repo');
+
+window.__BENCH_DONE = false;
+window.__RESULT = null;
+window.__ERROR = null;
+
+function setStatus(text) {
+    statusEl.textContent = text;
+    document.title = text;
+}
+
+function setResult(result) {
+    window.__RESULT = result;
+    window.__BENCH_DONE = true;
+    setStatus('done');
+    resultEl.textContent = JSON.stringify(result, null, 2);
+}
+
+function setError(error) {
+    const rendered = error instanceof Error ? `${error.message}\n${error.stack || ''}` : String(error);
+    window.__ERROR = rendered;
+    window.__BENCH_DONE = true;
+    setStatus('error');
+    resultEl.textContent = rendered;
+    console.error(error);
+}
+
+function parseInteger(name, fallback) {
+    const raw = search.get(name);
+    if (raw === null || raw === '') {
+        return fallback;
+    }
+
+    const value = Number(raw);
+    if (!Number.isInteger(value) || value < 0) {
+        throw new Error(`Invalid integer for "${name}": ${raw}`);
+    }
+
+    return value;
+}
+
+function ensureRepoUrl(rawRepoUrl) {
+    if (!rawRepoUrl) {
+        throw new Error('Missing "repo" query parameter');
+    }
+
+    const normalized = rawRepoUrl.endsWith('/') ? rawRepoUrl : `${rawRepoUrl}/`;
+    return new URL(normalized);
+}
+
+function receive(ws, bytes) {
+    ws._receiveData(bytes);
+}
+
+function dispatchMessage(ws, data) {
+    ws.onmessage(new MessageEvent('message', { data }));
+}
+
+function createVersionBuffer() {
+    return new TextEncoder().encode('RFB 003.008\n');
+}
+
+function encodeName(name) {
+    return new TextEncoder().encode(name);
+}
+
+function buildServerInit(width, height, name) {
+    const nameBytes = encodeName(name);
+
+    const header = new Uint8Array(24);
+    const view = new DataView(header.buffer);
+    view.setUint16(0, width, false);
+    view.setUint16(2, height, false);
+    header[4] = 24;
+    header[5] = 24;
+    header[6] = 0;
+    header[7] = 1;
+    view.setUint16(8, 255, false);
+    view.setUint16(10, 255, false);
+    view.setUint16(12, 255, false);
+    header[14] = 16;
+    header[15] = 8;
+    header[16] = 0;
+    view.setUint32(20, nameBytes.length, false);
+
+    return { header, nameBytes };
+}
+
+function handshake(ws, width, height, name) {
+    receive(ws, createVersionBuffer());
+    receive(ws, new Uint8Array([1, 1]));
+    receive(ws, new Uint8Array([0, 0, 0, 0]));
+
+    const init = buildServerInit(width, height, name);
+    receive(ws, init.header);
+    receive(ws, init.nameBytes);
+}
+
+async function loadModules(repoBase) {
+    // util/browser.js has a top-level WebCodecs probe that can stall in
+    // headless Chrome. Remove the APIs before importing RFB so the module
+    // resolves quickly and deterministically in benchmark runs.
+    try { delete window.VideoDecoder; } catch {}
+    try { delete window.EncodedVideoChunk; } catch {}
+
+    const [rfbModule, websocketModule] = await Promise.all([
+        import(new URL('core/rfb.js', repoBase).href),
+        import(new URL('tests/fake.websocket.js', repoBase).href),
+    ]);
+
+    return {
+        RFB: rfbModule.default,
+        FakeWebSocket: websocketModule.default,
+    };
+}
+
+function createHarness(RFB, FakeWebSocket) {
+    const mount = document.createElement('div');
+    document.body.appendChild(mount);
+
+    const ws = new FakeWebSocket();
+    const rfb = new RFB(mount, ws);
+    ws._open();
+
+    return { mount, rfb, ws };
+}
+
+function destroyHarness(harness) {
+    try {
+        harness.rfb.disconnect();
+    } catch {}
+
+    if (harness.mount.parentNode !== null) {
+        harness.mount.parentNode.removeChild(harness.mount);
+    }
+}
+
+function buildCopyRectBatch(rectsPerMessage) {
+    const bytesPerRect = 16;
+    const buffer = new ArrayBuffer(4 + (rectsPerMessage * bytesPerRect));
+    const view = new DataView(buffer);
+    let offset = 0;
+
+    view.setUint8(offset++, 0);
+    view.setUint8(offset++, 0);
+    view.setUint16(offset, rectsPerMessage, false);
+    offset += 2;
+
+    for (let i = 0; i < rectsPerMessage; i++) {
+        view.setUint16(offset, 0, false); offset += 2;
+        view.setUint16(offset, 0, false); offset += 2;
+        view.setUint16(offset, 1, false); offset += 2;
+        view.setUint16(offset, 1, false); offset += 2;
+        view.setInt32(offset, 1, false); offset += 4; // CopyRect encoding
+        view.setUint16(offset, 0, false); offset += 2;
+        view.setUint16(offset, 0, false); offset += 2;
+    }
+
+    return buffer;
+}
+
+function createCopyRectMessages(messageCount, rectsPerMessage) {
+    const messages = [];
+    for (let i = 0; i < messageCount; i++) {
+        messages.push(buildCopyRectBatch(rectsPerMessage));
+    }
+    return messages;
+}
+
+function average(values) {
+    return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+async function runSmokeRaw(RFB, FakeWebSocket) {
+    const start = performance.now();
+    const harness = createHarness(RFB, FakeWebSocket);
+
+    try {
+        handshake(harness.ws, 2, 2, 'smoke');
+
+        const update = new Uint8Array(4 + 12 + 4);
+        const view = new DataView(update.buffer);
+        let offset = 0;
+
+        update[offset++] = 0;
+        update[offset++] = 0;
+        view.setUint16(offset, 1, false); offset += 2;
+
+        view.setUint16(offset, 0, false); offset += 2;
+        view.setUint16(offset, 0, false); offset += 2;
+        view.setUint16(offset, 1, false); offset += 2;
+        view.setUint16(offset, 1, false); offset += 2;
+        view.setInt32(offset, 0, false); offset += 4; // Raw encoding
+
+        update[offset++] = 0xff;
+        update[offset++] = 0x00;
+        update[offset++] = 0x00;
+        update[offset++] = 0x00;
+
+        receive(harness.ws, update);
+        await new Promise((resolve) => window.setTimeout(resolve, 50));
+
+        const pixel = Array.from(harness.rfb.getImageData().data.slice(0, 4));
+        const expectedPixel = [255, 0, 0, 255];
+        const pass = harness.rfb._rfbConnectionState === 'connected' &&
+            pixel.length === expectedPixel.length &&
+            pixel.every((value, index) => value === expectedPixel[index]);
+
+        return {
+            scenario: 'smoke-raw',
+            pass,
+            state: harness.rfb._rfbConnectionState,
+            pixel,
+            expectedPixel,
+            durationMs: performance.now() - start,
+        };
+    } finally {
+        destroyHarness(harness);
+    }
+}
+
+async function runProtocolCopyRect(RFB, FakeWebSocket) {
+    const iterations = parseInteger('iterations', 6);
+    const warmup = parseInteger('warmup', 2);
+    const messages = parseInteger('messages', 50);
+    const rects = parseInteger('rects', 5000);
+    const stubDisplay = search.get('stubDisplay') !== '0';
+    const harness = createHarness(RFB, FakeWebSocket);
+
+    try {
+        handshake(harness.ws, 4, 4, 'bench');
+        harness.rfb._enabledContinuousUpdates = true;
+
+        if (typeof harness.ws._getSentData === 'function') {
+            harness.ws._getSentData();
+        }
+
+        if (stubDisplay) {
+            harness.rfb._display.copyImage = () => {};
+            harness.rfb._display.fillRect = () => {};
+            harness.rfb._display.blitImage = () => {};
+            harness.rfb._display.flip = () => {};
+        }
+
+        const payloads = createCopyRectMessages(messages, rects);
+        const feed = () => {
+            for (const payload of payloads) {
+                dispatchMessage(harness.ws, payload);
+            }
+        };
+
+        for (let i = 0; i < warmup; i++) {
+            feed();
+        }
+
+        const samples = [];
+        for (let i = 0; i < iterations; i++) {
+            const start = performance.now();
+            feed();
+
+            if (typeof harness.rfb._display.flush === 'function' && harness.rfb._display.pending()) {
+                await harness.rfb._display.flush();
+            }
+
+            samples.push(performance.now() - start);
+        }
+
+        const avg = average(samples);
+        const min = Math.min(...samples);
+        const max = Math.max(...samples);
+        const rectsPerIteration = messages * rects;
+
+        return {
+            scenario: 'protocol-copyrect',
+            stubDisplay,
+            iterations,
+            warmup,
+            messages,
+            rectsPerMessage: rects,
+            rectsPerIteration,
+            avgMs: avg,
+            minMs: min,
+            maxMs: max,
+            rectsPerSecond: rectsPerIteration / (avg / 1000),
+            samplesMs: samples,
+        };
+    } finally {
+        destroyHarness(harness);
+    }
+}
+
+async function run() {
+    const repoBase = ensureRepoUrl(repoUrl);
+    setStatus(`loading ${scenario}`);
+    const { RFB, FakeWebSocket } = await loadModules(repoBase);
+
+    if (scenario === 'smoke-raw') {
+        setStatus('running smoke-raw');
+        setResult(await runSmokeRaw(RFB, FakeWebSocket));
+        return;
+    }
+
+    if (scenario === 'protocol-copyrect') {
+        setStatus('running protocol-copyrect');
+        setResult(await runProtocolCopyRect(RFB, FakeWebSocket));
+        return;
+    }
+
+    throw new Error(`Unknown scenario "${scenario}"`);
+}
+
+run().catch(setError);

--- a/tests/perf/run_rfb_bench.mjs
+++ b/tests/perf/run_rfb_bench.mjs
@@ -1,0 +1,489 @@
+#!/usr/bin/env node
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import http from 'node:http';
+import net from 'node:net';
+import { spawn, spawnSync } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const pageUrl = pathToFileURL(path.join(scriptDir, 'rfb_stream_bench.html')).href;
+const repoRoot = path.resolve(scriptDir, '..', '..');
+
+const DEFAULT_SCENARIOS = [
+    {
+        name: 'smoke-raw',
+        type: 'smoke',
+        scenario: 'smoke-raw',
+    },
+    {
+        name: 'protocol-copyrect-parser',
+        type: 'compare',
+        scenario: 'protocol-copyrect',
+        params: {
+            iterations: 6,
+            warmup: 2,
+            messages: 50,
+            rects: 5000,
+            stubDisplay: 1,
+        },
+    },
+    {
+        name: 'protocol-copyrect-full',
+        type: 'compare',
+        scenario: 'protocol-copyrect',
+        params: {
+            iterations: 5,
+            warmup: 2,
+            messages: 20,
+            rects: 2000,
+            stubDisplay: 0,
+        },
+    },
+];
+
+function printHelp() {
+    console.log(`Usage: node tests/perf/run_rfb_bench.mjs [options]
+
+Options:
+  --candidate <path>      Repo checkout to benchmark. Defaults to the current checkout.
+  --baseline <path>       Baseline repo checkout. If omitted, a temporary worktree is created.
+  --baseline-ref <ref>    Git ref to use for the temporary baseline worktree.
+  --chrome <path>         Chrome/Chromium executable to launch.
+  --json                  Print JSON only.
+  --keep-worktree         Keep the temporary baseline worktree on disk.
+  --help                  Show this message.
+`);
+}
+
+function parseArgs(argv) {
+    const options = {
+        candidate: repoRoot,
+        baseline: null,
+        baselineRef: null,
+        chrome: null,
+        json: false,
+        keepWorktree: false,
+    };
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+
+        switch (arg) {
+            case '--candidate':
+                options.candidate = argv[++i];
+                break;
+            case '--baseline':
+                options.baseline = argv[++i];
+                break;
+            case '--baseline-ref':
+                options.baselineRef = argv[++i];
+                break;
+            case '--chrome':
+                options.chrome = argv[++i];
+                break;
+            case '--json':
+                options.json = true;
+                break;
+            case '--keep-worktree':
+                options.keepWorktree = true;
+                break;
+            case '--help':
+                options.help = true;
+                break;
+            default:
+                throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+
+    return options;
+}
+
+function runCommand(command, args, cwd) {
+    const result = spawnSync(command, args, {
+        cwd,
+        encoding: 'utf8',
+    });
+
+    if (result.status !== 0) {
+        throw new Error([
+            `Command failed: ${command} ${args.join(' ')}`,
+            result.stdout.trim(),
+            result.stderr.trim(),
+        ].filter(Boolean).join('\n'));
+    }
+
+    return result.stdout.trim();
+}
+
+function resolveChromeExecutable(explicitChrome) {
+    if (explicitChrome) {
+        return explicitChrome;
+    }
+
+    if (process.env.CHROME_BIN) {
+        return process.env.CHROME_BIN;
+    }
+
+    const candidates = [
+        'google-chrome',
+        'google-chrome-stable',
+        'chromium',
+        'chromium-browser',
+    ];
+
+    for (const candidate of candidates) {
+        const result = spawnSync('bash', ['-lc', `command -v ${candidate}`], {
+            encoding: 'utf8',
+        });
+
+        if (result.status === 0) {
+            return result.stdout.trim();
+        }
+    }
+
+    throw new Error('Unable to locate a Chrome/Chromium executable');
+}
+
+function resolveDefaultBaselineRef(candidateRoot) {
+    const refs = ['origin/master', 'master', 'origin/main', 'main'];
+
+    for (const ref of refs) {
+        const result = spawnSync('git', ['-C', candidateRoot, 'rev-parse', '--verify', '--quiet', `${ref}^{commit}`], {
+            encoding: 'utf8',
+        });
+
+        if (result.status === 0) {
+            return ref;
+        }
+    }
+
+    throw new Error('Unable to resolve a default baseline ref (tried origin/master, master, origin/main, main)');
+}
+
+function dirToFileUrl(dirPath) {
+    const href = pathToFileURL(path.resolve(dirPath)).href;
+    return href.endsWith('/') ? href : `${href}/`;
+}
+
+async function allocatePort() {
+    return await new Promise((resolve, reject) => {
+        const server = net.createServer();
+        server.listen(0, '127.0.0.1', () => {
+            const address = server.address();
+            server.close((error) => {
+                if (error) {
+                    reject(error);
+                    return;
+                }
+
+                resolve(address.port);
+            });
+        });
+        server.on('error', reject);
+    });
+}
+
+async function httpGetJson(url) {
+    return await new Promise((resolve, reject) => {
+        const request = http.get(url, (response) => {
+            let data = '';
+            response.setEncoding('utf8');
+            response.on('data', (chunk) => { data += chunk; });
+            response.on('end', () => {
+                try {
+                    resolve(JSON.parse(data));
+                } catch (error) {
+                    reject(error);
+                }
+            });
+        });
+
+        request.on('error', reject);
+    });
+}
+
+async function waitForDevtools(port, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        try {
+            await httpGetJson(`http://127.0.0.1:${port}/json/version`);
+            return;
+        } catch (error) {
+            await delay(100);
+        }
+    }
+
+    throw new Error(`Timed out waiting for Chrome DevTools on port ${port}`);
+}
+
+async function getPageTarget(port, expectedUrl, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+        const pages = await httpGetJson(`http://127.0.0.1:${port}/json/list`);
+        const page = pages.find((entry) => entry.type === 'page' && entry.url === expectedUrl);
+
+        if (page) {
+            return page;
+        }
+
+        await delay(100);
+    }
+
+    throw new Error(`Timed out waiting for page target: ${expectedUrl}`);
+}
+
+async function cdpEvaluate(page, expression) {
+    return await new Promise((resolve, reject) => {
+        const ws = new WebSocket(page.webSocketDebuggerUrl);
+
+        ws.addEventListener('open', () => {
+            ws.send(JSON.stringify({
+                id: 1,
+                method: 'Runtime.evaluate',
+                params: {
+                    expression,
+                    returnByValue: true,
+                },
+            }));
+        });
+
+        ws.addEventListener('message', (event) => {
+            try {
+                resolve(JSON.parse(event.data.toString()));
+            } catch (error) {
+                reject(error);
+            } finally {
+                ws.close();
+            }
+        });
+
+        ws.addEventListener('error', reject);
+    });
+}
+
+async function killChrome(child) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+        return;
+    }
+
+    const exited = new Promise((resolve) => child.once('exit', resolve));
+    child.kill('SIGTERM');
+    await Promise.race([exited, delay(5000)]);
+
+    if (child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGKILL');
+        await Promise.race([exited, delay(5000)]);
+    }
+}
+
+function createScenarioUrl(repoPath, scenario) {
+    const params = new URLSearchParams();
+    params.set('repo', dirToFileUrl(repoPath));
+    params.set('scenario', scenario.scenario);
+
+    if (scenario.params) {
+        for (const [key, value] of Object.entries(scenario.params)) {
+            params.set(key, String(value));
+        }
+    }
+
+    return `${pageUrl}?${params.toString()}`;
+}
+
+async function runScenario(chromeExecutable, repoPath, scenario) {
+    const port = await allocatePort();
+    const userDataDir = await mkdtemp(path.join(os.tmpdir(), 'novnc-rfb-bench-chrome-'));
+    const logs = [];
+    const scenarioUrl = createScenarioUrl(repoPath, scenario);
+    const child = spawn(chromeExecutable, [
+        '--headless',
+        '--no-sandbox',
+        '--disable-gpu',
+        '--disable-extensions',
+        '--disable-background-networking',
+        '--disable-component-update',
+        '--disable-default-apps',
+        '--disable-sync',
+        '--incognito',
+        '--no-default-browser-check',
+        '--no-first-run',
+        `--remote-debugging-port=${port}`,
+        `--user-data-dir=${userDataDir}`,
+        '--allow-file-access-from-files',
+        scenarioUrl,
+    ], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => { logs.push(chunk.trim()); });
+    child.stderr.on('data', (chunk) => { logs.push(chunk.trim()); });
+
+    try {
+        await waitForDevtools(port, 15000);
+        const page = await getPageTarget(port, scenarioUrl, 15000);
+        const deadline = Date.now() + 120000;
+
+        while (Date.now() < deadline) {
+            const response = await cdpEvaluate(page, `(() => ({
+                done: window.__BENCH_DONE === true,
+                error: window.__ERROR || null,
+                result: window.__RESULT || null,
+                status: document.getElementById('status')?.textContent || document.title,
+            }))()`);
+
+            const state = response.result.result.value;
+
+            if (state.done) {
+                if (state.error) {
+                    throw new Error(`Scenario ${scenario.name} failed:\n${state.error}`);
+                }
+
+                return state.result;
+            }
+
+            await delay(200);
+        }
+
+        throw new Error(`Scenario ${scenario.name} timed out`);
+    } catch (error) {
+        const logTail = logs.filter(Boolean).slice(-20).join('\n');
+        if (logTail) {
+            error.message = `${error.message}\n\nChrome log tail:\n${logTail}`;
+        }
+        throw error;
+    } finally {
+        await killChrome(child);
+        await rm(userDataDir, {
+            recursive: true,
+            force: true,
+            maxRetries: 5,
+            retryDelay: 100,
+        });
+    }
+}
+
+function formatMs(value) {
+    return `${value.toFixed(2)} ms`;
+}
+
+function formatPct(value) {
+    return `${value.toFixed(1)}%`;
+}
+
+function formatDeltaSentence(deltaPct) {
+    if (deltaPct >= 0) {
+        return `${formatPct(deltaPct)} faster on the candidate`;
+    }
+
+    return `${formatPct(Math.abs(deltaPct))} slower on the candidate`;
+}
+
+function summarizeComparison(baseline, candidate) {
+    const deltaPct = ((baseline.avgMs - candidate.avgMs) / baseline.avgMs) * 100;
+    return {
+        baseline,
+        candidate,
+        deltaPct,
+    };
+}
+
+function buildMarkdown(summary) {
+    const lines = [
+        '## Browser-level smoke + protocol-stream benchmark',
+        '',
+        `- Smoke test (\`smoke-raw\`): baseline ${summary.smoke.baseline.pass ? 'pass' : 'fail'}, candidate ${summary.smoke.candidate.pass ? 'pass' : 'fail'}, candidate pixel ${JSON.stringify(summary.smoke.candidate.pixel)}.`,
+        `- Parser-focused protocol benchmark (\`CopyRect\`, display stubbed): baseline ${formatMs(summary.parser.baseline.avgMs)}, candidate ${formatMs(summary.parser.candidate.avgMs)}, ${formatDeltaSentence(summary.parser.deltaPct)}.`,
+        `- Full-pipeline protocol benchmark (\`CopyRect\`, display active): baseline ${formatMs(summary.full.baseline.avgMs)}, candidate ${formatMs(summary.full.candidate.avgMs)}, delta ${formatPct(summary.full.deltaPct)}.`,
+        '',
+        'The parser-focused benchmark runs actual noVNC `RFB/Websock` protocol parsing on complete `FramebufferUpdate` messages and stubs the display layer so the measurement stays attributable to the receive path. When display work is included, the signal is largely drowned out by rendering cost, so the end-to-end delta is not a good attribution tool for this specific change.',
+    ];
+
+    return lines.join('\n');
+}
+
+async function createBaselineWorktree(candidateRoot, baselineRef) {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'novnc-rfb-bench-baseline-'));
+    const worktreePath = path.join(tempRoot, 'checkout');
+    runCommand('git', ['-C', candidateRoot, 'worktree', 'add', '--detach', worktreePath, baselineRef], candidateRoot);
+    return { tempRoot, worktreePath };
+}
+
+async function removeBaselineWorktree(candidateRoot, worktree) {
+    try {
+        runCommand('git', ['-C', candidateRoot, 'worktree', 'remove', '--force', worktree.worktreePath], candidateRoot);
+    } finally {
+        await rm(worktree.tempRoot, { recursive: true, force: true });
+    }
+}
+
+async function main() {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+        printHelp();
+        return;
+    }
+
+    const chromeExecutable = resolveChromeExecutable(options.chrome);
+    const candidateRoot = path.resolve(options.candidate);
+    const baselineRef = options.baseline ? null : (options.baselineRef || resolveDefaultBaselineRef(candidateRoot));
+
+    let baselineRoot = options.baseline ? path.resolve(options.baseline) : null;
+    let worktree = null;
+
+    if (!baselineRoot) {
+        worktree = await createBaselineWorktree(candidateRoot, baselineRef);
+        baselineRoot = worktree.worktreePath;
+    }
+
+    try {
+        const smokeScenario = DEFAULT_SCENARIOS.find((scenario) => scenario.name === 'smoke-raw');
+        const parserScenario = DEFAULT_SCENARIOS.find((scenario) => scenario.name === 'protocol-copyrect-parser');
+        const fullScenario = DEFAULT_SCENARIOS.find((scenario) => scenario.name === 'protocol-copyrect-full');
+
+        const smokeBaseline = await runScenario(chromeExecutable, baselineRoot, smokeScenario);
+        const smokeCandidate = await runScenario(chromeExecutable, candidateRoot, smokeScenario);
+        const parserBaseline = await runScenario(chromeExecutable, baselineRoot, parserScenario);
+        const parserCandidate = await runScenario(chromeExecutable, candidateRoot, parserScenario);
+        const fullBaseline = await runScenario(chromeExecutable, baselineRoot, fullScenario);
+        const fullCandidate = await runScenario(chromeExecutable, candidateRoot, fullScenario);
+
+        const summary = {
+            chromeExecutable,
+            candidateRoot,
+            baselineRoot,
+            baselineRef,
+            smoke: {
+                baseline: smokeBaseline,
+                candidate: smokeCandidate,
+            },
+            parser: summarizeComparison(parserBaseline, parserCandidate),
+            full: summarizeComparison(fullBaseline, fullCandidate),
+        };
+
+        if (options.json) {
+            console.log(JSON.stringify(summary, null, 2));
+            return;
+        }
+
+        console.log(JSON.stringify(summary, null, 2));
+        console.log('\nSuggested PR summary:\n');
+        console.log(buildMarkdown(summary));
+    } finally {
+        if (worktree && !options.keepWorktree) {
+            await removeBaselineWorktree(candidateRoot, worktree);
+        }
+    }
+}
+
+main().catch((error) => {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exitCode = 1;
+});

--- a/tests/test.rfb.js
+++ b/tests/test.rfb.js
@@ -107,6 +107,7 @@ describe('Remote Frame Buffer protocol client', function () {
         Websock.prototype._allocateBuffers = function () {
             this._sQ = _sQ;
             this._rQ = rQ;
+            this._rQdv = new DataView(this._rQ.buffer);
         };
 
         // Avoiding printing the entire Websock buffer on errors

--- a/tests/test.websock.js
+++ b/tests/test.websock.js
@@ -580,6 +580,7 @@ describe('Websock', function () {
 
         it('should compact the receive queue when fully read', function () {
             sock._rQ = new Uint8Array([0, 1, 2, 3, 4, 5, 0, 0, 0, 0]);
+            sock._rQdv = new DataView(sock._rQ.buffer);
             sock._rQlen = 6;
             sock._rQi = 6;
             const msg = { data: new Uint8Array([1, 2, 3]).buffer };
@@ -590,6 +591,7 @@ describe('Websock', function () {
 
         it('should compact the receive queue when we reach the end of the buffer', function () {
             sock._rQ = new Uint8Array(20);
+            sock._rQdv = new DataView(sock._rQ.buffer);
             sock._rQbufferSize = 20;
             sock._rQlen = 20;
             sock._rQi = 10;
@@ -601,6 +603,7 @@ describe('Websock', function () {
 
         it('should automatically resize the receive queue if the incoming message is larger than the buffer', function () {
             sock._rQ = new Uint8Array(20);
+            sock._rQdv = new DataView(sock._rQ.buffer);
             sock._rQlen = 0;
             sock._rQi = 0;
             sock._rQbufferSize = 20;
@@ -613,6 +616,7 @@ describe('Websock', function () {
 
         it('should automatically resize the receive queue if the incoming message is larger than 1/8th of the buffer and we reach the end of the buffer', function () {
             sock._rQ = new Uint8Array(20);
+            sock._rQdv = new DataView(sock._rQ.buffer);
             sock._rQlen = 16;
             sock._rQi = 15;
             sock._rQbufferSize = 20;


### PR DESCRIPTION
## Summary

- Replace the byte-by-byte addition in `core/websock.js:_rQshift()` with a DataView-backed fast path for 1/2/4 byte reads to cut CPU time in the receive queue.
- Maintain a cached DataView whenever the receive queue buffer is allocated or resized so the optimized path is always available.
- Capture and share reproducible browser benchmarks that highlight the performance win across different engines and machines.

## Performance Summary

Average speed-up = mean reduction in the 1/2/4-byte benchmark cases (higher is better).

```
Speed-up (% faster)
                0        10       20       30       40       50
                |--------|--------|--------|--------|--------|
Chrome   45.2%  █████████████████████████████████████████
Edge     40.9%  █████████████████████████████████████
Firefox  29.9%  ███████████████████████████
Safari   43.5%  ███████████████████████████████████████

```

| Browser / Platform | Avg speed-up |
| --- | --- |
| Windows Chrome 142 | 43.6% faster |
| Windows Chrome 142 (Machine 2) | 46.4% faster |
| Windows Chrome 101 | 41.7% faster |
| Windows Chrome 92.0 | 45.6% faster |
| Windows Chrome 83.0 | 44.7% faster |
| Windows Chrome 71.0 | 49.0% faster |
| Windows Edge 142 | 46.1% faster |
| Windows Edge 142 (Machine 2) | 35.6% faster |
| Windows Firefox 113 | 31.6% faster |
| Windows Firefox 142 | 35.7% faster |
| Windows Firefox 145.0 | 22.5% faster |
| Safari 18 | 43.5% faster |

## Testing

- Manual benchmark – Windows 10, Chrome 142 (20 logical cores) ✅
- Manual benchmark – Windows 10, Chrome 142 (dual-core machine) ✅
- Manual benchmark – Windows 10, Chrome 101/92/83/71 ✅
- Manual benchmark – Windows 10, Edge 142 (two hardware profiles) ✅
- Manual benchmark – Windows 10, Firefox 113/142/145 ✅
- Manual benchmark – macOS 10.15, Safari 18.6 ✅

## Benchmark Results

### Windows Chrome 142

| Key | Value | Key | Value |
| --- | ----- | --- | ----- |
| Buffer size (bytes) | 67108864 | Buffer size (MB) | 64.0 |
| Rounds per case | 10 | Bytes tested | 1, 2, 4 |
| Timer | performance.now() | User agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 |
| Platform | Win32 | HW concurrency | 20 |
| Device memory (GB) | 8 | Language | zh-CN |
| Languages | zh-CN, zh | Screen resolution | 2560x1440 |
| Screen pixel depth | 24 | JS heap size limit (MB) | 4095.8 |
| Total JS heap (MB) | 183.7 | Used JS heap (MB) | 176.1 |
| Performance timeOrigin | 1763268027246.2 |  |  |

| Bytes | Method   | Rounds | Avg ms | Min ms | Max ms | Winner |
| ----- | -------- | ------ | ------ | ------ | ------ | ------ |
| 1 | loop     | 10 | 205.920 | 192.900 | 249.300 |  |
| 1 | DataView | 10 | 164.550 | 156.800 | 201.300 | 🏆 |
| 2 | loop     | 10 | 179.260 | 177.000 | 181.200 |  |
| 2 | DataView | 10 | 99.260 | 96.000 | 118.300 | 🏆 |
| 4 | loop     | 10 | 184.910 | 181.100 | 197.600 |  |
| 4 | DataView | 10 | 62.880 | 60.700 | 73.600 | 🏆 |

### Windows Chrome 142(Machine 2)

| Key | Value | Key | Value |
| --- | ----- | --- | ----- |
| Buffer size (bytes) | 67108864 | Buffer size (MB) | 64.0 |
| Rounds per case | 10 | Bytes tested | 1, 2, 4 |
| Timer | performance.now() | User agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 |
| Platform | Win32 | HW concurrency | 2 |
| Device memory (GB) | 8 | Language | zh-CN |
| Languages | zh-CN, zh | Screen resolution | 2560x1440 |
| Screen pixel depth | 24 | JS heap size limit (MB) | 4095.8 |
| Total JS heap (MB) | 75.5 | Used JS heap (MB) | 72.3 |
| Performance timeOrigin | 1763455005177.6 |  |  |

| Bytes | Method   | Rounds | Avg ms | Min ms | Max ms | Winner |
| ----- | -------- | ------ | ------ | ------ | ------ | ------ |
| 1 | loop     | 10 | 366.130 | 353.100 | 424.600 |  |
| 1 | DataView | 10 | 235.270 | 226.700 | 275.500 | 🏆 |
| 2 | loop     | 10 | 215.860 | 206.400 | 279.500 |  |
| 2 | DataView | 10 | 136.190 | 129.600 | 166.100 | 🏆 |
| 4 | loop     | 10 | 261.090 | 238.400 | 290.300 |  |
| 4 | DataView | 10 | 87.640 | 76.900 | 96.700 | 🏆 |

### Windows Chrome 101

| Key | Value | Key | Value |
| --- | ----- | --- | ----- |
| Buffer size (bytes) | 67108864 | Buffer size (MB) | 64.0 |
| Rounds per case | 10 | Bytes tested | 1, 2, 4 |
| Timer | performance.now() | User agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.0.0 Safari/537.36 |
| Platform | Win32 | HW concurrency | 2 |
| Device memory (GB) | 8 | Language | zh-CN |
| Languages | zh-CN, zh | Screen resolution | 2560x1440 |
| Screen pixel depth | 24 | JS heap size limit (MB) | 4095.8 |
| Total JS heap (MB) | 73.5 | Used JS heap (MB) | 71.3 |
| Performance timeOrigin | 1763454953935.7 |  |  |

| Bytes | Method   | Rounds | Avg ms | Min ms | Max ms | Winner |
| ----- | -------- | ------ | ------ | ------ | ------ | ------ |
| 1 | loop     | 10 | 292.310 | 270.600 | 343.900 |  |
| 1 | DataView | 10 | 243.210 | 228.300 | 273.700 | 🏆 |
| 2 | loop     | 10 | 227.190 | 216.700 | 290.900 |  |
| 2 | DataView | 10 | 127.550 | 123.700 | 147.800 | 🏆 |
| 4 | loop     | 10 | 238.620 | 233.300 | 264.500 |  |
| 4 | DataView | 10 | 85.110 | 81.900 | 98.400 | 🏆 |

### Windows Chrome 92.0

| Key | Value | Key | Value |
| --- | ----- | --- | ----- |
| Buffer size (bytes) | 67108864 | Buffer size (MB) | 64.0 |
| Rounds per case | 10 | Bytes tested | 1, 2, 4 |
| Timer | performance.now() | User agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36 |
| Platform | Win32 | HW concurrency | 2 |
| Device memory (GB) | 8 | Language | zh-CN |
| Languages | zh-CN, zh | Screen resolution | 2560x1440 |
| Screen pixel depth | 24 | JS heap size limit (MB) | 4095.8 |
| Total JS heap (MB) | 72.2 | Used JS heap (MB) | 69.8 |
| Performance timeOrigin | 1763454862654.8 |  |  |

| Bytes | Method   | Rounds | Avg ms | Min ms | Max ms | Winner |
| ----- | -------- | ------ | ------ | ------ | ------ | ------ |
| 1 | loop     | 10 | 332.680 | 310.400 | 374.800 |  |
| 1 | DataView | 10 | 239.060 | 226.800 | 267.200 | 🏆 |
| 2 | loop     | 10 | 224.740 | 217.400 | 248.000 |  |
| 2 | DataView | 10 | 127.160 | 122.800 | 154.100 | 🏆 |
| 4 | loop     | 10 | 241.880 | 230.600 | 282.900 |  |
| 4 | DataView | 10 | 83.860 | 75.000 | 113.400 | 🏆 |

### Windows Chrome 83.0

| Key | Value | Key | Value |
| --- | ----- | --- | ----- |
| Buffer size (bytes) | 67108864 | Buffer size (MB) | 64.0 |
| Rounds per case | 10 | Bytes tested | 1, 2, 4 |
| Timer | performance.now() | User agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36 |
| Platform | Win32 | HW concurrency | 2 |
| Device memory (GB) | 8 | Language | zh-CN |
| Languages | zh-CN, zh | Screen resolution | 2560x1440 |
| Screen pixel depth | 24 | JS heap size limit (MB) | 3585.8 |
| Total JS heap (MB) | 73.1 | Used JS heap (MB) | 68.9 |
| Performance timeOrigin | 1763454793849.9363 |  |  |

| Bytes | Method   | Rounds | Avg ms | Min ms | Max ms | Winner |
| ----- | -------- | ------ | ------ | ------ | ------ | ------ |
| 1 | loop     | 10 | 372.971 | 349.125 | 447.595 |  |
| 1 | DataView | 10 | 288.493 | 251.800 | 475.025 | 🏆 |
| 2 | loop     | 10 | 269.894 | 263.340 | 302.725 |  |
| 2 | DataView | 10 | 148.638 | 144.555 | 166.145 | 🏆 |
| 4 | loop     | 10 | 267.037 | 245.535 | 303.445 |  |
| 4 | DataView | 10 | 89.074 | 82.745 | 119.115 | 🏆 |


### Windows Chrome 71.0

| Key | Value | Key | Value |
| --- | ----- | --- | ----- |
| Buffer size (bytes) | 67108864 | Buffer size (MB) | 64.0 |
| Rounds per case | 10 | Bytes tested | 1, 2, 4 |
| Timer | performance.now() | User agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.44 Safari/537.36 |
| Platform | Win32 | HW concurrency | 2 |
| Device memory (GB) | 8 | Language | zh-CN |
| Languages | zh-CN, zh | Screen resolution | 2560x1440 |
| Screen pixel depth | 24 | JS heap size limit (MB) | 2222.1 |
| Total JS heap (MB) | 9.5 | Used JS heap (MB) | 9.5 |
| Performance timeOrigin | 1763454480039.055 |  |  |

| Bytes | Method   | Rounds | Avg ms | Min ms | Max ms | Winner |
| ----- | -------- | ------ | ------ | ------ | ------ | ------ |
| 1 | loop     | 10 | 268.720 | 224.600 | 449.000 |  |
| 1 | DataView | 10 | 218.370 | 210.400 | 236.700 | 🏆 |
| 2 | loop     | 10 | 318.890 | 229.300 | 422.500 |  |
| 2 | DataView | 10 | 151.140 | 113.800 | 217.400 | 🏆 |
| 4 | loop     | 10 | 259.290 | 229.800 | 318.600 |  |
| 4 | DataView | 10 | 63.390 | 57.000 | 81.200 | 🏆 |

### Windows Edge 142

| Key | Value | Key | Value |
| --- | ----- | --- | ----- |
| Buffer size (bytes) | 67108864 | Buffer size (MB) | 64.0 |
| Rounds per case | 10 | Bytes tested | 1, 2, 4 |
| Timer | performance.now() | User agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0 |
| Platform | Win32 | HW concurrency | 16 |
| Device memory (GB) | 8 | Language | en |
| Languages | en, zh-CN, en-GB, en-US | Screen resolution | 2560x1440 |
| Screen pixel depth | 24 | JS heap size limit (MB) | 4095.8 |
| Total JS heap (MB) | 123.7 | Used JS heap (MB) | 114.7 |
| Performance timeOrigin | 1763453859070.7 |  |  |


| Bytes | Method   | Rounds | Avg ms | Min ms | Max ms | Winner |
| ----- | -------- | ------ | ------ | ------ | ------ | ------ |
| 1 | loop     | 10 | 281.940 | 267.900 | 343.200 |  |
| 1 | DataView | 10 | 213.270 | 202.200 | 268.100 | 🏆 |
| 2 | loop     | 10 | 228.380 | 226.100 | 241.200 |  |
| 2 | DataView | 10 | 126.480 | 123.100 | 155.000 | 🏆 |
| 4 | loop     | 10 | 249.870 | 246.300 | 264.600 |  |
| 4 | DataView | 10 | 76.660 | 74.500 | 88.000 | 🏆 |

### Windows Edge 142(Machine 2)

| Key | Value | Key | Value |
| --- | ----- | --- | ----- |
| Buffer size (bytes) | 67108864 | Buffer size (MB) | 64.0 |
| Rounds per case | 10 | Bytes tested | 1, 2, 4 |
| Timer | performance.now() | User agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0 |
| Platform | Win32 | HW concurrency | 2 |
| Device memory (GB) | 8 | Language | zh-CN |
| Languages | zh-CN, en, en-GB, en-US | Screen resolution | 2560x1440 |
| Screen pixel depth | 24 | JS heap size limit (MB) | 4095.8 |
| Total JS heap (MB) | 93.1 | Used JS heap (MB) | 89.2 |
| Performance timeOrigin | 1763432982331 |  |  |

| Bytes | Method   | Rounds | Avg ms | Min ms | Max ms | Winner |
| ----- | -------- | ------ | ------ | ------ | ------ | ------ |
| 1 | loop     | 10 | 281.980 | 249.200 | 366.600 |  |
| 1 | DataView | 10 | 245.630 | 233.200 | 272.700 | 🏆 |
| 2 | loop     | 10 | 260.800 | 207.600 | 384.000 |  |
| 2 | DataView | 10 | 211.140 | 135.500 | 398.800 | 🏆 |
| 4 | loop     | 10 | 868.830 | 295.300 | 3937.300 |  |
| 4 | DataView | 10 | 219.100 | 90.300 | 735.600 | 🏆 |

### Windows Firefox 113

| Key | Value | Key | Value |
| --- | ----- | --- | ----- |
| Buffer size (bytes) | 67108864 | Buffer size (MB) | 64.0 |
| Rounds per case | 10 | Bytes tested | 1, 2, 4 |
| Timer | performance.now() | User agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/113.0 |
| Platform | Win32 | HW concurrency | 2 |
| Language | zh-CN | Languages | zh-CN, zh, zh-TW, zh-HK, en-US, en |
| Screen resolution | 2560x1440 | Screen pixel depth | 24 |
| Performance timeOrigin | 1763454236144 |  |  |

| Bytes | Method   | Rounds | Avg ms | Min ms | Max ms | Winner |
| ----- | -------- | ------ | ------ | ------ | ------ | ------ |
| 1 | loop     | 10 | 679.600 | 611.000 | 918.000 |  |
| 1 | DataView | 10 | 656.000 | 621.000 | 747.000 | 🏆 |
| 2 | loop     | 10 | 500.000 | 487.000 | 519.000 |  |
| 2 | DataView | 10 | 364.100 | 342.000 | 430.000 | 🏆 |
| 4 | loop     | 10 | 893.800 | 590.000 | 1707.000 |  |
| 4 | DataView | 10 | 319.800 | 244.000 | 506.000 | 🏆 |

### Windows Firefox 142

| Key | Value | Key | Value |
| --- | ----- | --- | ----- |
| Buffer size (bytes) | 67108864 | Buffer size (MB) | 64.0 |
| Rounds per case | 10 | Bytes tested | 1, 2, 4 |
| Timer | performance.now() | User agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:142.0) Gecko/20100101 Firefox/142.0 |
| Platform | Win32 | HW concurrency | 2 |
| Language | zh-CN | Languages | zh-CN, zh, zh-TW, zh-HK, en-US, en |
| Screen resolution | 2560x1440 | Screen pixel depth | 24 |
| Performance timeOrigin | 1763454368830 |  |  |

| Bytes | Method   | Rounds | Avg ms | Min ms | Max ms | Winner |
| ----- | -------- | ------ | ------ | ------ | ------ | ------ |
| 1 | loop     | 10 | 1069.500 | 547.000 | 2812.000 |  |
| 1 | DataView | 10 | 614.900 | 532.000 | 700.000 | 🏆 |
| 2 | loop     | 10 | 457.100 | 386.000 | 562.000 |  |
| 2 | DataView | 10 | 378.400 | 327.000 | 550.000 | 🏆 |
| 4 | loop     | 10 | 498.000 | 244.000 | 2302.000 |  |
| 4 | DataView | 10 | 261.600 | 196.000 | 591.000 | 🏆 |

### Windows Firefox 145.0

| Key | Value | Key | Value |
| --- | ----- | --- | ----- |
| Buffer size (bytes) | 67108864 | Buffer size (MB) | 64.0 |
| Rounds per case | 10 | Bytes tested | 1, 2, 4 |
| Timer | performance.now() | User agent | Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:145.0) Gecko/20100101 Firefox/145.0 |
| Platform | Win32 | HW concurrency | 2 |
| Language | zh-CN | Languages | zh-CN, zh, zh-TW, zh-HK, en-US, en |
| Screen resolution | 2560x1440 | Screen pixel depth | 24 |
| Performance timeOrigin | 1763455136427 |  |  |

| Bytes | Method   | Rounds | Avg ms | Min ms | Max ms | Winner |
| ----- | -------- | ------ | ------ | ------ | ------ | ------ |
| 1 | loop     | 10 | 601.100 | 541.000 | 749.000 |  |
| 1 | DataView | 10 | 503.900 | 459.000 | 646.000 | 🏆 |
| 2 | loop     | 10 | 426.900 | 346.000 | 525.000 |  |
| 2 | DataView | 10 | 327.800 | 268.000 | 377.000 | 🏆 |
| 4 | loop     | 10 | 256.500 | 233.000 | 310.000 |  |
| 4 | DataView | 10 | 184.100 | 169.000 | 203.000 | 🏆 |

### Safari 18

| Key | Value | Key | Value |
| --- | ----- | --- | ----- |
| Buffer size (bytes) | 67108864 | Buffer size (MB) | 64.0 |
| Rounds per case | 10 | Bytes tested | 1, 2, 4 |
| Timer | performance.now() | User agent | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Safari/605.1.15 |
| Platform | MacIntel | HW concurrency | 4 |
| Language | en-US | Languages | en-US |
| Screen resolution | 3840x2160 | Screen pixel depth | 24 |
| Performance timeOrigin | 1763455352927 |  |  |

| Bytes | Method   | Rounds | Avg ms | Min ms | Max ms | Winner |
| ----- | -------- | ------ | ------ | ------ | ------ | ------ |
| 1 | loop     | 10 | 1415.600 | 1365.000 | 1546.000 |  |
| 1 | DataView | 10 | 962.200 | 934.000 | 1029.000 | 🏆 |
| 2 | loop     | 10 | 889.100 | 870.000 | 917.000 |  |
| 2 | DataView | 10 | 472.100 | 468.000 | 474.000 | 🏆 |
| 4 | loop     | 10 | 849.900 | 694.000 | 1098.000 |  |
| 4 | DataView | 10 | 412.500 | 269.000 | 615.000 | 🏆 |

## Karma Test

```
  Websock
    Receive queue methods
      rQpeek8
        √ should peek at the next byte without poping it off the queue
      rQshift8()
        √ should pop a single byte from the receive queue
      rQshift16()
        √ should pop two bytes from the receive queue and return a single number
      rQshift32()
        √ should pop four bytes from the receive queue and return a single number
      rQlen())
        √ should return the number of buffered bytes in the receive queue
      rQshiftStr
        √ should shift the given number of bytes off of the receive queue and return a string
        √ should be able to handle very large strings
      rQshiftBytes
        √ should shift the given number of bytes of the receive queue and return an array
        √ should return a shared array if requested
      rQpeekBytes
        √ should not modify the receive queue
        √ should return a shared array if requested
      rQwait
        √ should return true if there are not enough bytes in the receive queue
        √ should return false if there are enough bytes in the receive queue
        √ should return true and reduce rQi by "goback" if there are not enough bytes
        √ should raise an error if we try to go back more than possible
        √ should not reduce rQi if there are enough bytes
    Send queue methods
      sQpush8()
        √ should send a single byte
        √ should not send any data until flushing
        √ should implicitly flush if the queue is full
      sQpush16()
        √ should send a number as two bytes
        √ should not send any data until flushing
        √ should implicitly flush if the queue is full
      sQpush32()
        √ should send a number as two bytes
        √ should not send any data until flushing
        √ should implicitly flush if the queue is full
      sQpushString()
        √ should send a string buffer
        √ should not send any data until flushing
        √ should implicitly flush if the queue is full
        √ should implicitly split a large buffer
      sQpushBytes()
        √ should send a byte buffer
        √ should not send any data until flushing
        √ should implicitly flush if the queue is full
        √ should implicitly split a large buffer
      flush
        √ should actually send on the websocket
        √ should not call send if we do not have anything queued up
    lifecycle methods
      opening
        √ should pick the correct protocols if none are given
        √ should open the actual websocket
      attaching
        √ should attach to an existing websocket
      closing
        √ should close the actual websocket if it is open
        √ should close the actual websocket if it is connecting
        √ should not try to close the actual websocket if closing
        √ should not try to close the actual websocket if closed
        √ should reset onmessage to not call _recvMessage
      event handlers
        √ should call _recvMessage on a message
        √ should call the open event handler on opening
        √ should call the close event handler on closing
        √ should call the error event handler on error
      ready state
        √ should be "unused" after construction
        √ should be "connecting" if WebSocket is connecting
        √ should be "open" if WebSocket is open
        √ should be "closing" if WebSocket is closing
        √ should be "closed" if WebSocket is closed
        √ should be "unknown" if WebSocket state is unknown
        √ should be "connecting" if RTCDataChannel is connecting
        √ should be "open" if RTCDataChannel is open
        √ should be "closing" if RTCDataChannel is closing
        √ should be "closed" if RTCDataChannel is closed
        √ should be "unknown" if RTCDataChannel state is unknown
    WebSocket receiving
      √ should support adding data to the receive queue
      √ should call the message event handler if present
      √ should not call the message event handler if there is nothing in the receive queue
      √ should compact the receive queue when fully read
      √ should compact the receive queue when we reach the end of the buffer
      √ should automatically resize the receive queue if the incoming message is larger than the buffer
      √ should automatically resize the receive queue if the incoming message is larger than 1/8th of the buffer and we reach the end of the buffer

```

## Can I use

https://caniuse.com/mdn-javascript_builtins_dataview