### PR TITLE
Fix comment typo in display.js

### DIFF
--- a/core/display.js
+++ b/core/display.js
@@ -14,7 +14,7 @@ export default class Display {
     constructor(target) {
         this._drawCtx = null;
 
-        this._renderQ = [];  // queue drawing actions for in-oder rendering
+        this._renderQ = [];  // queue drawing actions for in-order rendering
         this._flushPromise = null;
 
         // the full frame buffer (logical canvas) size


### PR DESCRIPTION
I noticed a simple typo - "inoder rendering"