### PR TITLE
Fix control bar HTML structure in vnc.html

### DIFF
--- a/vnc.html
+++ b/vnc.html
@@ -112,7 +112,9 @@
     <!-- noVNC control bar -->
     <div id="noVNC_control_bar_anchor" class="noVNC_crosscenter">
         <div id="noVNC_control_bar">
-            <div id="noVNC_control_bar_handle" title="Hide/Show the control bar"><div></div></div>
+            <div id="noVNC_control_bar_handle" title="Hide/Show the control bar"><div>
+                
+            </div id="noVNC_control_bar_hint"></div>
 
             <div class="noVNC_scroll">
 


### PR DESCRIPTION
when we are clicking on noVNC control bar we are getting an Exception popup because a div tag got missed in vnc.html we have tested it from our end after updating it is working fine could you please merge this change