### PR TITLE
Add optional username field for auth

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1047,6 +1047,12 @@ const UI = {
             password = undefined;
         }
 
+        let username = UI.getSetting('username');
+
+        if (username === null) {
+            username = undefined;
+        }
+
         UI.hideStatus();
 
         UI.closeConnectPanel();
@@ -1085,7 +1091,7 @@ const UI = {
                              url.href,
                              { shared: UI.getSetting('shared'),
                                repeaterID: UI.getSetting('repeaterID'),
-                               credentials: { password: password } });
+                               credentials: { username: username, password: password } });
         } catch (exc) {
             Log.Error("Failed to connect to server: " + exc);
             UI.updateVisualState('disconnected');


### PR DESCRIPTION
We see no reason not to support username.  Necessary for e.g. when using PAM auth with wayvnc. 

Disclaimer: I had this patched into our OpenOndemand repo, which still was on noVNC 1.3.0, so I haven't tested this with master branch, but the only change I saw was `WebUtil` -> `UI` and the changes are rather trivial. 