### PR TITLE
Improve credentials input focus logic

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1289,12 +1289,15 @@ const UI = {
         if (e.detail.types.indexOf("username") === -1) {
             document.getElementById("noVNC_username_block").classList.add("noVNC_hidden");
         } else {
-            inputFocus = inputFocus === "none" ? "noVNC_username_input" : inputFocus;
+            inputFocus = inputFocus === "none" &&
+                document.getElementById("noVNC_username_input").value === ""
+                ? "noVNC_username_input" : inputFocus;
         }
         if (e.detail.types.indexOf("password") === -1) {
             document.getElementById("noVNC_password_block").classList.add("noVNC_hidden");
         } else {
-            inputFocus = inputFocus === "none" ? "noVNC_password_input" : inputFocus;
+            inputFocus = inputFocus === "none"
+                ? "noVNC_password_input" : inputFocus;
         }
         document.getElementById('noVNC_credentials_dlg')
             .classList.add('noVNC_open');

--- a/app/ui.js
+++ b/app/ui.js
@@ -1288,16 +1288,13 @@ const UI = {
         let inputFocus = "none";
         if (e.detail.types.indexOf("username") === -1) {
             document.getElementById("noVNC_username_block").classList.add("noVNC_hidden");
-        } else {
-            inputFocus = inputFocus === "none" &&
-                document.getElementById("noVNC_username_input").value === ""
-                ? "noVNC_username_input" : inputFocus;
+        } else if (document.getElementById("noVNC_username_input").value === "") {
+            inputFocus = "noVNC_username_input";
         }
         if (e.detail.types.indexOf("password") === -1) {
             document.getElementById("noVNC_password_block").classList.add("noVNC_hidden");
-        } else {
-            inputFocus = inputFocus === "none"
-                ? "noVNC_password_input" : inputFocus;
+        } else if (inputFocus === "none") {
+            inputFocus = "noVNC_password_input";
         }
         document.getElementById('noVNC_credentials_dlg')
             .classList.add('noVNC_open');


### PR DESCRIPTION
Hi. First of all, thank you so much for this amazing piece of software :slightly_smiling_face: it's very useful to me!

With this PR I propose a very simple change: when the credentials input dialog is shown, the **username** field should be focused only if it's empty. Otherwise the **password** field should be focused instead.

## Rationale

I propose this change because sometimes I find myself doing this:

1. I click the `Disconnect` button and/or I restart my VNC server (**without** reloading the noVNC browser tab)
2. I click the `Connect` button to reconnect to the server
3. At this point the "Username" field is already filled
4. I accidentally start typing the password in the username field, which is now focused even if it already cointains data, but it's **not masked** and so the password is shown in clear text on the screen :smiling_face_with_tear: 

![](https://github.com/user-attachments/assets/efc6a4cd-e4ef-408b-a1ae-5adbeb96cfb7)

After the proposed changes, the "Password" field would be focused instead, so the password is safely masked:

![](https://github.com/user-attachments/assets/9adac3bc-a9b0-429a-a526-b41d9f4801b5)

Let me know what you think :wink: Thanks in advance! And have a great day