### PR TITLE
Fix silent module load failure in Chrome 86-93 due to missing VideoDecoder.isConfigSupported

### DIFF
--- a/core/util/browser.js
+++ b/core/util/browser.js
@@ -107,7 +107,8 @@ export const hasScrollbarGutter = _hasScrollbarGutter;
 export let supportsWebCodecsH264Decode = false;
 
 async function _checkWebCodecsH264DecodeSupport() {
-    if (!('VideoDecoder' in window)) {
+    if (!('VideoDecoder' in window) ||
+        !('isConfigSupported' in VideoDecoder)) {
         return false;
     }
 


### PR DESCRIPTION
## Summary

Fixes #2060

Chrome 86–93 shipped `VideoDecoder` as part of an origin trial but did **not** include `VideoDecoder.isConfigSupported` — that method was only added in Chrome 94. The existing guard in `_checkWebCodecsH264DecodeSupport()` checked for `VideoDecoder` in `window` but not for `isConfigSupported` on the constructor, causing a "is not a function" error at the top-level `await` call site. Because this happens during ES module evaluation, the entire module silently fails to load with no console error — just a blank page.

## Change

```js
// Before
if (!('VideoDecoder' in window)) {
    return false;
}

// After
if (!('VideoDecoder' in window) ||
    !('isConfigSupported' in VideoDecoder)) {
    return false;
}
```

This makes the function gracefully return `false` on browsers that have `VideoDecoder` but lack `isConfigSupported`, instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)