### PR TITLE
Use macOS 26 runner instead of macOS 10.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,10 @@ jobs:
           - ChromeHeadless
           - FirefoxHeadless
         include:
-          - os: macos-latest
+          # FIXME: We'd like to use "macos-latest", but Safari tests
+          #        are flaky on it and timeout often. As of 2026-05-23
+          #        macos-latest is still on 10.15.
+          - os: macos-26
             browser: Safari
           - os: windows-latest
             browser: EdgeHeadless


### PR DESCRIPTION
This is a workaround for failing tests on Safari.