### PR TITLE
feat: Enable local cursor

### DIFF
--- a/core/util/cursor.js
+++ b/core/util/cursor.js
@@ -106,7 +106,7 @@ export default class Cursor {
     }
 
     clear() {
-        this._target.style.cursor = 'none';
+        this._target.style.cursor = 'default';
         this._canvas.width = 0;
         this._canvas.height = 0;
         this._position.x = this._position.x + this._hotSpot.x;


### PR DESCRIPTION
This PR updates the cursor style in the `Cursor.clear()` method from `'none'` to `'default'`. This ensures that a local cursor remains visible when the display cursor is cleared, which provides better feedback to the user.