### PR TITLE
Fix hardware cursor scaling and clipping

### DIFF
--- a/core/util/cursor.js
+++ b/core/util/cursor.js
@@ -7,10 +7,17 @@
 export default class Cursor {
     constructor() {
         this._target = null;
+        this._parent = null;
+        this._parentPosition = null;
+
+        this._container = document.createElement('div');
+        this._container.style.position = 'absolute';
+        this._container.style.zIndex = '65535';
+        this._container.style.overflow = 'hidden';
+        this._container.style.pointerEvents = 'none';
 
         this._canvas = document.createElement('canvas');
-        this._canvas.style.position = 'fixed';
-        this._canvas.style.zIndex = '65535';
+        this._canvas.style.position = 'absolute';
         this._canvas.style.pointerEvents = 'none';
         // Safari on iOS can select the cursor image
         // https://bugs.webkit.org/show_bug.cgi?id=249223
@@ -19,9 +26,11 @@ export default class Cursor {
         // Can't use "display" because of Firefox bug #1445997
         this._canvas.style.visibility = 'hidden';
 
-        // The position is the cursor hotspot in client coordinates. Keeping
-        // it separate from the bitmap position lets us apply the same local
-        // scale to both the cursor image and its hotspot.
+        this._container.appendChild(this._canvas);
+
+        // The position is the cursor hotspot in framebuffer canvas
+        // coordinates. Keeping it in the same coordinate system as the
+        // cursor bitmap makes browser pinch zoom irrelevant to positioning.
         this._position = { x: 0, y: 0 };
         this._hotSpot = { x: 0, y: 0 };
 
@@ -42,8 +51,18 @@ export default class Cursor {
         }
 
         this._target = target;
+        this._parent = this._target.parentElement;
 
-        document.body.appendChild(this._canvas);
+        if (!this._parent) {
+            throw new Error("Cursor target must have a parent element");
+        }
+
+        if (window.getComputedStyle(this._parent).position === 'static') {
+            this._parentPosition = this._parent.style.position;
+            this._parent.style.position = 'relative';
+        }
+
+        this._parent.appendChild(this._container);
 
         const options = { capture: true, passive: true };
         this._target.addEventListener('mouseover', this._eventHandlers.mouseover, options);
@@ -55,6 +74,7 @@ export default class Cursor {
         // framebuffer dimensions. Recalculate the cursor even if the mouse is
         // stationary when that happens, or when scrolling moves the canvas.
         this._resizeObserver.observe(this._target);
+        this._resizeObserver.observe(this._parent);
         window.addEventListener('resize', this._eventHandlers.geometrychange);
         window.addEventListener('scroll', this._eventHandlers.geometrychange, true);
 
@@ -76,11 +96,17 @@ export default class Cursor {
         window.removeEventListener('resize', this._eventHandlers.geometrychange);
         window.removeEventListener('scroll', this._eventHandlers.geometrychange, true);
 
-        if (document.contains(this._canvas)) {
-            document.body.removeChild(this._canvas);
+        if (this._parent.contains(this._container)) {
+            this._parent.removeChild(this._container);
+        }
+
+        if (this._parentPosition !== null) {
+            this._parent.style.position = this._parentPosition;
         }
 
         this._target = null;
+        this._parent = null;
+        this._parentPosition = null;
     }
 
     change(rgba, hotx, hoty, w, h) {
@@ -117,16 +143,7 @@ export default class Cursor {
     // Mouse events might be emulated, this allows
     // moving the cursor in such cases
     move(clientX, clientY) {
-        // clientX/clientY are relative the _visual viewport_,
-        // but our position is relative the _layout viewport_,
-        // so try to compensate when we can
-        if (window.visualViewport) {
-            this._position.x = clientX + window.visualViewport.offsetLeft;
-            this._position.y = clientY + window.visualViewport.offsetTop;
-        } else {
-            this._position.x = clientX;
-            this._position.y = clientY;
-        }
+        this._setPosition(clientX, clientY);
         this._updatePosition();
         let target = document.elementFromPoint(clientX, clientY);
         this._updateVisibility(target);
@@ -147,8 +164,7 @@ export default class Cursor {
     _handleMouseMove(event) {
         this._updateVisibility(event.target);
 
-        this._position.x = event.clientX;
-        this._position.y = event.clientY;
+        this._setPosition(event.clientX, event.clientY);
 
         this._updatePosition();
     }
@@ -233,43 +249,16 @@ export default class Cursor {
         }
     }
 
-    _getVisibleTargetRect() {
+    _setPosition(clientX, clientY) {
         const targetRect = this._target.getBoundingClientRect();
-        const rect = {
-            left: targetRect.left,
-            top: targetRect.top,
-            right: targetRect.right,
-            bottom: targetRect.bottom,
-        };
+        const scaleX = this._target.width ? targetRect.width / this._target.width : 1;
+        const scaleY = this._target.height ? targetRect.height / this._target.height : 1;
 
-        // The canvas can be larger than noVNC's scrolling viewport. Limit the
-        // cursor to the part of the canvas that each clipping ancestor exposes.
-        let element = this._target.parentElement;
-        while (element) {
-            const style = window.getComputedStyle(element);
-            const bounds = element.getBoundingClientRect();
-            const overflowX = style.overflowX || style.overflow;
-            const overflowY = style.overflowY || style.overflow;
-
-            if (overflowX !== 'visible') {
-                rect.left = Math.max(rect.left, bounds.left);
-                rect.right = Math.min(rect.right, bounds.right);
-            }
-            if (overflowY !== 'visible') {
-                rect.top = Math.max(rect.top, bounds.top);
-                rect.bottom = Math.min(rect.bottom, bounds.bottom);
-            }
-
-            element = element.parentElement;
-        }
-
-        // A fixed-position cursor is also limited to the browser viewport.
-        rect.left = Math.max(rect.left, 0);
-        rect.top = Math.max(rect.top, 0);
-        rect.right = Math.min(rect.right, document.documentElement.clientWidth);
-        rect.bottom = Math.min(rect.bottom, document.documentElement.clientHeight);
-
-        return rect;
+        // Use the same client-to-canvas conversion as noVNC's mouse input.
+        // The visual viewport offset from Android pinch zoom is already
+        // reflected in client coordinates and the target rectangle.
+        this._position.x = scaleX ? (clientX - targetRect.left) / scaleX : 0;
+        this._position.y = scaleY ? (clientY - targetRect.top) / scaleY : 0;
     }
 
     _updatePosition() {
@@ -282,23 +271,21 @@ export default class Cursor {
         const scaleY = this._target.height ? targetRect.height / this._target.height : 1;
         const width = this._canvas.width * scaleX;
         const height = this._canvas.height * scaleY;
-        const left = this._position.x - this._hotSpot.x * scaleX;
-        const top = this._position.y - this._hotSpot.y * scaleY;
+        const left = (this._position.x - this._hotSpot.x) * scaleX;
+        const top = (this._position.y - this._hotSpot.y) * scaleY;
+
+        // Keep the cursor overlay in the same layout and scrolling coordinate
+        // system as the framebuffer canvas. This avoids any mismatch between
+        // client coordinates and page-level fixed positioning.
+        this._container.style.left = this._target.offsetLeft + "px";
+        this._container.style.top = this._target.offsetTop + "px";
+        this._container.style.width = targetRect.width + "px";
+        this._container.style.height = targetRect.height + "px";
 
         this._canvas.style.width = width + "px";
         this._canvas.style.height = height + "px";
         this._canvas.style.left = left + "px";
         this._canvas.style.top = top + "px";
-
-        // A CSS cursor is allowed to paint outside its target element. Clip the
-        // emulated cursor instead so it behaves like pixels in the framebuffer.
-        const visibleRect = this._getVisibleTargetRect();
-        const clipTop = Math.max(visibleRect.top - top, 0);
-        const clipRight = Math.max(left + width - visibleRect.right, 0);
-        const clipBottom = Math.max(top + height - visibleRect.bottom, 0);
-        const clipLeft = Math.max(visibleRect.left - left, 0);
-
-        this._canvas.style.clipPath = `inset(${clipTop}px ${clipRight}px ${clipBottom}px ${clipLeft}px)`;
     }
 
     _captureIsActive() {

--- a/core/util/cursor.js
+++ b/core/util/cursor.js
@@ -7,11 +7,9 @@
 export default class Cursor {
     constructor() {
         this._target = null;
-        this._parent = null;
-        this._parentPosition = null;
 
         this._container = document.createElement('div');
-        this._container.style.position = 'absolute';
+        this._container.style.position = 'fixed';
         this._container.style.zIndex = '65535';
         this._container.style.overflow = 'hidden';
         this._container.style.pointerEvents = 'none';
@@ -51,18 +49,8 @@ export default class Cursor {
         }
 
         this._target = target;
-        this._parent = this._target.parentElement;
 
-        if (!this._parent) {
-            throw new Error("Cursor target must have a parent element");
-        }
-
-        if (window.getComputedStyle(this._parent).position === 'static') {
-            this._parentPosition = this._parent.style.position;
-            this._parent.style.position = 'relative';
-        }
-
-        this._parent.appendChild(this._container);
+        document.body.appendChild(this._container);
 
         const options = { capture: true, passive: true };
         this._target.addEventListener('mouseover', this._eventHandlers.mouseover, options);
@@ -72,11 +60,15 @@ export default class Cursor {
 
         // Local scaling changes the canvas's CSS size without changing its
         // framebuffer dimensions. Recalculate the cursor even if the mouse is
-        // stationary when that happens, or when scrolling moves the canvas.
+        // stationary when that happens, or when scrolling or browser zoom
+        // moves the canvas.
         this._resizeObserver.observe(this._target);
-        this._resizeObserver.observe(this._parent);
         window.addEventListener('resize', this._eventHandlers.geometrychange);
         window.addEventListener('scroll', this._eventHandlers.geometrychange, true);
+        if (window.visualViewport) {
+            window.visualViewport.addEventListener('resize', this._eventHandlers.geometrychange);
+            window.visualViewport.addEventListener('scroll', this._eventHandlers.geometrychange);
+        }
 
         this.clear();
     }
@@ -95,18 +87,16 @@ export default class Cursor {
         this._resizeObserver.disconnect();
         window.removeEventListener('resize', this._eventHandlers.geometrychange);
         window.removeEventListener('scroll', this._eventHandlers.geometrychange, true);
-
-        if (this._parent.contains(this._container)) {
-            this._parent.removeChild(this._container);
+        if (window.visualViewport) {
+            window.visualViewport.removeEventListener('resize', this._eventHandlers.geometrychange);
+            window.visualViewport.removeEventListener('scroll', this._eventHandlers.geometrychange);
         }
 
-        if (this._parentPosition !== null) {
-            this._parent.style.position = this._parentPosition;
+        if (document.contains(this._container)) {
+            document.body.removeChild(this._container);
         }
 
         this._target = null;
-        this._parent = null;
-        this._parentPosition = null;
     }
 
     change(rgba, hotx, hoty, w, h) {
@@ -274,11 +264,11 @@ export default class Cursor {
         const left = (this._position.x - this._hotSpot.x) * scaleX;
         const top = (this._position.y - this._hotSpot.y) * scaleY;
 
-        // Keep the cursor overlay in the same layout and scrolling coordinate
-        // system as the framebuffer canvas. This avoids any mismatch between
-        // client coordinates and page-level fixed positioning.
-        this._container.style.left = this._target.offsetLeft + "px";
-        this._container.style.top = this._target.offsetTop + "px";
+        // Use the same viewport rectangle for every part of the overlay. In
+        // particular, do not mix offsetLeft/offsetTop layout coordinates with
+        // getBoundingClientRect() coordinates after browser pinch zoom.
+        this._container.style.left = targetRect.left + "px";
+        this._container.style.top = targetRect.top + "px";
         this._container.style.width = targetRect.width + "px";
         this._container.style.height = targetRect.height + "px";
 

--- a/core/util/cursor.js
+++ b/core/util/cursor.js
@@ -4,28 +4,24 @@
  * Licensed under MPL 2.0 or any later version (see LICENSE.txt)
  */
 
-import { supportsCursorURIs, isTouchDevice } from './browser.js';
-
-const useFallback = !supportsCursorURIs || isTouchDevice;
-
 export default class Cursor {
     constructor() {
         this._target = null;
 
         this._canvas = document.createElement('canvas');
+        this._canvas.style.position = 'fixed';
+        this._canvas.style.zIndex = '65535';
+        this._canvas.style.pointerEvents = 'none';
+        // Safari on iOS can select the cursor image
+        // https://bugs.webkit.org/show_bug.cgi?id=249223
+        this._canvas.style.userSelect = 'none';
+        this._canvas.style.WebkitUserSelect = 'none';
+        // Can't use "display" because of Firefox bug #1445997
+        this._canvas.style.visibility = 'hidden';
 
-        if (useFallback) {
-            this._canvas.style.position = 'fixed';
-            this._canvas.style.zIndex = '65535';
-            this._canvas.style.pointerEvents = 'none';
-            // Safari on iOS can select the cursor image
-            // https://bugs.webkit.org/show_bug.cgi?id=249223
-            this._canvas.style.userSelect = 'none';
-            this._canvas.style.WebkitUserSelect = 'none';
-            // Can't use "display" because of Firefox bug #1445997
-            this._canvas.style.visibility = 'hidden';
-        }
-
+        // The position is the cursor hotspot in client coordinates. Keeping
+        // it separate from the bitmap position lets us apply the same local
+        // scale to both the cursor image and its hotspot.
         this._position = { x: 0, y: 0 };
         this._hotSpot = { x: 0, y: 0 };
 
@@ -34,7 +30,10 @@ export default class Cursor {
             'mouseleave': this._handleMouseLeave.bind(this),
             'mousemove': this._handleMouseMove.bind(this),
             'mouseup': this._handleMouseUp.bind(this),
+            'geometrychange': this._updatePosition.bind(this),
         };
+
+        this._resizeObserver = new ResizeObserver(this._eventHandlers.geometrychange);
     }
 
     attach(target) {
@@ -44,15 +43,20 @@ export default class Cursor {
 
         this._target = target;
 
-        if (useFallback) {
-            document.body.appendChild(this._canvas);
+        document.body.appendChild(this._canvas);
 
-            const options = { capture: true, passive: true };
-            this._target.addEventListener('mouseover', this._eventHandlers.mouseover, options);
-            this._target.addEventListener('mouseleave', this._eventHandlers.mouseleave, options);
-            this._target.addEventListener('mousemove', this._eventHandlers.mousemove, options);
-            this._target.addEventListener('mouseup', this._eventHandlers.mouseup, options);
-        }
+        const options = { capture: true, passive: true };
+        this._target.addEventListener('mouseover', this._eventHandlers.mouseover, options);
+        this._target.addEventListener('mouseleave', this._eventHandlers.mouseleave, options);
+        this._target.addEventListener('mousemove', this._eventHandlers.mousemove, options);
+        this._target.addEventListener('mouseup', this._eventHandlers.mouseup, options);
+
+        // Local scaling changes the canvas's CSS size without changing its
+        // framebuffer dimensions. Recalculate the cursor even if the mouse is
+        // stationary when that happens, or when scrolling moves the canvas.
+        this._resizeObserver.observe(this._target);
+        window.addEventListener('resize', this._eventHandlers.geometrychange);
+        window.addEventListener('scroll', this._eventHandlers.geometrychange, true);
 
         this.clear();
     }
@@ -62,16 +66,18 @@ export default class Cursor {
             return;
         }
 
-        if (useFallback) {
-            const options = { capture: true, passive: true };
-            this._target.removeEventListener('mouseover', this._eventHandlers.mouseover, options);
-            this._target.removeEventListener('mouseleave', this._eventHandlers.mouseleave, options);
-            this._target.removeEventListener('mousemove', this._eventHandlers.mousemove, options);
-            this._target.removeEventListener('mouseup', this._eventHandlers.mouseup, options);
+        const options = { capture: true, passive: true };
+        this._target.removeEventListener('mouseover', this._eventHandlers.mouseover, options);
+        this._target.removeEventListener('mouseleave', this._eventHandlers.mouseleave, options);
+        this._target.removeEventListener('mousemove', this._eventHandlers.mousemove, options);
+        this._target.removeEventListener('mouseup', this._eventHandlers.mouseup, options);
 
-            if (document.contains(this._canvas)) {
-                document.body.removeChild(this._canvas);
-            }
+        this._resizeObserver.disconnect();
+        window.removeEventListener('resize', this._eventHandlers.geometrychange);
+        window.removeEventListener('scroll', this._eventHandlers.geometrychange, true);
+
+        if (document.contains(this._canvas)) {
+            document.body.removeChild(this._canvas);
         }
 
         this._target = null;
@@ -83,8 +89,6 @@ export default class Cursor {
             return;
         }
 
-        this._position.x = this._position.x + this._hotSpot.x - hotx;
-        this._position.y = this._position.y + this._hotSpot.y - hoty;
         this._hotSpot.x = hotx;
         this._hotSpot.y = hoty;
 
@@ -97,20 +101,15 @@ export default class Cursor {
         ctx.clearRect(0, 0, w, h);
         ctx.putImageData(img, 0, 0);
 
-        if (useFallback) {
-            this._updatePosition();
-        } else {
-            let url = this._canvas.toDataURL();
-            this._target.style.cursor = 'url(' + url + ')' + hotx + ' ' + hoty + ', default';
-        }
+        this._updatePosition();
     }
 
     clear() {
         this._target.style.cursor = 'none';
         this._canvas.width = 0;
         this._canvas.height = 0;
-        this._position.x = this._position.x + this._hotSpot.x;
-        this._position.y = this._position.y + this._hotSpot.y;
+        this._canvas.style.width = '0px';
+        this._canvas.style.height = '0px';
         this._hotSpot.x = 0;
         this._hotSpot.y = 0;
     }
@@ -118,9 +117,6 @@ export default class Cursor {
     // Mouse events might be emulated, this allows
     // moving the cursor in such cases
     move(clientX, clientY) {
-        if (!useFallback) {
-            return;
-        }
         // clientX/clientY are relative the _visual viewport_,
         // but our position is relative the _layout viewport_,
         // so try to compensate when we can
@@ -151,8 +147,8 @@ export default class Cursor {
     _handleMouseMove(event) {
         this._updateVisibility(event.target);
 
-        this._position.x = event.clientX - this._hotSpot.x;
-        this._position.y = event.clientY - this._hotSpot.y;
+        this._position.x = event.clientX;
+        this._position.y = event.clientY;
 
         this._updatePosition();
     }
@@ -237,9 +233,72 @@ export default class Cursor {
         }
     }
 
+    _getVisibleTargetRect() {
+        const targetRect = this._target.getBoundingClientRect();
+        const rect = {
+            left: targetRect.left,
+            top: targetRect.top,
+            right: targetRect.right,
+            bottom: targetRect.bottom,
+        };
+
+        // The canvas can be larger than noVNC's scrolling viewport. Limit the
+        // cursor to the part of the canvas that each clipping ancestor exposes.
+        let element = this._target.parentElement;
+        while (element) {
+            const style = window.getComputedStyle(element);
+            const bounds = element.getBoundingClientRect();
+            const overflowX = style.overflowX || style.overflow;
+            const overflowY = style.overflowY || style.overflow;
+
+            if (overflowX !== 'visible') {
+                rect.left = Math.max(rect.left, bounds.left);
+                rect.right = Math.min(rect.right, bounds.right);
+            }
+            if (overflowY !== 'visible') {
+                rect.top = Math.max(rect.top, bounds.top);
+                rect.bottom = Math.min(rect.bottom, bounds.bottom);
+            }
+
+            element = element.parentElement;
+        }
+
+        // A fixed-position cursor is also limited to the browser viewport.
+        rect.left = Math.max(rect.left, 0);
+        rect.top = Math.max(rect.top, 0);
+        rect.right = Math.min(rect.right, document.documentElement.clientWidth);
+        rect.bottom = Math.min(rect.bottom, document.documentElement.clientHeight);
+
+        return rect;
+    }
+
     _updatePosition() {
-        this._canvas.style.left = this._position.x + "px";
-        this._canvas.style.top = this._position.y + "px";
+        if (!this._target) {
+            return;
+        }
+
+        const targetRect = this._target.getBoundingClientRect();
+        const scaleX = this._target.width ? targetRect.width / this._target.width : 1;
+        const scaleY = this._target.height ? targetRect.height / this._target.height : 1;
+        const width = this._canvas.width * scaleX;
+        const height = this._canvas.height * scaleY;
+        const left = this._position.x - this._hotSpot.x * scaleX;
+        const top = this._position.y - this._hotSpot.y * scaleY;
+
+        this._canvas.style.width = width + "px";
+        this._canvas.style.height = height + "px";
+        this._canvas.style.left = left + "px";
+        this._canvas.style.top = top + "px";
+
+        // A CSS cursor is allowed to paint outside its target element. Clip the
+        // emulated cursor instead so it behaves like pixels in the framebuffer.
+        const visibleRect = this._getVisibleTargetRect();
+        const clipTop = Math.max(visibleRect.top - top, 0);
+        const clipRight = Math.max(left + width - visibleRect.right, 0);
+        const clipBottom = Math.max(top + height - visibleRect.bottom, 0);
+        const clipLeft = Math.max(visibleRect.left - left, 0);
+
+        this._canvas.style.clipPath = `inset(${clipTop}px ${clipRight}px ${clipBottom}px ${clipLeft}px)`;
     }
 
     _captureIsActive() {


### PR DESCRIPTION
When "local scaling" is enabled, and the guest VM has a hardware cursor, the screen is scaled but the cursor is not.

This results in a cursor double in size relative to the screen. It will also cause an offset in many cases and renders the cursor outside of the screen canvas.

This PR fixes those problems and hardware cursors display correctly now.

