### PR TITLE
Fall back to manual clipboard manager if the user explicitly denied the clipboard permission

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -1868,7 +1868,7 @@ const UI = {
                     // Use fallback clipboard panel
                     return;
                 }
-                if (support === 'denied' || support === 'available') {
+                if (support === 'available') {
                     UI.closeClipboardPanel();
                     document.getElementById('noVNC_clipboard_button')
                         .classList.add('noVNC_hidden');


### PR DESCRIPTION
Hi,

First of all, I've tested the automatic clipboard management feature which is now available on the master branch and I find it really cool, thanks for implementing that!

However, it's worth pointing out that in a plenty of use-cases the user would not trust the VM enough to allow ultimate automatic access to the host clipboard. For instance, noVNC is integrated with certain malware sandboxes like [CERT-Polska/drakvuf-sandbox](https://github.com/CERT-Polska/drakvuf-sandbox). In such case, the VM is purposely infected with malware, and we arrive into the case where:
1. The noVNC user has a modern browser that indeed supports clipboard management APIs, but
2. They still don't want to take advantage of that and fall back to manual clipboard management tooltip for better control.

Right now, the noVNC will disable the clipboard feature entirely if the clipboard API is available but the user explicitly denied the permission. I think that there is no point of doing so, and falling back to manual clipboard management tooltip is a much better value added.

/cc @psrok1 @msm-code

related #2020