### PR TITLE
Fix H264 hardware video decoding failure

### DIFF
--- a/core/decoders/h264.js
+++ b/core/decoders/h264.js
@@ -196,9 +196,9 @@ export class H264Context {
             }
 
             if (parser.profileIdc !== null) {
-                self._profileIdc = parser.profileIdc;
-                self._constraintSet = parser.constraintSet;
-                self._levelIdc = parser.levelIdc;
+                this._profileIdc = parser.profileIdc;
+                this._constraintSet = parser.constraintSet;
+                this._levelIdc = parser.levelIdc;
             }
 
             if (this._decoder === null || this._decoder.state !== 'configured') {
@@ -206,12 +206,12 @@ export class H264Context {
                     Log.Warn("Missing key frame. Can't decode until one arrives");
                     continue;
                 }
-                if (self._profileIdc === null) {
+                if (this._profileIdc === null) {
                     Log.Warn('Cannot config decoder. Have not received SPS and PPS yet.');
                     continue;
                 }
-                this._configureDecoder(self._profileIdc, self._constraintSet,
-                                       self._levelIdc);
+                this._configureDecoder(this._profileIdc, this._constraintSet,
+                                       this._levelIdc);
             }
 
             result = this._preparePendingFrame(timestamp);


### PR DESCRIPTION
### Summary

H264 decoding via WebCodecs `VideoDecoder` silently fails when hardware acceleration is used (e.g. Intel iGPU with D3D11 on Windows). The screen stays blank with no errors in the console. This PR fixes two issues:

1. **`self` vs `this` typo in `H264Context.decode()`** — `self` refers to `window` in browser context, so SPS parameters (profile, constraint set, level) were being set on the global object instead of the `H264Context` instance, preventing the decoder from ever being configured.

2. **Render queue deadlock with hardware video decoder** — The display render queue blocks on unready video frames (`ready = false`), which triggers the `_flushing` backpressure mechanism in `rfb.js`, stopping all VNC message processing. This starves the `VideoDecoder` pipeline of input. Hardware decoders (unlike software decoders) may buffer frames internally for reordering (e.g. H264 High profile allows B-frames), requiring continued input before producing output. The result is a deadlock:

   ```
   Decoder waiting for more input → render queue waiting for decoder output
   → _flushing stops VNC messages → no more input fed to decoder → deadlock
   ```

### Changes

- **`core/decoders/h264.js`**: Replace `self._profileIdc` / `self._constraintSet` / `self._levelIdc` with `this.*`
- **`core/display.js`**:
  - Video frames that aren't ready no longer block the render queue. Instead, they register an async callback to draw when the decoder produces output, allowing subsequent frames to continue being fed to the decoder.
  - The `flip` operation waits for all pending video frames to resolve before executing (`Promise.all`), preserving visual correctness.
  - Extract `_drawVideoFrame()` helper to deduplicate the frame drawing logic.

### Root cause analysis

Confirmed via `chrome://tracing` on Windows 10 with Intel UHD Graphics:

- The D3D11 hardware decoder accepted 3 H264 frames (1 keyframe + 2 delta) with `kOk` status
- `DoDecode` completed successfully, `CreatePictureBuffers` was called
- `BeginScopedWriteAccess` was called 3 times but `EndScopedWriteAccess` was never called — the decoder held frames in its internal buffer
- Zero `OutputResult` events, zero JS output callbacks
- After ~6 seconds of silence, `VideoDecoder::Shutdown` was called

The render queue's blocking pattern was originally designed for `Image` objects (Tight/TightPNG encoding), where each image decodes independently. The same pattern was applied to video frames when H264 support was added, but `VideoDecoder` is a pipeline that requires continuous input flow — blocking the queue cuts off the input and creates a deadlock.

### Tests

- [x] Verify H264 decoding works with hardware acceleration on Intel iGPU (Windows)
- [x] Verify H264 decoding still works with software decoding fallback
- [x] Verify no visual tearing or frame ordering issues during H264 playback
