### PR TITLE
fix H264 decoder to handle dropped frames and avoid blocking render q…

### DIFF
--- a/core/decoders/h264.js
+++ b/core/decoders/h264.js
@@ -9,6 +9,12 @@
 
 import * as Log from '../util/logging.js';
 
+// Tolerate a couple of dropped frames before throttling: an occasional
+// hiccup shouldn't slow down an otherwise-healthy stream.
+const BACKOFF_DROP_THRESHOLD = 2;
+const BACKOFF_BASE_DELAY_MS = 50;
+const BACKOFF_MAX_DELAY_MS = 2000;
+
 export class H264Parser {
     constructor(data) {
         this._data = data;
@@ -119,19 +125,60 @@ export class H264Context {
         this._levelIdc = null;
         this._decoder = null;
         this._pendingFrames = [];
+        this._consecutiveDrops = 0;
+    }
+
+    // How long to hold off resolving a dropped frame's promise. The render
+    // queue (display.js) already waits on this promise before letting rfb.js
+    // read any more data from the server, so delaying it here throttles our
+    // own FramebufferUpdateRequest rate whenever decoding keeps failing --
+    // otherwise a stream that never successfully decodes turns into an
+    // unthrottled request loop that starves every other client sharing the
+    // same hardware encoder on the server.
+    _backoffDelay() {
+        if (this._consecutiveDrops <= BACKOFF_DROP_THRESHOLD) {
+            return 0;
+        }
+        const exponent = this._consecutiveDrops - BACKOFF_DROP_THRESHOLD;
+        return Math.min(BACKOFF_BASE_DELAY_MS * (2 ** exponent), BACKOFF_MAX_DELAY_MS);
+    }
+
+    _dropPending(pending) {
+        this._consecutiveDrops++;
+        pending.ready = true;
+
+        const delay = this._backoffDelay();
+        if (delay > 0) {
+            Log.Warn("H264: " + this._consecutiveDrops +
+                " consecutive dropped frames, backing off " + delay + "ms");
+            setTimeout(() => pending.resolve(), delay);
+        } else {
+            pending.resolve();
+        }
     }
 
     _handleFrame(frame) {
         let pending = this._pendingFrames.shift();
         if (pending === undefined) {
-            throw new Error("Pending frame queue empty when receiving frame from decoder");
+            this._consecutiveDrops++;
+            Log.Warn("Pending frame queue empty when receiving frame from decoder, dropping frame");
+            frame.close();
+            return;
         }
 
         if (pending.timestamp != frame.timestamp) {
-            throw new Error("Video frame timestamp mismatch. Expected " +
-                frame.timestamp + " but but got " + pending.timestamp);
+            // The queue is desynced from the decoder's output order. Drop
+            // this frame rather than throwing: an uncaught throw here would
+            // leave `pending` (and the render queue entry awaiting its
+            // promise) stuck unresolved forever.
+            Log.Warn("Video frame timestamp mismatch, dropping frame. Expected " +
+                pending.timestamp + " but got " + frame.timestamp);
+            frame.close();
+            this._dropPending(pending);
+            return;
         }
 
+        this._consecutiveDrops = 0;
         pending.frame = frame;
         pending.ready = true;
         pending.resolve();
@@ -142,7 +189,15 @@ export class H264Context {
     }
 
     _handleError(e) {
-        throw new Error("Failed to decode frame: " + e.message);
+        // The decoder aborts every in-flight decode() on error, so none of
+        // them will ever reach _handleFrame(). Resolve them all now (as
+        // dropped frames) instead of throwing, so nothing is left waiting
+        // forever on a promise that will never resolve.
+        Log.Warn("Failed to decode frame: " + e.message);
+        while (this._pendingFrames.length > 0) {
+            let pending = this._pendingFrames.shift();
+            this._dropPending(pending);
+        }
     }
 
     _configureDecoder(profileIdc, constraintSet, levelIdc) {
@@ -156,11 +211,22 @@ export class H264Context {
             profileIdc.toString(16).padStart(2, '0') +
             constraintSet.toString(16).padStart(2, '0') +
             levelIdc.toString(16).padStart(2, '0');
+
         this._decoder.configure({
             codec: codec,
             codedWidth: this._width,
             codedHeight: this._height,
             optimizeForLatency: true,
+            // Hardware decode sessions on this platform accept configure()
+            // and decode() but silently never invoke output()/error() --
+            // confirmed by isConfigSupported() reporting hardware as
+            // supported while frames never resolved. Software decode is the
+            // only path that actually delivers frames.
+            hardwareAcceleration: 'prefer-software',
+            // The stream is Annex-B (start-code delimited NAL units, see
+            // H264Parser above) -- without this, VideoDecoderConfig defaults
+            // to AVCC (length-prefixed) framing.
+            avc: { format: 'annexb' },
         });
     }
 
@@ -196,9 +262,9 @@ export class H264Context {
             }
 
             if (parser.profileIdc !== null) {
-                self._profileIdc = parser.profileIdc;
-                self._constraintSet = parser.constraintSet;
-                self._levelIdc = parser.levelIdc;
+                this._profileIdc = parser.profileIdc;
+                this._constraintSet = parser.constraintSet;
+                this._levelIdc = parser.levelIdc;
             }
 
             if (this._decoder === null || this._decoder.state !== 'configured') {
@@ -206,12 +272,12 @@ export class H264Context {
                     Log.Warn("Missing key frame. Can't decode until one arrives");
                     continue;
                 }
-                if (self._profileIdc === null) {
+                if (this._profileIdc === null) {
                     Log.Warn('Cannot config decoder. Have not received SPS and PPS yet.');
                     continue;
                 }
-                this._configureDecoder(self._profileIdc, self._constraintSet,
-                                       self._levelIdc);
+                this._configureDecoder(this._profileIdc, this._constraintSet,
+                                       this._levelIdc);
             }
 
             result = this._preparePendingFrame(timestamp);
@@ -225,7 +291,14 @@ export class H264Context {
             try {
                 this._decoder.decode(chunk);
             } catch (e) {
+                // decode() rejected the chunk synchronously -- it will never
+                // reach the decoder's output/error callback, so the pending
+                // frame just queued above would otherwise sit unresolved
+                // forever, permanently blocking the render queue (and this
+                // connection's FramebufferUpdateRequest loop) behind it.
                 Log.Warn("Failed to decode:", e);
+                this._pendingFrames.pop();
+                this._dropPending(result);
             }
         }
 

--- a/core/display.js
+++ b/core/display.js
@@ -534,25 +534,29 @@ export default class Display {
                     break;
                 case 'frame':
                     if (a.frame.ready) {
-                        // The encoded frame may be larger than the rect due to
-                        // limitations of the encoder, so we need to crop the
-                        // frame.
+                        // A dropped/jammed frame resolves with no actual
+                        // VideoFrame attached -- skip drawing it and move on.
                         let frame = a.frame.frame;
-                        if (frame.codedWidth < a.width || frame.codedHeight < a.height) {
-                            Log.Warn("Decoded video frame does not cover its full rectangle area. Expecting at least " +
-                                      a.width + "x" + a.height + " but got " +
-                                      frame.codedWidth + "x" + frame.codedHeight);
+                        if (frame !== null) {
+                            // The encoded frame may be larger than the rect due to
+                            // limitations of the encoder, so we need to crop the
+                            // frame.
+                            if (frame.codedWidth < a.width || frame.codedHeight < a.height) {
+                                Log.Warn("Decoded video frame does not cover its full rectangle area. Expecting at least " +
+                                          a.width + "x" + a.height + " but got " +
+                                          frame.codedWidth + "x" + frame.codedHeight);
+                            }
+                            const sx = 0;
+                            const sy = 0;
+                            const sw = a.width;
+                            const sh = a.height;
+                            const dx = a.x;
+                            const dy = a.y;
+                            const dw = sw;
+                            const dh = sh;
+                            this.drawImage(frame, sx, sy, sw, sh, dx, dy, dw, dh);
+                            frame.close();
                         }
-                        const sx = 0;
-                        const sy = 0;
-                        const sw = a.width;
-                        const sh = a.height;
-                        const dx = a.x;
-                        const dy = a.y;
-                        const dw = sw;
-                        const dh = sh;
-                        this.drawImage(frame, sx, sy, sw, sh, dx, dy, dw, dh);
-                        frame.close();
                     } else {
                         let display = this;
                         a.frame.promise.then(() => {


### PR DESCRIPTION
**Brief**
Fixes a bug where noVNC's H.264 decoder would permanently and silently freeze the entire VNC session the first time anything went slightly wrong with decoding (a dropped frame, a timestamp mismatch, or a WebCodecs error). It was caused due to H264Context throwing instead of resolving its pending-frame promise on any hiccup, which deadlocked the render queue that gates all further server reads
Also - a self/this typo and a synchronous-throw gap in decode() caused the same freeze via different paths. Separately, hardware-accelerated VideoDecoder sessions on some browser/OS combos accept input but silently never call back at all and this is what we've experienced on our PLC's (at Unitronics) where the server delivered frames correctly but the browser swallowed them. It was fixed by forcing hardwareAcceleration: 'prefer-software'. All changes are confined to H264Context in h264.js and the H.264-only 'frame' case in display.js, so every other VNC encoding (Tight/ZRLE/Raw/etc.) is completely untouched. It passed our QA tests and gave excellent results of continuous H.264 streaming with no stalls over enduring run, where before it froze after one frame.

Just to make the motivation clear - H264 encodings  (and H265 in more recent PLC's) is the only one with hardware-backed acceleration thats supported by all the PLC's we use (NXP and ST) both ends - encoding and decoding so we had to lay the entire frame-pipe and noVNC is used by our clients.


**A bit more in-details**

Root cause is a combination of four separate bugs, all in the H.264-only code path:

1. _handleFrame() / _handleError() threw on any mismatch or decode error instead of resolving the frame's pending promise. display.js's render queue blocks on that exact promise before letting rfb.js read more data from the socket, so an uncaught throw inside an async WebCodecs callback (invisible to any normal try/catch) leaves the render queue and therefore the whole connection's FramebufferUpdateRequest loop stuck forever, with no visible error in the console.

2. A self/this typo in decode() wrote parsed SPS fields (_profileIdc etc.) onto the global window object instead of the per-connection H264Context instance. Harmless-looking (no crash -self aliases window in a browser tab) but silently wrong state that breaks multi-connection or multi-region use.

3. A synchronous-throw gap: if VideoDecoder.decode() itself threw synchronously (chunk rejected before being queued), the pending frame just created was never cleaned up same permanent-freeze outcome as (1), via a different path.

4. Hardware decode sessions on some browser/OS/driver combinations accept configure() and decode() calls but then never invoke output() or error() at all - confirmed against a real Unitronics imx6 PLC (ImxVncServer/neatvnc, hardware H.264 over /dev/mxc_vpu): server-side logging proved the server correctly encoded and delivered two H.264 payloads (keyframe + delta) to the browser client, while the browser's VideoDecoder silently swallowed the first one isConfigSupported() reported hardware decode as supported, but no callback ever fired.


Why it's safe to merge

1. Fully scoped to the H.264 path. H264Context is only instantiated for the encodingH264 RFB encoding, and display.js's 'frame' case is exclusively fed by that same path - every other encoding (Raw, Tight, ZRLE, Hextile, RRE, CopyRect, JPEG) resolves through the separate 'blit'/'copy'/'fill'/'img' cases, untouched by this diff. No shared decoder, encoding-negotiation code, or other core/decoders/*.js file is modified.

2. Strictly safer behavior, not new risk. Before: one decode hiccup → permanent silent freeze. After: that same event is logged and the stream recovers. No new failure mode is introduced.

3. hardwareAcceleration: 'prefer-software' only affects the browser's local decode of an already-encoded stream - so no effect on the server, wire protocol, or the PLC's hardware VPU encode pipeline. Software H.264 decode at 1024×600 @ ~15 fps is trivial for any modern CPU.

4. Backoff only engages after repeated consecutive failures (threshold 2) - a healthy stream's behavior is unchanged beyond the software-decode preference.