### PR TITLE
Replace top-level await with then() in browser.js

### DIFF
--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -182,7 +182,10 @@ async function _checkWebCodecsH264DecodeSupport() {
 
     return true;
 }
-supportsWebCodecsH264Decode = await _checkWebCodecsH264DecodeSupport();
+
+_checkWebCodecsH264DecodeSupport().then(result => {
+    supportsWebCodecsH264Decode = result;
+});
 
 /*
  * The functions for detection of platforms and browsers below are exported

--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -183,7 +183,9 @@ async function _checkWebCodecsH264DecodeSupport() {
     return true;
 }
 
-_checkWebCodecsH264DecodeSupport().then(result => {
+// FIXME: Avoid top-level await due to a Chromium bug where Decoder.flush()
+// can hang indefinitely on some Android devices, blocking module evaluation.
+_checkWebCodecsH264DecodeSupport().then((result) => {
     supportsWebCodecsH264Decode = result;
 });
 


### PR DESCRIPTION
On certain Android Chromium browsers, `Decoder.flush()` may hang indefinitely. As a result, the associated promise remains in a pending state, preventing the page from loading because the top‑level `await` blocks module evaluation.